### PR TITLE
feat: provision Jack Yang CTO access + per-user workspace defaults

### DIFF
--- a/command-center.html
+++ b/command-center.html
@@ -4634,6 +4634,15 @@ async function updateIssueStatus(id, status) {
       document.getElementById('dashboard').style.display = 'none';
     }
 
+    // Map user roles to default workspace and role filter
+    var ROLE_DEFAULTS = {
+      cto: { workspace: 'dev', roleFilter: 'cto' },
+      admin: { workspace: 'ops', roleFilter: 'all' },
+      coo: { workspace: 'ops', roleFilter: 'coo' },
+      editor: { workspace: 'editorial', roleFilter: 'editor' },
+      viewer: { workspace: 'ops', roleFilter: 'all' },
+    };
+
     function showDashboard(user) {
       currentUser = user;
       document.getElementById('login-screen').style.display = 'none';
@@ -4647,6 +4656,18 @@ async function updateIssueStatus(id, status) {
         badge.textContent = user.role || 'admin';
         badge.style.background = (roleColors[user.role] || '#6b7280') + '22';
         badge.style.color = roleColors[user.role] || '#6b7280';
+      }
+
+      // Set defaults on first login (if no saved workspace)
+      if (user && user.role && !localStorage.getItem('mmt-workspace')) {
+        var defaults = ROLE_DEFAULTS[user.role];
+        if (defaults) {
+          _activeWorkspace = defaults.workspace;
+          localStorage.setItem('mmt-workspace', defaults.workspace);
+          _roleFilter = defaults.roleFilter;
+          var roleSel = document.getElementById('role-selector');
+          if (roleSel) roleSel.value = defaults.roleFilter;
+        }
       }
 
       loadDashboard();

--- a/output/jack-onboarding.md
+++ b/output/jack-onboarding.md
@@ -1,0 +1,83 @@
+# Jack's Access — Mission Meets Tech
+
+## Command Center
+
+**URL:** https://missionmeetstech.com/command-center.html
+**Login:** Enter `jackyang2326@gmail.com` → magic link sent to your inbox
+**Default workspace:** Development
+**Your role:** CTO
+
+### First login
+1. Go to the URL above
+2. Enter your email
+3. Check inbox for magic link (arrives within 30 seconds)
+4. Click the link — you're in
+
+> **Note:** Mary needs to add your user record first. From the command center, click "Manage Users" → add `jackyang2326@gmail.com` with name `Jack Yang` and role `cto`. Or run this curl against the API with the COMMAND_CENTER_KEY.
+
+## MissionPulse.ai
+
+**URL:** https://missionpulse.ai
+**Login:** Sign up or log in with `jackyang2326@gmail.com` via Supabase Auth
+**Role:** Set to `admin` or `cto` in the `profiles` table after first login
+
+## GitHub Repos
+
+- https://github.com/maryadawson-code/mmt-site — MMT marketing site + command center
+- https://github.com/maryadawson-code/missionpulse-frontend — MissionPulse SaaS app
+
+> **Action needed:** Mary needs to add your GitHub username as a collaborator on both repos (Settings → Collaborators → Add people)
+
+## What's live right now
+
+### Command Center (mmt-site)
+- **3 workspaces:** Development, Operations, Editorial
+- Your Dev workspace has:
+  - **Engineering:** Live Netlify deploy history, GitHub PRs, tech debt from roadmap
+  - **Roadmap:** Full CRUD — create features, verify health, pre-flight checks, edit, comment
+  - **Issues:** Full lifecycle — detect → diagnose → fix → approve → deploy → verify → close
+  - **QA:** Product health grades, SLA metrics, regression management (file issues, link PRs, resolve)
+  - **Agent Fleet:** Agent status cards with steering (pause/resume/cancel/escalate), quick dispatch, per-agent task stream
+  - **Site Health:** Ops events, circuit breakers, feature flags, held emails
+  - **Security:** CMMC L2 posture, open findings
+  - **Cost Intelligence:** API costs, alerts, trends
+
+### MissionPulse.ai (missionpulse-frontend)
+- **Agent interaction layer** (spec 10O-10S):
+  - AgentCards — live agent status dashboard (30s poll)
+  - AgentConversationPanel — real-time task event stream (15s poll)
+  - AgentSteering — pause/resume/cancel/escalate/reprioritize controls
+  - ApprovalQueue — HITL safety gate with risk levels + diff previews
+  - NaturalLanguageRouter — NL command bar for dispatching tasks to agents
+- **Product Roadmap** — feature-level tracking with developer workspace (5 tabs: Overview, Code, AI Assistant, Tests & Health, Deploy)
+- **6 agents seeded:** ops-code, ops-editorial, ops-research, ops-monitor, ops-social, ops-newsletter
+
+## Quick start
+
+1. Open Command Center → you'll land in the **Development** workspace
+2. Check **Roadmap** for current features and status
+3. Check **Issues** for anything in "Needs Attention"
+4. **Agent Fleet** → dispatch tasks or steer running agents
+5. **Engineering** → see recent deploys and open PRs
+6. Press **Cmd+K** to search/navigate to any view across all workspaces
+
+## Environment setup (for local dev)
+
+```bash
+# Clone repos
+git clone git@github.com:maryadawson-code/mmt-site.git
+git clone git@github.com:maryadawson-code/missionpulse-frontend.git
+
+# mmt-site (static site + Netlify functions)
+cd mmt-site
+npm install
+node build.js
+netlify dev  # runs locally with functions
+
+# missionpulse-frontend (Next.js)
+cd missionpulse-frontend
+npm install
+npm run dev  # http://localhost:3000
+```
+
+Required env vars are in each repo's CLAUDE.md.


### PR DESCRIPTION
## Summary
Adds per-user workspace defaults based on role, and creates Jack's onboarding doc.

## Code changes (command-center.html)
- `ROLE_DEFAULTS` map: sets default workspace + role filter per user role
  - `cto` → Development workspace, CTO filter
  - `coo` → Operations workspace, COO filter
  - `editor` → Editorial workspace, Editor filter
  - `admin` → Operations workspace, All filter
- Applied in `showDashboard()` on first login only (no saved workspace in localStorage)
- Users can freely switch workspaces after — preference is saved

## Onboarding doc
`output/jack-onboarding.md` — covers login, what's live, quick start, local dev setup

## Manual steps required (Mary's checklist)
1. **Add Jack to dashboard_users**: From command center → Manage Users → add `jackyang2326@gmail.com`, name `Jack Yang`, role `cto`
2. **GitHub collaborator access**: Add Jack's GitHub username to both repos (Settings → Collaborators)
3. **MissionPulse.ai**: After Jack signs up, set `profiles.role` to `admin` in Supabase
4. **Send Jack the onboarding doc** (`output/jack-onboarding.md`)

## Existing access (already in place)
- Jack's email is in `ADMIN_EMAILS` for score-deck, score-deck-background, and roadmap-api
- No GitHub collaborator access yet (only `maryadawson-code`)

## Test plan
- [ ] CTO role user lands on Development workspace on first login
- [ ] COO role user lands on Operations workspace on first login
- [ ] Editor role user lands on Editorial workspace on first login
- [ ] Subsequent logins use saved localStorage preference
- [ ] Switching workspaces still works after default is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)