### PR TITLE
feat: cross-agent learning loop

### DIFF
--- a/netlify/functions/agent-bridge.js
+++ b/netlify/functions/agent-bridge.js
@@ -617,22 +617,35 @@ exports.handler = wrapHandler(async (event) => {
     // === LEARNINGS ===
     if (action === "learning_read") {
       const { agent: agentId, domain } = body;
-      let query = supabase.from("agent_learnings").select("id, rule, category, domain, confidence, times_applied").eq("is_active", true).order("confidence", { ascending: false }).limit(body.limit || 50);
-      if (agentId) query = query.eq("agent", agentId);
+      let query = supabase.from("agent_learnings").select("id, rule, category, domain, confidence, times_applied, source_agent, applies_to, verified, supersedes").eq("is_active", true).order("confidence", { ascending: false }).limit(body.limit || 50);
+      // Cross-agent filtering: return learnings that apply to this agent OR to "all"
+      if (agentId) {
+        query = query.or(`applies_to.cs.{${agentId}},applies_to.cs.{all}`);
+      }
       if (domain) query = query.eq("domain", domain);
       const { data } = await query;
-      return ok({ learnings: data || [] });
+      // Filter out superseded learnings: if a learning has been superseded by another active one, exclude it
+      const supersededIds = new Set((data || []).filter(l => l.supersedes).map(l => l.supersedes));
+      const filtered = (data || []).filter(l => !supersededIds.has(l.id));
+      return ok({ learnings: filtered });
     }
 
     if (action === "learning_write") {
-      const { agent: agentId, category: cat, domain, rule, context: ctx, source: src, sourceApprovalId, sourceIssueId, confidence } = body;
+      const { agent: agentId, category: cat, domain, rule, context: ctx, source: src, sourceApprovalId, sourceIssueId, confidence, applies_to: appliesTo, supersedes: supersedesId } = body;
       if (!agentId || !cat || !rule) return err(400, "agent, category, rule required");
       const { data, error: insertErr } = await supabase.from("agent_learnings").insert({
         agent: agentId, category: cat, domain, rule, context: ctx,
-        source: src || "self", source_approval_id: sourceApprovalId || null,
+        source: src || "self", source_agent: agentId,
+        source_approval_id: sourceApprovalId || null,
         source_issue_id: sourceIssueId || null, confidence: confidence || 0.8,
+        applies_to: appliesTo || ["all"],
+        supersedes: supersedesId || null,
       }).select("id").single();
       if (insertErr) return err(500, insertErr.message);
+      // If this supersedes another learning, mark the old one for reference
+      if (supersedesId) {
+        await supabase.from("agent_learnings").update({ is_active: false }).eq("id", supersedesId);
+      }
       return ok({ learningId: data.id });
     }
 

--- a/netlify/functions/sync-learnings.js
+++ b/netlify/functions/sync-learnings.js
@@ -1,0 +1,196 @@
+// ============================================================
+// sync-learnings.js — Cross-Agent Learning Sync
+//
+// POST /.netlify/functions/sync-learnings
+// Auth: Bearer token (MMT_BRIDGE_KEY)
+//
+// Actions:
+//   export: Returns learnings since a given timestamp
+//   import: Accepts learnings from Claude Project agents
+//   diff:   Returns learnings a specific agent hasn't seen
+// ============================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { createLogger } = require("./lib/logger");
+
+const HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Content-Type": "application/json",
+};
+
+function ok(data) { return { statusCode: 200, headers: HEADERS, body: JSON.stringify(data) }; }
+function err(status, msg) { return { statusCode: status, headers: HEADERS, body: JSON.stringify({ error: msg }) }; }
+
+exports.handler = async (event) => {
+  const log = createLogger("sync-learnings");
+
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 204, headers: HEADERS, body: "" };
+  }
+
+  if (event.httpMethod !== "POST") {
+    return err(405, "POST only");
+  }
+
+  // Auth
+  const authHeader = event.headers.authorization || event.headers.Authorization || "";
+  const token = authHeader.replace(/^Bearer\s+/i, "");
+  if (!token || token !== process.env.AGENT_BRIDGE_KEY) {
+    log.warn("Unauthorized sync request");
+    return err(401, "Unauthorized");
+  }
+
+  const SUPABASE_URL = process.env.SUPABASE_URL;
+  const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) return err(500, "Not configured");
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+  let body;
+  try { body = JSON.parse(event.body); } catch { return err(400, "Invalid JSON"); }
+  const { action } = body;
+
+  // === EXPORT: Return learnings since a timestamp ===
+  if (action === "export") {
+    const since = body.since || "1970-01-01T00:00:00Z";
+    const appliesTo = body.applies_to; // optional filter
+    const category = body.category; // optional filter
+    const verifiedOnly = body.verified_only || false;
+
+    let query = supabase
+      .from("agent_learnings")
+      .select("id, agent, category, domain, rule, context, source, source_agent, applies_to, verified, supersedes, confidence, times_applied, prevented_errors, created_at, is_active")
+      .gte("created_at", since)
+      .eq("is_active", true)
+      .order("created_at", { ascending: false });
+
+    if (appliesTo) {
+      query = query.or(`applies_to.cs.{${appliesTo}},applies_to.cs.{all}`);
+    }
+    if (category) query = query.eq("category", category);
+    if (verifiedOnly) query = query.eq("verified", true);
+
+    const { data, error: qErr } = await query;
+    if (qErr) return err(500, qErr.message);
+
+    // Log the sync
+    if (body.agent_id) {
+      await supabase.from("learning_sync_log").insert({
+        agent_id: body.agent_id,
+        sync_direction: "export",
+        learnings_synced: (data || []).length,
+        sync_metadata: { since, category, applies_to: appliesTo },
+      });
+    }
+
+    log.done({ action: "export", count: (data || []).length });
+    return ok({ learnings: data || [], count: (data || []).length });
+  }
+
+  // === IMPORT: Accept learnings from external agents ===
+  if (action === "import") {
+    const learnings = body.learnings;
+    if (!Array.isArray(learnings) || learnings.length === 0) {
+      return err(400, "learnings array required");
+    }
+
+    const results = [];
+    for (const l of learnings) {
+      if (!l.category || !l.rule) {
+        results.push({ rule: l.rule, status: "skipped", reason: "missing category or rule" });
+        continue;
+      }
+
+      // Check for duplicate rule text
+      const { data: existing } = await supabase
+        .from("agent_learnings")
+        .select("id")
+        .eq("rule", l.rule)
+        .eq("is_active", true)
+        .limit(1);
+
+      if (existing && existing.length > 0) {
+        results.push({ rule: l.rule, status: "duplicate", existing_id: existing[0].id });
+        continue;
+      }
+
+      const { data: inserted, error: insertErr } = await supabase
+        .from("agent_learnings")
+        .insert({
+          agent: l.agent || body.source_agent || "claude-project",
+          category: l.category,
+          domain: l.domain || null,
+          rule: l.rule,
+          context: l.context || null,
+          source: "import",
+          source_agent: body.source_agent || "claude-project",
+          applies_to: l.applies_to || ["all"],
+          verified: l.verified || false,
+          supersedes: l.supersedes || null,
+          confidence: l.confidence || 0.7,
+        })
+        .select("id")
+        .single();
+
+      if (insertErr) {
+        results.push({ rule: l.rule, status: "error", error: insertErr.message });
+      } else {
+        results.push({ rule: l.rule, status: "imported", id: inserted.id });
+      }
+    }
+
+    // Log the sync
+    if (body.source_agent) {
+      await supabase.from("learning_sync_log").insert({
+        agent_id: body.source_agent,
+        sync_direction: "import",
+        learnings_synced: results.filter(r => r.status === "imported").length,
+        sync_metadata: { total: learnings.length, results_summary: { imported: results.filter(r => r.status === "imported").length, duplicate: results.filter(r => r.status === "duplicate").length, skipped: results.filter(r => r.status === "skipped").length, error: results.filter(r => r.status === "error").length } },
+      });
+    }
+
+    log.done({ action: "import", imported: results.filter(r => r.status === "imported").length, total: learnings.length });
+    return ok({ results, imported: results.filter(r => r.status === "imported").length });
+  }
+
+  // === DIFF: Return learnings an agent hasn't seen ===
+  if (action === "diff") {
+    const agentId = body.agent_id;
+    if (!agentId) return err(400, "agent_id required");
+
+    // Get last sync time for this agent
+    const { data: lastSync } = await supabase
+      .from("learning_sync_log")
+      .select("last_sync_at")
+      .eq("agent_id", agentId)
+      .eq("sync_direction", "export")
+      .order("last_sync_at", { ascending: false })
+      .limit(1);
+
+    const since = lastSync && lastSync.length > 0 ? lastSync[0].last_sync_at : "1970-01-01T00:00:00Z";
+
+    // Get learnings since last sync that apply to this agent
+    const { data, error: qErr } = await supabase
+      .from("agent_learnings")
+      .select("id, agent, category, domain, rule, context, source_agent, applies_to, verified, supersedes, confidence, created_at")
+      .gte("created_at", since)
+      .eq("is_active", true)
+      .or(`applies_to.cs.{${agentId}},applies_to.cs.{all}`)
+      .order("created_at", { ascending: false });
+
+    if (qErr) return err(500, qErr.message);
+
+    // Log the sync
+    await supabase.from("learning_sync_log").insert({
+      agent_id: agentId,
+      sync_direction: "export",
+      learnings_synced: (data || []).length,
+      sync_metadata: { since, type: "diff" },
+    });
+
+    log.done({ action: "diff", agent: agentId, since, count: (data || []).length });
+    return ok({ learnings: data || [], since, count: (data || []).length });
+  }
+
+  return err(400, "Unknown action. Use: export, import, diff");
+};

