### PR TITLE
fix: API token optimization — strip blob columns from bridge and command center

### DIFF
--- a/netlify/functions/agent-bridge.js
+++ b/netlify/functions/agent-bridge.js
@@ -45,24 +45,24 @@ exports.handler = async (event) => {
     const result = {};
 
     if (section === "all" || section === "agents") {
-      const { data } = await supabase.from("agent_heartbeats").select("*").order("last_seen", { ascending: false });
+      const { data } = await supabase.from("agent_heartbeats").select("agent, status, last_seen, current_task").order("last_seen", { ascending: false });
       result.agents = data || [];
     }
     if (section === "all" || section === "tasks") {
-      const { data } = await supabase.from("task_queue").select("*").in("status", ["pending", "in_progress"]).order("created_at", { ascending: false }).limit(50);
+      const { data } = await supabase.from("task_queue").select("id, task, agent, status, priority, created_at, completed_at, result").in("status", ["pending", "in_progress"]).order("created_at", { ascending: false }).limit(50);
       result.tasks = data || [];
     }
     if (section === "all" || section === "signals") {
-      const { data } = await supabase.from("intel_signals").select("*").neq("status", "killed").order("created_at", { ascending: false }).limit(50);
+      const { data } = await supabase.from("intel_signals").select("id, title, signal_type, summary, status, source, created_at").neq("status", "killed").order("created_at", { ascending: false }).limit(50);
       result.signals = data || [];
     }
     if (section === "all" || section === "pipeline") {
-      const { data } = await supabase.from("newsletter_pipeline").select("*").order("publish_date", { ascending: false }).limit(20);
+      const { data } = await supabase.from("newsletter_pipeline").select("id, publish_date, day_slot, lead_topic, lead_score, status, notes, linkedin_drafted, podcast_points_drafted").order("publish_date", { ascending: false }).limit(20);
       result.pipeline = data || [];
     }
     if (section === "all" || section === "orders") {
-      const { data: mp } = await supabase.from("marketpulse_orders").select("*").order("created_at", { ascending: false }).limit(20);
-      const { data: pp } = await supabase.from("mp_scoring_history").select("*").order("created_at", { ascending: false }).limit(20);
+      const { data: mp } = await supabase.from("marketpulse_orders").select("id, session_id, created_at, email, topic, workflow_state, status").order("created_at", { ascending: false }).limit(20);
+      const { data: pp } = await supabase.from("mp_scoring_history").select("id, created_at, email, file_name, verdict, overall_grade, avg_score, workflow_state, document_type").order("created_at", { ascending: false }).limit(20);
       result.orders = { marketpulse: mp || [], proposalpulse: pp || [] };
     }
 

--- a/netlify/functions/command-center-api.js
+++ b/netlify/functions/command-center-api.js
@@ -140,7 +140,7 @@ exports.handler = async (event) => {
       // V2: Newsletter pipeline
       supabase
         .from("newsletter_pipeline")
-        .select("*")
+        .select("id, publish_date, day_slot, lead_topic, lead_score, status, notes, linkedin_drafted, podcast_points_drafted")
         .gte("publish_date", today)
         .lte("publish_date", fourWeeksOut)
         .order("publish_date", { ascending: true })
@@ -150,7 +150,7 @@ exports.handler = async (event) => {
       // V2: Task queue
       supabase
         .from("task_queue")
-        .select("*")
+        .select("id, task, agent, status, priority, created_at, completed_at, result")
         .or(`status.eq.pending,status.eq.in_progress,and(status.eq.completed,completed_at.gte.${oneDayAgo})`)
         .order("created_at", { ascending: false })
         .limit(20)
@@ -160,7 +160,7 @@ exports.handler = async (event) => {
       // V3: Agent registry (replaces agent_heartbeats)
       supabase
         .from("agent_registry")
-        .select("*")
+        .select("id, name, role, status, current_task, last_active, sort_order")
         .eq("archived", false)
         .order("sort_order", { ascending: true })
         .then(r => r.data || [])
@@ -169,7 +169,7 @@ exports.handler = async (event) => {
       // V2: Intel signals
       supabase
         .from("intel_signals")
-        .select("*")
+        .select("id, title, signal_type, summary, status, source, relevance_score, created_at")
         .in("status", ["new", "scored", "assigned"])
         .order("created_at", { ascending: false })
         .limit(10)


### PR DESCRIPTION
## Summary

Replace `select('*')` with explicit column lists in the two most-called API endpoints:
- `agent-bridge.js` — called by 6 agents on every heartbeat (288 calls/day)
- `command-center-api.js` — called on every dashboard page load

### Key savings
- **marketpulse_orders**: No longer returns `report_html` (10-30KB per row)
- **mp_scoring_history**: No longer returns `report_html` + `redteam_report_html` (20-60KB per row)
- **agent_registry, intel_signals, newsletter_pipeline, task_queue**: Explicit columns instead of `*`

### Estimated impact
At 20 rows × 30KB avg per blob × 288 bridge calls/day = ~170MB/day of unnecessary data transfer eliminated from agent heartbeat loops.

## Test plan
- [ ] `node -c` passes on both files
- [ ] Command center dashboard still loads all sections
- [ ] Agent bridge `?section=orders` returns data without report_html
- [ ] Agent bridge `?section=all` returns all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)