### PR TITLE
feat: Creative Studio — migrated from missionpulse.ai

### DIFF
--- a/command-center.html
+++ b/command-center.html
@@ -652,6 +652,8 @@
     let selectedAgent = null;
     let currentFilter = 'all';
     let _lastResearch = null;
+    let _creativeData = null;
+    let _creativeProject = null;
     let _costData = null;
     let _billingData = null;
     let _servicesData = null;
@@ -694,6 +696,7 @@
         apiPost({ action: 'ciso_posture' }).then(c => { if (c && !c.error) { _cisoData = c; renderTiles(dashData); } }).catch(() => {});
         apiPost({ action: 'penny_dashboard' }).then(p => { if (p && !p.error) { _pennyData = p; renderTiles(dashData); } }).catch(() => {});
         fetch('/.netlify/functions/roadmap-api?key=' + apiKey + '&view=summary').then(r => r.ok ? r.json() : null).then(d => { if (d) { _roadmapLive = d; renderTiles(dashData); } }).catch(() => {});
+        fetch('/.netlify/functions/creative-api?key=' + apiKey).then(r => r.ok ? r.json() : null).then(d => { if (d) { _creativeData = d; renderTiles(dashData); } }).catch(() => {});
         Promise.all([
           fetch('/.netlify/functions/finance-api?key=' + apiKey + '&view=services-summary').then(r => r.ok ? r.json() : null),
           fetch('/.netlify/functions/customer-api?key=' + apiKey + '&view=summary').then(r => r.ok ? r.json() : null),
@@ -873,7 +876,7 @@
         { id: 'business', icon: '\ud83d\udcca', title: 'Business', m1: revTotal !== null ? '$' + revTotal.toLocaleString() : '--', m1l: rev?.month || 'Revenue', m2: null, m2l: null, badge: 0, roles: ['coo', 'all'] },
         { id: 'health', icon: '\ud83d\udee1\ufe0f', title: 'Site Health', m1: errorEvents.length, m1l: 'Errors (24h)', m2: null, m2l: null, badge: critEvents.length, roles: ['cto', 'all'] },
         { id: 'agents', icon: '\ud83e\udd16', title: 'Agent Fleet', m1: onlineAgents.length + '/' + agents.length, m1l: 'Online', m2: null, m2l: null, badge: staleAgents.length, roles: ['cto', 'all'] },
-        { id: 'content', icon: '\ud83c\udfa8', title: 'Content Studio', m1: images.length, m1l: 'Images', m2: signals.length, m2l: 'Signals', badge: 0, roles: ['coo', 'editor', 'all'] },
+        { id: 'content', icon: '\ud83c\udfa8', title: 'Content Studio', m1: _creativeData ? _creativeData.projects.length : images.length, m1l: _creativeData ? 'Projects' : 'Images', m2: _creativeData ? _creativeData.recent_images.length : signals.length, m2l: _creativeData ? 'Images' : 'Signals', badge: _creativeData ? _creativeData.projects.filter(p => p.status === 'generating').length : 0, roles: ['coo', 'editor', 'all'] },
         { id: 'competitive', icon: '\ud83c\udfaf', title: 'Competitive Intel', m1: '--', m1l: 'Competitors', m2: '--', m2l: 'Unreviewed', badge: 0, roles: ['coo', 'all'] },
         { id: 'learnings', icon: '\ud83e\udde0', title: 'Agent Memory', m1: '--', m1l: 'Active rules', m2: '--', m2l: 'Applied', badge: 0, roles: ['cto', 'editor', 'all'] },
         { id: 'security', icon: '\ud83d\udee1\ufe0f', title: 'Security Posture', m1: _cisoData ? _cisoData.cmmc_score.percent_met + '%' : '--', m1l: 'CMMC L2', m2: _cisoData ? (_cisoData.open_findings.critical + _cisoData.open_findings.high) : '--', m2l: 'Crit+High', badge: _cisoData ? _cisoData.open_findings.critical : 0, roles: ['cto', 'all'] },
@@ -1377,12 +1380,79 @@
     function renderDetailContent(data) {
       const el = document.getElementById('detail-content');
       const images = data.recent_images || [];
+      const projects = _creativeData ? _creativeData.projects : [];
+      const creativeImages = _creativeData ? _creativeData.recent_images : [];
+      const pipeline = data.pipeline || [];
 
       let h = '<button class="back-btn" onclick="showHome()">&#8592; Back to Dashboard</button>';
       h += '<div class="detail-title">\ud83c\udfa8 Content Studio</div>';
 
-      // Image generation form
-      h += '<div class="detail-card"><h3>Image Generation</h3>';
+      // === CREATIVE STUDIO: Projects ===
+      h += '<div class="detail-card"><h3>Creative Projects</h3>';
+      h += '<div style="display:flex;gap:8px;margin-bottom:12px;align-items:center;">';
+      h += '<input type="text" id="creative-title" placeholder="Article title..." style="flex:1;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#e2e8f0;padding:8px 10px;border-radius:4px;font-size:0.85rem;">';
+      h += '<select id="creative-pipeline" style="background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#e2e8f0;padding:8px 10px;border-radius:4px;font-size:0.8rem;"><option value="">Link to pipeline...</option>';
+      pipeline.forEach(p => { h += '<option value="' + p.id + '">' + esc((p.lead_topic || 'Untitled').substring(0, 40)) + ' (' + p.publish_date + ')</option>'; });
+      h += '</select>';
+      h += '<button class="btn btn-cyan" onclick="createCreativeProject()">+ New Project</button></div>';
+
+      // Project list
+      if (!projects.length) {
+        h += '<p style="color:rgba(255,255,255,0.3);font-size:0.8rem;">No creative projects yet. Create one above.</p>';
+      } else {
+        const statusColors = { drafting: '#60a5fa', generating: '#eab308', selecting: '#a855f7', complete: '#22c55e' };
+        h += '<div style="display:grid;gap:8px;">';
+        projects.forEach(p => {
+          const color = statusColors[p.status] || '#9ca3af';
+          const promptCount = p.creative_prompts ? p.creative_prompts[0]?.count || 0 : 0;
+          const imageCount = p.creative_images ? p.creative_images[0]?.count || 0 : 0;
+          h += '<div style="background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.08);border-radius:8px;padding:12px;cursor:pointer;display:flex;align-items:center;gap:12px;" onclick="openCreativeProject(\'' + p.id + '\')">';
+          h += '<div style="width:8px;height:8px;border-radius:50%;background:' + color + ';flex-shrink:0;" title="' + p.status + '"></div>';
+          h += '<div style="flex:1;min-width:0;"><div style="font-size:0.85rem;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">' + esc(p.article_title) + '</div>';
+          h += '<div style="font-size:0.7rem;color:rgba(255,255,255,0.4);margin-top:2px;">' + promptCount + ' prompts · ' + imageCount + ' images · ' + timeSince(p.updated_at) + '</div></div>';
+          h += '<span style="font-size:0.7rem;color:' + color + ';text-transform:uppercase;font-weight:600;">' + p.status + '</span>';
+          if (p.pipeline_id) h += '<span style="font-size:0.65rem;color:#00e5fa;" title="Linked to pipeline">📰</span>';
+          h += '<button class="btn btn-sm" style="background:rgba(239,68,68,0.15);color:#ef4444;font-size:0.7rem;padding:2px 8px;" onclick="event.stopPropagation();deleteCreativeProject(\'' + p.id + '\')">×</button>';
+          h += '</div>';
+        });
+        h += '</div>';
+      }
+      h += '</div>';
+
+      // === CREATIVE STUDIO: Project Detail (shown when a project is selected) ===
+      h += '<div id="creative-project-detail" style="display:none;"></div>';
+
+      // === CREATIVE STUDIO: Image Gallery ===
+      h += '<div class="detail-card"><h3>Image Gallery</h3>';
+      h += '<div id="creative-gallery" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:10px;">';
+      const allImages = creativeImages.length ? creativeImages : images;
+      if (!allImages.length) {
+        h += '<p style="color:rgba(255,255,255,0.2);font-size:0.75rem;">No images yet</p>';
+      } else {
+        allImages.forEach(img => {
+          const isCreative = !!img.model_used;
+          const stars = img.rating ? '★'.repeat(img.rating) + '☆'.repeat(5 - img.rating) : '';
+          h += '<div style="background:rgba(255,255,255,0.03);border:1px solid ' + (img.selected ? 'rgba(34,197,94,0.5)' : 'rgba(255,255,255,0.08)') + ';border-radius:8px;overflow:hidden;position:relative;">';
+          h += img.image_url ? '<img src="' + img.image_url + '" style="width:100%;height:100px;object-fit:cover;cursor:pointer;" onclick="window.open(this.src)">' : '<div style="width:100%;height:100px;display:flex;align-items:center;justify-content:center;font-size:0.7rem;color:rgba(255,255,255,0.3);">' + (img.model_used || img.provider || '') + '</div>';
+          if (img.selected) h += '<div style="position:absolute;top:4px;right:4px;background:#22c55e;color:#000;font-size:0.6rem;padding:1px 5px;border-radius:3px;font-weight:700;">SELECTED</div>';
+          h += '<div style="padding:6px 8px;">';
+          h += '<div style="font-size:0.65rem;color:rgba(255,255,255,0.4);">' + fmtDate(img.created_at) + ' · ' + (img.model_used || img.provider || '') + '</div>';
+          if (stars) h += '<div style="font-size:0.7rem;color:#eab308;margin-top:2px;">' + stars + '</div>';
+          if (isCreative) {
+            h += '<div style="display:flex;gap:3px;margin-top:4px;">';
+            for (let s = 1; s <= 5; s++) {
+              h += '<button style="background:none;border:none;color:' + (s <= (img.rating||0) ? '#eab308' : 'rgba(255,255,255,0.15)') + ';cursor:pointer;font-size:0.75rem;padding:0;" onclick="rateCreativeImage(\'' + img.id + '\',' + s + ',\'' + (img.project_id||'') + '\')">' + (s <= (img.rating||0) ? '★' : '☆') + '</button>';
+            }
+            h += ' <button class="btn btn-sm" style="background:rgba(34,197,94,0.15);color:#22c55e;font-size:0.6rem;padding:1px 6px;margin-left:auto;" onclick="selectCreativeImage(\'' + img.id + '\',\'' + (img.project_id||'') + '\')">Select</button>';
+            h += '</div>';
+          }
+          h += '</div></div>';
+        });
+      }
+      h += '</div></div>';
+
+      // Image generation form (existing)
+      h += '<div class="detail-card"><h3>Quick Image Generation</h3>';
       h += '<div class="content-studio-form" style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">';
       h += '<div><textarea id="image-prompt" rows="3" placeholder="Newsletter header: dark background, cyber-themed circuit board pattern with a glowing blue pulse..." style="width:100%;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#e2e8f0;padding:10px;border-radius:4px;font-size:0.85rem;resize:vertical;"></textarea>';
       h += '<div style="display:flex;gap:8px;margin-top:8px;flex-wrap:wrap;">';
@@ -1394,18 +1464,7 @@
       h += '<div id="image-preview" style="min-height:200px;background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.05);border-radius:8px;display:flex;align-items:center;justify-content:center;overflow:hidden;"><span style="color:rgba(255,255,255,0.2);font-size:0.8rem;">Image will appear here</span></div>';
       h += '</div></div>';
 
-      // Recent images gallery
-      h += '<div class="detail-card"><h3>Recent Images</h3>';
-      h += '<div id="image-history" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px;">';
-      if (!images.length) h += '<p style="color:rgba(255,255,255,0.2);font-size:0.75rem;">No images yet</p>';
-      else images.forEach(img => {
-        h += '<div style="background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.08);border-radius:6px;overflow:hidden;cursor:pointer;" title="' + esc(img.prompt.substring(0, 80)) + '">';
-        h += img.image_url ? '<img src="' + img.image_url + '" style="width:100%;height:80px;object-fit:cover;">' : '<div style="width:100%;height:80px;display:flex;align-items:center;justify-content:center;font-size:0.7rem;color:rgba(255,255,255,0.3);">' + img.provider + '</div>';
-        h += '<div style="padding:4px 6px;font-size:0.65rem;color:rgba(255,255,255,0.4);">' + fmtDate(img.created_at) + ' · ' + img.provider + '</div></div>';
-      });
-      h += '</div></div>';
-
-      // Research hub
+      // Research hub (existing)
       h += '<div class="detail-card"><h3>Research Hub</h3>';
       h += '<div style="display:flex;gap:8px;margin-bottom:12px;"><input type="text" id="research-query" placeholder="What is the current status of VA T4NG2 task orders?" style="flex:1;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#e2e8f0;padding:10px;border-radius:4px;font-size:0.85rem;"><button class="btn btn-cyan" onclick="runResearch()">Research All</button></div>';
       h += '<div style="display:flex;gap:8px;margin-bottom:16px;">';
@@ -2038,6 +2097,165 @@
       if (!_lastResearch) return;
       const text = Object.entries(_lastResearch.results).filter(([k, v]) => v.answer).map(([k, v]) => '=== ' + k.toUpperCase() + ' ===\n' + v.answer).join('\n\n');
       navigator.clipboard.writeText(text).then(() => toast('Research copied to clipboard.'));
+    }
+
+    // --- CREATIVE STUDIO ---
+    async function creativePost(body) {
+      return fetch('/.netlify/functions/creative-api?key=' + apiKey, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).then(r => r.json());
+    }
+
+    async function createCreativeProject() {
+      const title = document.getElementById('creative-title').value.trim();
+      if (!title) return;
+      const pipelineId = document.getElementById('creative-pipeline').value || null;
+      const d = await creativePost({ action: 'create_project', article_title: title, pipeline_id: pipelineId });
+      if (d.created) { document.getElementById('creative-title').value = ''; toast('Project created.'); await refreshCreative(); }
+      else toast('Error: ' + (d.error || 'Unknown'));
+    }
+
+    async function deleteCreativeProject(id) {
+      if (!confirm('Delete this project and all its prompts/images?')) return;
+      await creativePost({ action: 'delete_project', id });
+      toast('Project deleted.'); await refreshCreative();
+    }
+
+    async function openCreativeProject(id) {
+      const d = await creativePost({ action: 'get_project', id });
+      if (!d.project) { toast('Project not found.'); return; }
+      _creativeProject = d;
+      renderCreativeProjectDetail(d);
+    }
+
+    function renderCreativeProjectDetail(d) {
+      const el = document.getElementById('creative-project-detail');
+      const proj = d.project;
+      const prompts = d.prompts || [];
+      const imgs = d.images || [];
+      const research = d.research || [];
+      const statusColors = { drafting: '#60a5fa', generating: '#eab308', selecting: '#a855f7', complete: '#22c55e' };
+
+      let h = '<div class="detail-card" style="border:1px solid rgba(0,229,250,0.2);">';
+      h += '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">';
+      h += '<h3 style="margin:0;">' + esc(proj.article_title) + '</h3>';
+      h += '<div style="display:flex;gap:8px;align-items:center;">';
+      h += '<span style="font-size:0.75rem;color:' + (statusColors[proj.status] || '#9ca3af') + ';text-transform:uppercase;font-weight:600;">' + proj.status + '</span>';
+      h += '<button class="btn btn-sm" style="background:rgba(255,255,255,0.1);color:#e2e8f0;font-size:0.75rem;" onclick="document.getElementById(\'creative-project-detail\').style.display=\'none\'">Close</button>';
+      h += '</div></div>';
+      if (proj.article_url) h += '<div style="font-size:0.75rem;margin-bottom:8px;"><a href="' + proj.article_url + '" target="_blank" style="color:#00e5fa;">View article →</a></div>';
+
+      // Prompt builder
+      h += '<div style="margin-bottom:16px;">';
+      h += '<div style="font-weight:600;font-size:0.8rem;margin-bottom:8px;color:rgba(255,255,255,0.6);">Prompts</div>';
+      h += '<div style="display:flex;gap:8px;margin-bottom:8px;">';
+      h += '<textarea id="creative-prompt-text" rows="2" placeholder="Describe the image you want to generate..." style="flex:1;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#e2e8f0;padding:8px;border-radius:4px;font-size:0.82rem;resize:vertical;"></textarea>';
+      h += '<div style="display:flex;flex-direction:column;gap:4px;">';
+      h += '<input type="text" id="creative-style-tags" placeholder="Style tags (comma-separated)" style="background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#e2e8f0;padding:6px 8px;border-radius:4px;font-size:0.75rem;">';
+      h += '<button class="btn btn-cyan btn-sm" onclick="createCreativePrompt(\'' + proj.id + '\')">Add Prompt</button>';
+      h += '</div></div>';
+
+      // Existing prompts
+      if (prompts.length) {
+        prompts.forEach(p => {
+          h += '<div style="background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.06);border-radius:6px;padding:8px 10px;margin-bottom:6px;">';
+          h += '<div style="font-size:0.8rem;color:#e2e8f0;">v' + p.version + ': ' + esc(p.prompt_text.substring(0, 150)) + (p.prompt_text.length > 150 ? '...' : '') + '</div>';
+          if (p.style_tags && p.style_tags.length) h += '<div style="margin-top:4px;">' + p.style_tags.map(t => '<span style="background:rgba(0,229,250,0.1);color:#00e5fa;font-size:0.65rem;padding:1px 6px;border-radius:3px;margin-right:4px;">' + esc(t) + '</span>').join('') + '</div>';
+          h += '<div style="margin-top:4px;"><button class="btn btn-sm" style="background:rgba(0,229,250,0.15);color:#00e5fa;font-size:0.7rem;padding:2px 8px;" onclick="generateCreativeImage(\'' + proj.id + '\',\'' + p.id + '\',\'' + esc(p.prompt_text.replace(/'/g, "\\'")) + '\')">Generate Image</button>';
+          h += ' <button class="btn btn-sm" style="background:rgba(255,255,255,0.08);color:rgba(255,255,255,0.5);font-size:0.7rem;padding:2px 8px;" onclick="document.getElementById(\'creative-prompt-text\').value=\'' + esc(p.prompt_text.replace(/'/g, "\\'").replace(/\n/g, ' ')) + '\';document.getElementById(\'creative-style-tags\').value=\'' + (p.style_tags||[]).join(', ') + '\'">Refine</button></div>';
+          h += '</div>';
+        });
+      }
+      h += '</div>';
+
+      // Project images
+      h += '<div style="margin-bottom:16px;">';
+      h += '<div style="font-weight:600;font-size:0.8rem;margin-bottom:8px;color:rgba(255,255,255,0.6);">Generated Images (' + imgs.length + ')</div>';
+      h += '<div id="creative-project-images" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:8px;">';
+      if (!imgs.length) h += '<p style="color:rgba(255,255,255,0.2);font-size:0.75rem;">No images generated yet</p>';
+      imgs.forEach(img => {
+        const stars = img.rating ? '★'.repeat(img.rating) + '☆'.repeat(5 - img.rating) : '☆☆☆☆☆';
+        h += '<div style="background:rgba(255,255,255,0.03);border:1px solid ' + (img.selected ? 'rgba(34,197,94,0.5)' : 'rgba(255,255,255,0.08)') + ';border-radius:6px;overflow:hidden;">';
+        h += '<img src="' + img.image_url + '" style="width:100%;height:90px;object-fit:cover;cursor:pointer;" onclick="window.open(this.src)">';
+        if (img.selected) h += '<div style="text-align:center;background:#22c55e;color:#000;font-size:0.6rem;font-weight:700;padding:1px;">SELECTED</div>';
+        h += '<div style="padding:4px 6px;font-size:0.65rem;color:rgba(255,255,255,0.4);">' + (img.model_used || '') + ' · ' + fmtDate(img.created_at) + '</div>';
+        h += '<div style="padding:0 6px 4px;display:flex;align-items:center;gap:2px;">';
+        for (let s = 1; s <= 5; s++) {
+          h += '<button style="background:none;border:none;color:' + (s <= (img.rating||0) ? '#eab308' : 'rgba(255,255,255,0.15)') + ';cursor:pointer;font-size:0.7rem;padding:0;" onclick="rateCreativeImage(\'' + img.id + '\',' + s + ',\'' + proj.id + '\')">' + (s <= (img.rating||0) ? '★' : '☆') + '</button>';
+        }
+        if (!img.selected) h += '<button class="btn btn-sm" style="background:rgba(34,197,94,0.15);color:#22c55e;font-size:0.6rem;padding:1px 5px;margin-left:auto;" onclick="selectCreativeImage(\'' + img.id + '\',\'' + proj.id + '\')">✓</button>';
+        h += '</div></div>';
+      });
+      h += '</div></div>';
+
+      // Research for this project
+      h += '<div>';
+      h += '<div style="font-weight:600;font-size:0.8rem;margin-bottom:8px;color:rgba(255,255,255,0.6);">Research (' + research.length + ')</div>';
+      h += '<div style="display:flex;gap:8px;margin-bottom:8px;">';
+      h += '<select id="creative-research-type" style="background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#e2e8f0;padding:6px 8px;border-radius:4px;font-size:0.75rem;"><option value="reference_image">Reference Image</option><option value="style_guide">Style Guide</option><option value="color_palette">Color Palette</option><option value="mood">Mood</option><option value="competitor_example">Competitor</option></select>';
+      h += '<input type="text" id="creative-research-content" placeholder="URL or description..." style="flex:1;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:#e2e8f0;padding:6px 8px;border-radius:4px;font-size:0.75rem;">';
+      h += '<button class="btn btn-cyan btn-sm" onclick="addCreativeResearch(\'' + proj.id + '\')">Add</button></div>';
+      if (research.length) {
+        research.forEach(r => {
+          h += '<div style="display:flex;gap:8px;align-items:center;padding:4px 0;border-bottom:1px solid rgba(255,255,255,0.04);font-size:0.75rem;">';
+          h += '<span style="background:rgba(0,229,250,0.1);color:#00e5fa;padding:1px 6px;border-radius:3px;font-size:0.65rem;">' + r.type.replace(/_/g, ' ') + '</span>';
+          h += '<span style="color:rgba(255,255,255,0.5);flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + esc(r.content.substring(0, 100)) + '</span>';
+          h += '</div>';
+        });
+      }
+      h += '</div>';
+
+      h += '<div id="creative-gen-status" style="margin-top:8px;font-size:0.8rem;"></div>';
+      h += '</div>';
+      el.style.display = 'block';
+      el.innerHTML = h;
+    }
+
+    async function createCreativePrompt(projectId) {
+      const text = document.getElementById('creative-prompt-text').value.trim();
+      if (!text) return;
+      const tagsRaw = document.getElementById('creative-style-tags').value.trim();
+      const tags = tagsRaw ? tagsRaw.split(',').map(t => t.trim()).filter(Boolean) : [];
+      const d = await creativePost({ action: 'create_prompt', project_id: projectId, prompt_text: text, style_tags: tags });
+      if (d.created) { toast('Prompt added.'); openCreativeProject(projectId); }
+      else toast('Error: ' + (d.error || 'Unknown'));
+    }
+
+    async function generateCreativeImage(projectId, promptId, promptText) {
+      const statusEl = document.getElementById('creative-gen-status');
+      if (statusEl) statusEl.innerHTML = '<span style="color:#eab308;">Generating image... (10-30s)</span>';
+      const provider = document.getElementById('image-provider')?.value || 'gpt_image';
+      const size = document.getElementById('image-size')?.value || '1024x1024';
+      const style = document.getElementById('image-style')?.value || 'natural';
+      const d = await creativePost({ action: 'generate_image', project_id: projectId, prompt_id: promptId, prompt_text: promptText, provider, size, style });
+      if (d.created) { toast('Image generated.'); if (statusEl) statusEl.innerHTML = '<span style="color:#22c55e;">Done</span>'; openCreativeProject(projectId); await refreshCreative(); }
+      else { toast('Error: ' + (d.error || 'Unknown')); if (statusEl) statusEl.innerHTML = '<span style="color:#ef4444;">Failed: ' + esc(d.error || '') + '</span>'; }
+    }
+
+    async function rateCreativeImage(id, rating, projectId) {
+      await creativePost({ action: 'rate_image', id, rating, project_id: projectId });
+      if (_creativeProject && projectId) openCreativeProject(projectId);
+      else await refreshCreative();
+    }
+
+    async function selectCreativeImage(id, projectId) {
+      await creativePost({ action: 'rate_image', id, selected: true, project_id: projectId });
+      toast('Image selected.'); if (projectId) openCreativeProject(projectId);
+      await refreshCreative();
+    }
+
+    async function addCreativeResearch(projectId) {
+      const type = document.getElementById('creative-research-type').value;
+      const content = document.getElementById('creative-research-content').value.trim();
+      if (!content) return;
+      const d = await creativePost({ action: 'add_research', project_id: projectId, type, content });
+      if (d.created) { toast('Research added.'); openCreativeProject(projectId); }
+      else toast('Error: ' + (d.error || 'Unknown'));
+    }
+
+    async function refreshCreative() {
+      try {
+        const r = await fetch('/.netlify/functions/creative-api?key=' + apiKey);
+        if (r.ok) { _creativeData = await r.json(); renderTiles(dashData); }
+      } catch (e) {}
     }
 
     // --- ENGAGEMENT INTEL ---

--- a/netlify/functions/creative-api.js
+++ b/netlify/functions/creative-api.js
@@ -1,0 +1,301 @@
+// ============================================================
+// creative-api.js — Creative Studio API (migrated from missionpulse.ai)
+//
+// POST: action-based routing for creative project management
+// Auth: ?key= parameter checked against COMMAND_CENTER_KEY env var
+// ============================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { validateAuth } = require("./lib/auth");
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Content-Type": "application/json",
+};
+
+function unauthorized() {
+  return { statusCode: 401, headers: CORS_HEADERS, body: JSON.stringify({ error: "Unauthorized" }) };
+}
+
+function ok(data) {
+  return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify(data) };
+}
+
+function err(status, msg) {
+  return { statusCode: status, headers: CORS_HEADERS, body: JSON.stringify({ error: msg }) };
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 204, headers: CORS_HEADERS, body: "" };
+  }
+
+  const SUPABASE_URL = process.env.SUPABASE_URL;
+  const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+    return err(500, "Not configured");
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+  const auth = await validateAuth(event, supabase);
+  if (!auth.authenticated) return unauthorized();
+
+  // === GET: List projects with counts ===
+  if (event.httpMethod === "GET") {
+    const [projectsRes, imagesRes, promptsRes] = await Promise.all([
+      supabase
+        .from("creative_projects")
+        .select("*, creative_prompts(count), creative_images(count)")
+        .order("updated_at", { ascending: false })
+        .limit(50),
+      supabase
+        .from("creative_images")
+        .select("id, project_id, image_url, thumbnail_url, model_used, rating, selected, created_at")
+        .is("deleted_at", null)
+        .order("created_at", { ascending: false })
+        .limit(30),
+      supabase
+        .from("creative_prompts")
+        .select("id, project_id, prompt_text, style_tags, version, created_at")
+        .order("created_at", { ascending: false })
+        .limit(50),
+    ]);
+
+    return ok({
+      projects: projectsRes.data || [],
+      recent_images: imagesRes.data || [],
+      recent_prompts: promptsRes.data || [],
+    });
+  }
+
+  // === POST: Actions ===
+  if (event.httpMethod === "POST") {
+    let body;
+    try { body = JSON.parse(event.body); } catch { return err(400, "Invalid JSON"); }
+
+    const { action } = body;
+
+    // --- list_projects ---
+    if (action === "list_projects") {
+      const { data, error: qErr } = await supabase
+        .from("creative_projects")
+        .select("*")
+        .order("updated_at", { ascending: false })
+        .limit(body.limit || 50);
+      if (qErr) return err(500, qErr.message);
+      return ok({ projects: data });
+    }
+
+    // --- create_project ---
+    if (action === "create_project") {
+      const { article_title, article_url, article_excerpt, pipeline_id } = body;
+      if (!article_title) return err(400, "article_title required");
+      const { data, error: insertErr } = await supabase
+        .from("creative_projects")
+        .insert({
+          article_title,
+          article_url: article_url || null,
+          article_excerpt: article_excerpt || null,
+          pipeline_id: pipeline_id || null,
+        })
+        .select("*")
+        .single();
+      if (insertErr) return err(500, insertErr.message);
+      return ok({ created: true, project: data });
+    }
+
+    // --- update_project ---
+    if (action === "update_project" && body.id) {
+      const updates = { updated_at: new Date().toISOString() };
+      if (body.status) updates.status = body.status;
+      if (body.article_title) updates.article_title = body.article_title;
+      if (body.article_url !== undefined) updates.article_url = body.article_url;
+      if (body.article_excerpt !== undefined) updates.article_excerpt = body.article_excerpt;
+      if (body.pipeline_id !== undefined) updates.pipeline_id = body.pipeline_id;
+      const { error: updateErr } = await supabase.from("creative_projects").update(updates).eq("id", body.id);
+      if (updateErr) return err(500, updateErr.message);
+      return ok({ updated: true });
+    }
+
+    // --- delete_project ---
+    if (action === "delete_project" && body.id) {
+      const { error: deleteErr } = await supabase.from("creative_projects").delete().eq("id", body.id);
+      if (deleteErr) return err(500, deleteErr.message);
+      return ok({ deleted: true });
+    }
+
+    // --- get_project (full detail with prompts, images, research) ---
+    if (action === "get_project" && body.id) {
+      const [projRes, promptsRes, imagesRes, researchRes] = await Promise.all([
+        supabase.from("creative_projects").select("*").eq("id", body.id).single(),
+        supabase.from("creative_prompts").select("*").eq("project_id", body.id).order("created_at", { ascending: false }),
+        supabase.from("creative_images").select("*").eq("project_id", body.id).is("deleted_at", null).order("created_at", { ascending: false }),
+        supabase.from("creative_research").select("*").eq("project_id", body.id).order("created_at", { ascending: false }),
+      ]);
+      if (projRes.error) return err(404, "Project not found");
+      return ok({
+        project: projRes.data,
+        prompts: promptsRes.data || [],
+        images: imagesRes.data || [],
+        research: researchRes.data || [],
+      });
+    }
+
+    // --- create_prompt ---
+    if (action === "create_prompt") {
+      const { project_id, prompt_text, style_tags, parent_prompt_id } = body;
+      if (!project_id || !prompt_text) return err(400, "project_id and prompt_text required");
+
+      // Auto-increment version
+      let version = 1;
+      if (parent_prompt_id) {
+        const { data: parent } = await supabase
+          .from("creative_prompts")
+          .select("version")
+          .eq("id", parent_prompt_id)
+          .single();
+        if (parent) version = parent.version + 1;
+      }
+
+      const { data, error: insertErr } = await supabase
+        .from("creative_prompts")
+        .insert({
+          project_id,
+          prompt_text,
+          style_tags: style_tags || [],
+          version,
+          parent_prompt_id: parent_prompt_id || null,
+        })
+        .select("*")
+        .single();
+      if (insertErr) return err(500, insertErr.message);
+
+      // Update project status
+      await supabase.from("creative_projects").update({ status: "generating" }).eq("id", project_id);
+
+      return ok({ created: true, prompt: data });
+    }
+
+    // --- generate_image (calls ai-image function internally) ---
+    if (action === "generate_image") {
+      const { project_id, prompt_id, prompt_text, provider, size, style } = body;
+      if (!project_id || !prompt_id || !prompt_text) return err(400, "project_id, prompt_id, and prompt_text required");
+
+      // Call the existing ai-image function logic
+      try {
+        const aiImageModule = require("./ai-image");
+        const fakeEvent = {
+          httpMethod: "POST",
+          queryStringParameters: { key: event.queryStringParameters?.key },
+          body: JSON.stringify({
+            provider: provider || "gpt_image",
+            prompt: prompt_text,
+            size: size || "1024x1024",
+            style: style || "natural",
+          }),
+        };
+        const aiResp = await aiImageModule.handler(fakeEvent);
+        const aiData = JSON.parse(aiResp.body);
+
+        if (aiResp.statusCode !== 200 || aiData.error) {
+          return err(aiResp.statusCode || 500, aiData.error || "Image generation failed");
+        }
+
+        // Store the image URL
+        const imageUrl = aiData.base64
+          ? `data:${aiData.mimeType || "image/png"};base64,${aiData.base64}`
+          : aiData.url;
+
+        const { data: imgRow, error: imgErr } = await supabase
+          .from("creative_images")
+          .insert({
+            project_id,
+            prompt_id,
+            image_url: imageUrl,
+            model_used: provider || "gpt_image",
+            generation_params: { size, style, revised_prompt: aiData.revised_prompt },
+          })
+          .select("*")
+          .single();
+        if (imgErr) return err(500, imgErr.message);
+
+        return ok({ created: true, image: imgRow, revised_prompt: aiData.revised_prompt });
+      } catch (e) {
+        return err(500, e.message);
+      }
+    }
+
+    // --- list_images ---
+    if (action === "list_images") {
+      const query = supabase
+        .from("creative_images")
+        .select("*")
+        .is("deleted_at", null)
+        .order("created_at", { ascending: false })
+        .limit(body.limit || 50);
+      if (body.project_id) query.eq("project_id", body.project_id);
+      const { data, error: qErr } = await query;
+      if (qErr) return err(500, qErr.message);
+      return ok({ images: data });
+    }
+
+    // --- rate_image ---
+    if (action === "rate_image" && body.id) {
+      const updates = {};
+      if (body.rating !== undefined) updates.rating = body.rating;
+      if (body.selected !== undefined) updates.selected = body.selected;
+      if (body.notes !== undefined) updates.notes = body.notes;
+      const { error: updateErr } = await supabase.from("creative_images").update(updates).eq("id", body.id);
+      if (updateErr) return err(500, updateErr.message);
+
+      // If selecting, update project status
+      if (body.selected && body.project_id) {
+        // Deselect others in the same project
+        await supabase.from("creative_images").update({ selected: false }).eq("project_id", body.project_id).neq("id", body.id);
+        await supabase.from("creative_projects").update({ status: "complete" }).eq("id", body.project_id);
+      }
+
+      return ok({ updated: true });
+    }
+
+    // --- delete_image (soft delete) ---
+    if (action === "delete_image" && body.id) {
+      const { error: updateErr } = await supabase
+        .from("creative_images")
+        .update({ deleted_at: new Date().toISOString() })
+        .eq("id", body.id);
+      if (updateErr) return err(500, updateErr.message);
+      return ok({ deleted: true });
+    }
+
+    // --- research ---
+    if (action === "add_research") {
+      const { project_id, type, content, source } = body;
+      if (!project_id || !type || !content) return err(400, "project_id, type, and content required");
+      const { data, error: insertErr } = await supabase
+        .from("creative_research")
+        .insert({ project_id, type, content, source: source || null })
+        .select("*")
+        .single();
+      if (insertErr) return err(500, insertErr.message);
+      return ok({ created: true, research: data });
+    }
+
+    // --- list_research ---
+    if (action === "list_research" && body.project_id) {
+      const { data, error: qErr } = await supabase
+        .from("creative_research")
+        .select("*")
+        .eq("project_id", body.project_id)
+        .order("created_at", { ascending: false });
+      if (qErr) return err(500, qErr.message);
+      return ok({ research: data });
+    }
+
+    return err(400, "Unknown action: " + action);
+  }
+
+  return err(405, "Method not allowed");
+};

--- a/supabase/migrations/20260321300000_creative_studio.sql
+++ b/supabase/migrations/20260321300000_creative_studio.sql
@@ -1,0 +1,99 @@
+-- Creative Studio — Article Illustration Workspace
+-- Migrated from missionpulse.ai → missionmeetstech.com
+-- Tables: creative_projects, creative_prompts, creative_images, creative_research
+-- Storage: creative-studio bucket
+
+-- ─── Tables ──────────────────────────────────────────────────────
+
+create table if not exists creative_projects (
+  id uuid primary key default gen_random_uuid(),
+  article_title text not null,
+  article_url text,
+  article_excerpt text,
+  pipeline_id uuid references newsletter_pipeline(id) on delete set null,
+  status text not null default 'drafting'
+    check (status in ('drafting', 'generating', 'selecting', 'complete')),
+  created_by text not null default 'command_center',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists creative_prompts (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references creative_projects(id) on delete cascade,
+  prompt_text text not null,
+  refinement_notes text,
+  style_tags text[] default '{}',
+  version int not null default 1,
+  parent_prompt_id uuid references creative_prompts(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists creative_images (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references creative_projects(id) on delete cascade,
+  prompt_id uuid not null references creative_prompts(id) on delete cascade,
+  image_url text not null,
+  thumbnail_url text,
+  model_used text not null default 'dall-e-3',
+  generation_params jsonb default '{}',
+  rating int check (rating >= 1 and rating <= 5),
+  selected boolean not null default false,
+  notes text,
+  deleted_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists creative_research (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references creative_projects(id) on delete cascade,
+  type text not null
+    check (type in ('reference_image', 'style_guide', 'color_palette', 'mood', 'competitor_example')),
+  content text not null,
+  source text,
+  created_at timestamptz not null default now()
+);
+
+-- ─── Indexes ─────────────────────────────────────────────────────
+
+create index idx_creative_prompts_project on creative_prompts(project_id);
+create index idx_creative_images_project on creative_images(project_id);
+create index idx_creative_images_prompt on creative_images(prompt_id);
+create index idx_creative_research_project on creative_research(project_id);
+create index idx_creative_projects_created_by on creative_projects(created_by);
+create index idx_creative_projects_status on creative_projects(status);
+
+-- ─── Updated_at trigger ──────────────────────────────────────────
+
+create or replace function update_creative_projects_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_creative_projects_updated_at
+  before update on creative_projects
+  for each row execute function update_creative_projects_updated_at();
+
+-- ─── RLS ─────────────────────────────────────────────────────────
+-- Access is via Netlify Functions using the service role key.
+-- Enable RLS but grant full access to the service role (default for service_role).
+
+alter table creative_projects enable row level security;
+alter table creative_prompts enable row level security;
+alter table creative_images enable row level security;
+alter table creative_research enable row level security;
+
+-- ─── Storage Bucket ──────────────────────────────────────────────
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'creative-studio',
+  'creative-studio',
+  true,
+  10485760,
+  array['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml']
+)
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary
- **Supabase migration** (`20260321300000`): 4 tables (`creative_projects`, `creative_prompts`, `creative_images`, `creative_research`) + `creative-studio` storage bucket for generated images
- **`creative-api.js`** Netlify function: single endpoint with action-based routing for all creative operations (projects CRUD, prompt management, image generation/rating/selection, research). Follows `command-center-api.js` pattern with `?key=` auth
- **Content Studio UI expansion**: project list with status indicators, prompt builder with versioning and style tags, image gallery with star ratings and selection workflow, per-project research collector, newsletter pipeline linking

## Test plan
- [ ] Run Supabase migration against staging
- [ ] Verify `creative-api` GET returns empty projects/images/prompts
- [ ] Create a project, add prompts, generate images via the Content Studio detail view
- [ ] Confirm star ratings and image selection persist
- [ ] Confirm pipeline linking dropdown populates from `newsletter_pipeline`
- [ ] Verify Content Studio tile metrics update with project/image counts
- [ ] Test project deletion cascades (prompts, images, research removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)