--- a/supabase/migrations/20260321200000_cross_agent_learnings.sql
+++ b/supabase/migrations/20260321200000_cross_agent_learnings.sql
@@ -1,0 +1,62 @@
+-- Cross-Agent Learning Loop — Schema Migration
+-- Extends agent_learnings for cross-agent knowledge sharing
+-- Adds learning_sync_log for tracking agent sync state
+
+-- === 1. Extend agent_learnings table ===
+
+-- applies_to: array of agent IDs this learning is relevant to (or ["all"])
+ALTER TABLE agent_learnings ADD COLUMN IF NOT EXISTS applies_to TEXT[] DEFAULT ARRAY['all'];
+
+-- source_agent: which agent/system created this learning (distinct from "agent" which is the owning agent)
+ALTER TABLE agent_learnings ADD COLUMN IF NOT EXISTS source_agent TEXT DEFAULT 'unknown';
+
+-- verified: has a human confirmed this learning
+ALTER TABLE agent_learnings ADD COLUMN IF NOT EXISTS verified BOOLEAN DEFAULT false;
+
+-- supersedes: ID of a prior learning this replaces
+ALTER TABLE agent_learnings ADD COLUMN IF NOT EXISTS supersedes UUID REFERENCES agent_learnings(id) ON DELETE SET NULL;
+
+-- Backfill: set source_agent = agent for existing rows where source_agent is default
+UPDATE agent_learnings SET source_agent = agent WHERE source_agent = 'unknown' AND agent IS NOT NULL;
+
+-- Backfill: set applies_to = ARRAY[agent] for agent-specific learnings (non-generic)
+-- Leave as ['all'] for learnings that don't target a specific agent
+
+-- Index for applies_to filtering (GIN for array contains)
+CREATE INDEX IF NOT EXISTS idx_agent_learnings_applies_to ON agent_learnings USING GIN (applies_to);
+
+-- Index for supersedes chain lookups
+CREATE INDEX IF NOT EXISTS idx_agent_learnings_supersedes ON agent_learnings (supersedes) WHERE supersedes IS NOT NULL;
+
+-- Index for verified filter
+CREATE INDEX IF NOT EXISTS idx_agent_learnings_verified ON agent_learnings (verified) WHERE verified = true;
+
+
+-- === 2. Create learning_sync_log table ===
+
+CREATE TABLE IF NOT EXISTS learning_sync_log (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  sync_direction TEXT NOT NULL CHECK (sync_direction IN ('export', 'import')),
+  last_sync_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  learnings_synced INTEGER NOT NULL DEFAULT 0,
+  sync_metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for fast agent + direction lookups
+CREATE INDEX IF NOT EXISTS idx_learning_sync_log_agent ON learning_sync_log (agent_id, sync_direction);
+
+-- Enable RLS on both tables
+ALTER TABLE learning_sync_log ENABLE ROW LEVEL SECURITY;
+
+-- RLS policy: service_role can do everything (matches agent-bridge auth pattern)
+-- No anon access — all access goes through authenticated Netlify functions
+CREATE POLICY "Service role full access on learning_sync_log"
+  ON learning_sync_log
+  FOR ALL
+  USING (true)
+  WITH CHECK (true);
+
+-- Verify agent_learnings has RLS enabled (should already be set)
+ALTER TABLE agent_learnings ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

- Extends `agent_learnings` table with `applies_to`, `source_agent`, `verified`, `supersedes` columns
- Creates `learning_sync_log` table to track agent sync state
- New `sync-learnings.js` Netlify function with export/import/diff actions for cross-agent knowledge sync
- Updates `agent-bridge.js` learning_read to filter by `applies_to` and exclude superseded learnings
- Updates `agent-bridge.js` learning_write to auto-set `source_agent` and support `supersedes` chain

## Migration

Run `supabase/migrations/20260321200000_cross_agent_learnings.sql` in Supabase SQL editor.

## Test plan

- [ ] Verify migration runs without errors on Supabase
- [ ] Test learning_read with agent filter — should return agent-specific + "all" learnings
- [ ] Test learning_write with supersedes — should deactivate old learning
- [ ] Test sync-learnings export/import/diff actions
- [ ] Verify existing mmt_add_learning / mmt_check_learnings behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)