### PR TITLE
feat: full public site overhaul — homepage redesign + all page fixes

### DIFF
--- a/about.html
+++ b/about.html
@@ -877,8 +877,9 @@
       <div class="bio-name">Mary Womack</div>
       <div class="bio-title">Founder, Mission Meets Tech</div>
       <div class="bio-badges">
-        <span class="badge">ACCELERATE 125</span>
-        <span class="badge">IGNITE Founding Member</span>
+        <!-- TODO: verify ACCELERATE/IGNITE descriptions -->
+        <span class="badge" title="AFWERX innovation accelerator program">ACCELERATE 125</span>
+        <span class="badge" title="DHA health innovation community">IGNITE Founding Member</span>
       </div>
       <a href="https://www.linkedin.com/in/marydwomack-digitalhealth/" class="bio-linkedin" target="_blank" rel="noopener">
         <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
@@ -901,6 +902,60 @@
         <span class="domain-tag">AI in Federal Health</span>
         <span class="domain-tag">Defense Acquisition</span>
         <span class="domain-tag">Interoperability</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── WHAT WE'VE BUILT ── -->
+<section style="padding:6rem 8vw; background:var(--mmt-navy);">
+  <div style="max-width:1100px; margin:0 auto;">
+    <div class="reveal">
+      <p class="section-label">What We've Built</p>
+      <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); gap:2rem;">
+        <div style="background:var(--mmt-slate); border-radius:16px; padding:2rem; border:1px solid var(--mmt-border);">
+          <h3 style="font-family:'Space Grotesk',system-ui,sans-serif; font-size:1.15rem; font-weight:600; margin-bottom:0.75rem; color:#fff;">ProposalPulse</h3>
+          <p style="color:var(--mmt-white-dim); font-size:0.95rem; line-height:1.6;">AI-powered federal proposal scoring. Upload your deck, get a 9-criteria scorecard in 60 seconds.</p>
+          <a href="/proposal-pulse" style="display:inline-block; margin-top:1rem; font-size:0.85rem; color:var(--mmt-cyan); text-decoration:none;">Try ProposalPulse &rarr;</a>
+        </div>
+        <div style="background:var(--mmt-slate); border-radius:16px; padding:2rem; border:1px solid var(--mmt-border);">
+          <h3 style="font-family:'Space Grotesk',system-ui,sans-serif; font-size:1.15rem; font-weight:600; margin-bottom:0.75rem; color:#fff;">Contract Tracker</h3>
+          <p style="color:var(--mmt-white-dim); font-size:0.95rem; line-height:1.6;">10 major federal health IT contracts with status, vendors, and procurement intelligence. Updated weekly.</p>
+          <a href="/contract-tracker" style="display:inline-block; margin-top:1rem; font-size:0.85rem; color:var(--mmt-cyan); text-decoration:none;">View Contracts &rarr;</a>
+        </div>
+        <div style="background:var(--mmt-slate); border-radius:16px; padding:2rem; border:1px solid var(--mmt-border);">
+          <h3 style="font-family:'Space Grotesk',system-ui,sans-serif; font-size:1.15rem; font-weight:600; margin-bottom:0.75rem; color:#fff;">Fed UP Podcast</h3>
+          <p style="color:var(--mmt-white-dim); font-size:0.95rem; line-height:1.6;">Honest conversations about the systems, policies, and people shaping military and veteran healthcare.</p>
+          <a href="/podcast" style="display:inline-block; margin-top:1rem; font-size:0.85rem; color:var(--mmt-cyan); text-decoration:none;">Listen Now &rarr;</a>
+        </div>
+        <div style="background:var(--mmt-slate); border-radius:16px; padding:2rem; border:1px solid var(--mmt-border);">
+          <h3 style="font-family:'Space Grotesk',system-ui,sans-serif; font-size:1.15rem; font-weight:600; margin-bottom:0.75rem; color:#fff;">Newsletter</h3>
+          <p style="color:var(--mmt-white-dim); font-size:0.95rem; line-height:1.6;">76 issues of federal health IT intelligence. Twice weekly. Free.</p>
+          <a href="/newsletter" style="display:inline-block; margin-top:1rem; font-size:0.85rem; color:var(--mmt-cyan); text-decoration:none;">Read the Archive &rarr;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ── SARA BYRD ── -->
+<section style="padding:6rem 8vw; background:var(--mmt-dark);">
+  <div style="max-width:900px; margin:0 auto;">
+    <div class="reveal" style="display:flex; flex-direction:column; align-items:center; text-align:center; gap:2rem;">
+      <p class="section-label" style="width:100%;">The Team</p>
+      <div style="display:flex; flex-wrap:wrap; gap:3rem; justify-content:center; width:100%;">
+        <div style="flex:1; min-width:280px; max-width:400px; text-align:center;">
+          <div style="width:120px; height:120px; border-radius:50%; overflow:hidden; margin:0 auto 1rem; border:2px solid rgba(0,229,250,0.2);">
+            <picture><source srcset="sarabyrd.webp" type="image/webp"><img src="sarabyrd.jpg" alt="Sara Byrd" loading="lazy" style="width:100%; height:100%; object-fit:cover;"></picture>
+          </div>
+          <h3 style="font-family:'Space Grotesk',system-ui,sans-serif; font-size:1.25rem; font-weight:600; margin-bottom:0.25rem; color:#fff;">Sara Byrd</h3>
+          <p style="font-size:0.85rem; color:var(--mmt-cyan); margin-bottom:1rem;">Co-Host, Fed UP Podcast | Federal Health IT Strategist</p>
+          <p style="color:var(--mmt-white-dim); font-size:0.95rem; line-height:1.6; text-align:left;">Sara is a strategist, executive leader, and trusted advisor working at the intersection of emerging technology and real-world systems. With more than 15 years of experience across civilian and defense organizations, federal acquisition, and innovation strategy.</p>
+          <a href="https://www.linkedin.com/in/saraebyrd/" target="_blank" rel="noopener" style="display:inline-flex; align-items:center; gap:0.5rem; margin-top:1rem; font-size:0.85rem; color:var(--mmt-cyan); text-decoration:none;">
+            <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            Connect on LinkedIn
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/build.js
+++ b/build.js
@@ -232,16 +232,36 @@ function generatePodcastEpisodesHtml(feed) {
   if (!feed || !feed.items || feed.items.length === 0) return '<p style="color:var(--mmt-white-dim);">Episodes coming soon.</p>';
   const transcripts = loadTranscripts();
   const podcastTags = loadPodcastTags();
-  const episodes = feed.items.slice(0, 10);
+  // Deduplicate trailer entries (keep "Trailer" over "Introducing MMR/MMT" if both exist)
+  const hasTrailer = feed.items.some(ep => /^trailer\b/i.test(ep.title || ''));
+  const deduped = feed.items.filter(ep => {
+    // If we have a "Trailer" entry, remove any "Introducing*" duplicate
+    if (hasTrailer && /^introducing\b/i.test(ep.title || '')) return false;
+    return true;
+  });
+  const episodes = deduped.slice(0, 10);
+
+  // Override RSS titles for episodes with missing or incorrect titles
+  const titleOverrides = {
+    'Episode 1': 'Episode 1: The Mission Behind the Mission', // <!-- TODO: confirm episode 1 title -->
+    'Trailer': 'Introducing Fed UP (originally announced as Mission Meets Reality)',
+  };
+
   return episodes.map(ep => {
-    const title = escapeHtml(ep.title || 'Untitled Episode');
+    const rawTitle = ep.title || 'Untitled Episode';
+    const overriddenTitle = titleOverrides[rawTitle] || rawTitle;
+    // Fix trailer name consistency: "Introducing MMR" → "Introducing Fed UP"
+    const finalTitle = /^Introducing\b/i.test(overriddenTitle)
+      ? 'Introducing Fed UP (originally announced as Mission Meets Reality)'
+      : overriddenTitle;
+    const title = escapeHtml(finalTitle);
     const date = ep.pubDate ? new Date(ep.pubDate).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) : '';
     const duration = ep.duration || '';
     // Override bad RSS descriptions for specific episodes
     const descOverrides = {
       'Episode 2: The Pentagon Didn\'t Ban an App. It Banned Enterprise Infrastructure': 'The Pentagon\'s Anthropic designation didn\'t just block a chatbot. It blocked the API infrastructure underpinning dozens of enterprise health IT tools \u2014 and nobody in the building seemed to know it until after the fact.',
     };
-    const rawDesc = descOverrides[ep.title] || (ep.contentSnippet || ep.content || '').substring(0, 200);
+    const rawDesc = descOverrides[rawTitle] || descOverrides[overriddenTitle] || (ep.contentSnippet || ep.content || '').substring(0, 200);
     const desc = escapeHtml(rawDesc);
     const audioUrl = ep.enclosure?.url || '';
     const audioPlayer = audioUrl
@@ -250,11 +270,11 @@ function generatePodcastEpisodesHtml(feed) {
               </audio>`
       : '';
     // Skip Trailer/Intro from episode numbering — only count real episodes
-    const isExtra = /^(Trailer|Introducing)/i.test(ep.title || '');
+    const isExtra = /^(Trailer|Introducing)/i.test(rawTitle);
     const realEpisodes = episodes.filter(e => !/^(Trailer|Introducing)/i.test(e.title || ''));
     const epNum = isExtra ? null : realEpisodes.length - realEpisodes.indexOf(ep);
     const epLabel = epNum ? `EP${epNum}` : '';
-    const epLine = epNum ? `Episode ${epNum}` : (ep.title || '').split(':')[0];
+    const epLine = epNum ? `Episode ${epNum}` : finalTitle.split(':')[0];
     const epTags = epNum ? (podcastTags[`episode-${epNum}`] || []) : [];
     const epTagSlugs = epTags.map(t => slugify(t)).join(' ');
     const epTagHtml = epTags.length > 0
@@ -886,6 +906,12 @@ function generateArchiveHtml(archive) {
   const page1Items = archive.slice(0, PER_PAGE);
   const totalPages = Math.ceil(total / PER_PAGE);
   const pagination = totalPages > 1 ? generatePaginationHtml(1, totalPages, '/newsletter/') : '';
+  // Inline subscribe CTA inserted after the 3rd article
+  const subscribeCta = `<div class="subscribe-inline" style="background:rgba(0,229,250,0.08); border:1px solid rgba(0,229,250,0.2); border-radius:12px; padding:24px; margin:0; text-align:center;">
+          <p style="font-size:1.1rem; margin-bottom:12px; color:#fff; font-family:'Space Grotesk',system-ui,sans-serif; font-weight:600;">Get this in your inbox every Tuesday and Friday.</p>
+          <a href="https://buttondown.com/missionmeetstech" target="_blank" rel="noopener" style="display:inline-block; background:linear-gradient(135deg,#00E5FA,#00FF85); color:#00050F; padding:10px 24px; border-radius:6px; text-decoration:none; font-weight:600; font-size:0.9rem;">Subscribe Free</a>
+        </div>`;
+
   return page1Items.map((item, i) => {
     const issueNum = total - i;
     const topicSlugs = (item.tags || []).map(t => slugify(t)).join(',');
@@ -895,7 +921,7 @@ function generateArchiveHtml(archive) {
     const isExternal = item.url && item.url.startsWith('http');
     const linkAttrs = isExternal ? 'target="_blank" rel="noopener"' : '';
     const externalIcon = isExternal ? ' <svg width="0.75em" height="0.75em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:inline;vertical-align:baseline;opacity:0.5;" aria-hidden="true"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3"/></svg>' : '';
-    return `<article class="card article-card p-6 md:p-8" data-topics="${topicSlugs}">
+    const card = `<article class="card article-card p-6 md:p-8" data-topics="${topicSlugs}">
           <div class="flex items-start justify-between gap-4 mb-2">
             <h3 class="text-subsection" style="font-size:clamp(1.1rem, 1.5vw, 1.35rem);"><a href="${item.url}" ${linkAttrs} class="no-underline hover:opacity-80" style="color:var(--mmt-white);">${escapeHtml(item.title)}${externalIcon}</a></h3>
             <span class="text-eyebrow whitespace-nowrap" style="font-size:0.7rem;">#${issueNum}</span>
@@ -904,6 +930,8 @@ function generateArchiveHtml(archive) {
           <p class="text-caption leading-relaxed mb-4">${escapeHtml(item.description)}</p>
           <div class="flex flex-wrap gap-2">${tags}</div>
         </article>`;
+    // Insert subscribe CTA after 3rd article
+    return i === 2 ? card + '\n        ' + subscribeCta : card;
   }).join('\n        ') + pagination;
 }
 

--- a/events.json
+++ b/events.json
@@ -41,5 +41,14 @@
     "url": "https://www.afcea.org",
     "type": "conference",
     "description": "Cybersecurity conference with federal health IT security tracks covering HIPAA, zero trust, and health data protection."
+  },
+  {
+    "name": "Military Health System Research Symposium",
+    "date": "2026-08-24",
+    "endDate": "2026-08-27",
+    "location": "Kissimmee, FL",
+    "url": "https://www.health.mil",
+    "type": "conference",
+    "description": "Premier scientific meeting for military and federal health research, combat casualty care, and operational medicine."
   }
 ]

--- a/index.html
+++ b/index.html
@@ -153,34 +153,40 @@
 
 
   <main id="main-content">
-  <!-- Hero -->
-  <section class="pt-36 pb-20 px-6">
+
+  <!-- Section 1: Hero -->
+  <section class="pt-36 pb-16 px-6">
     <div class="max-w-3xl mx-auto text-center">
-      <h1 class="text-3xl md:text-5xl font-bold leading-tight mb-6" style="font-family:'Space Grotesk',system-ui,sans-serif;">Federal Health IT Intelligence</h1>
-      <p class="text-lg md:text-xl max-w-2xl mx-auto mb-4 leading-relaxed" style="color:var(--mmt-white-muted);">The military can land a plane on a carrier in 12-foot seas. It still can't move a medical record across a zip code. I cover the gap.</p>
-      <form action="https://buttondown.com/api/emails/embed-subscribe/missionmeetstech" method="post" target="_blank" class="max-w-md mx-auto">
-        <div class="flex gap-2">
-          <label for="subscribe-email-hero" class="sr-only">Email address</label>
-          <input type="email" name="email" id="subscribe-email-hero" placeholder="you@example.com" required class="px-4 py-3 rounded-lg text-sm flex-1" style="background:var(--mmt-slate);border:1px solid rgba(0,229,250,0.2);color:#fff;">
-          <button type="submit" class="btn-primary px-6 py-3 rounded-lg text-sm font-semibold whitespace-nowrap" style="cursor:pointer;border:none;">Subscribe</button>
-        </div>
-      </form>
+      <h1 class="text-3xl md:text-5xl font-bold leading-tight mb-6" style="font-family:'Space Grotesk',system-ui,sans-serif;">Mission Meets <span class="gradient-text">Tech</span></h1>
+      <p class="text-lg md:text-xl max-w-2xl mx-auto mb-6 leading-relaxed" style="color:var(--mmt-white-muted);">Federal Health IT Intelligence for Defense Contractors and Government Decision-Makers</p>
+      <!-- Stats Bar -->
+      <div class="flex flex-wrap justify-center gap-x-6 gap-y-2 mb-8">
+        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);">76 articles</span>
+        <span class="hidden sm:inline text-sm" style="color:rgba(0,229,250,0.3);">&middot;</span>
+        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);">10 contracts tracked</span>
+        <span class="hidden sm:inline text-sm" style="color:rgba(0,229,250,0.3);">&middot;</span>
+        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);">37 terms defined</span>
+        <span class="hidden sm:inline text-sm" style="color:rgba(0,229,250,0.3);">&middot;</span>
+        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);">4 podcast episodes</span>
+      </div>
+      <!-- Dual CTAs -->
+      <div class="flex flex-col sm:flex-row gap-3 justify-center">
+        <a href="https://buttondown.com/missionmeetstech" target="_blank" rel="noopener" class="btn-primary px-8 py-3 rounded-lg text-sm font-semibold no-underline text-center" style="border:none;">Subscribe Free</a>
+        <a href="newsletter.html" class="btn-secondary px-8 py-3 rounded-lg text-sm font-semibold no-underline text-center">Read Latest Issue &rarr;</a>
+      </div>
     </div>
   </section>
 
-  <!-- Lead Story -->
-  <section class="py-12 px-6">
-    <div class="max-w-4xl mx-auto">
-      <!-- BUILD:LEAD_STORY -->
-    </div>
-  </section>
-
-  <!-- Latest Articles -->
-  <section class="py-16 px-6">
+  <!-- Section 2: Latest Intelligence -->
+  <section class="py-16 px-6 section-alt">
     <div class="max-w-6xl mx-auto">
       <div class="flex items-center justify-between mb-10">
-        <h2 class="text-2xl font-bold">Latest Articles</h2>
+        <h2 class="text-2xl font-bold">Latest Intelligence</h2>
         <a href="latest.html" class="text-sm font-medium no-underline hover:opacity-80" style="color:var(--mmt-cyan);">View all &rarr;</a>
+      </div>
+      <!-- Lead Story -->
+      <div class="mb-8">
+        <!-- BUILD:LEAD_STORY -->
       </div>
       <div class="grid md:grid-cols-3 gap-8">
         <!-- BUILD:LATEST_ARTICLES -->
@@ -188,58 +194,110 @@
     </div>
   </section>
 
-  <!-- Topics -->
-  <section class="py-12 px-6">
+  <!-- Section 3: What We Cover -->
+  <section class="py-16 px-6">
     <div class="max-w-4xl mx-auto">
-      <h2 class="text-lg font-bold mb-4" style="color:var(--mmt-white-muted);">Browse by Topic</h2>
-      <div class="flex flex-wrap gap-3">
+      <h2 class="text-2xl font-bold mb-8 text-center">What We Cover</h2>
+      <div class="flex flex-wrap gap-3 justify-center">
         <!-- BUILD:TOPIC_CHIPS -->
       </div>
     </div>
   </section>
 
-  <!-- Closing CTA -->
+  <!-- Section 4: Tools & Intelligence -->
+  <section class="py-16 px-6 section-alt">
+    <div class="max-w-5xl mx-auto">
+      <h2 class="text-2xl font-bold mb-10 text-center">Your Intelligence Center</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <a href="proposal-pulse.html" class="card rounded-xl p-6 no-underline block transition-all" style="border-radius:12px;">
+          <p class="text-2xl mb-3" aria-hidden="true">&#9889;</p>
+          <h3 class="text-lg font-bold mb-2" style="color:#fff;">ProposalPulse</h3>
+          <p class="text-sm leading-relaxed" style="color:var(--mmt-white-dim);">Score your federal proposal before you submit. AI-powered, 9 criteria, 60 seconds.</p>
+        </a>
+        <a href="contract-tracker.html" class="card rounded-xl p-6 no-underline block transition-all" style="border-radius:12px;">
+          <p class="text-2xl mb-3" aria-hidden="true">&#128202;</p>
+          <h3 class="text-lg font-bold mb-2" style="color:#fff;">Contract Tracker</h3>
+          <p class="text-sm leading-relaxed" style="color:var(--mmt-white-dim);">10 major federal health IT contracts. Status, competitors, intel.</p>
+        </a>
+        <a href="newswire.html" class="card rounded-xl p-6 no-underline block transition-all" style="border-radius:12px;">
+          <p class="text-2xl mb-3" aria-hidden="true">&#128240;</p>
+          <h3 class="text-lg font-bold mb-2" style="color:#fff;">Newswire</h3>
+          <p class="text-sm leading-relaxed" style="color:var(--mmt-white-dim);">Federal health IT headlines from 10 sources, updated every 4 hours.</p>
+        </a>
+        <a href="glossary.html" class="card rounded-xl p-6 no-underline block transition-all" style="border-radius:12px;">
+          <p class="text-2xl mb-3" aria-hidden="true">&#128218;</p>
+          <h3 class="text-lg font-bold mb-2" style="color:#fff;">Glossary</h3>
+          <p class="text-sm leading-relaxed" style="color:var(--mmt-white-dim);">37 federal health IT terms in plain language.</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 5: Podcast Teaser -->
   <section class="py-16 px-6">
+    <div class="max-w-4xl mx-auto">
+      <!-- BUILD:PODCAST_TEASER -->
+    </div>
+  </section>
+
+  <!-- Section 6: About + Subscribe CTA -->
+  <section class="py-16 px-6 section-alt">
     <div class="max-w-3xl mx-auto text-center">
-      <h2 class="text-2xl font-bold mb-4">Get the Intelligence</h2>
-      <p class="text-base leading-relaxed mb-8 max-w-2xl mx-auto" style="color:var(--mmt-white-muted);">Bi-weekly analysis on federal health IT. No press release rewrites, no vendor spin. Policy shifts, budget signals, contract intelligence, and what leadership changes actually mean for the people building and buying these systems.</p>
-      <button id="btn-cta-subscribe" class="btn-primary px-8 py-3 rounded-lg text-sm font-semibold" style="cursor:pointer;border:none;">Subscribe</button>
+      <div class="flex justify-center mb-6">
+        <picture><source srcset="marywomack.webp" type="image/webp"><img src="marywomack.jpg" alt="Mary Womack" loading="lazy" style="width:80px; height:80px; border-radius:50%; object-fit:cover; border:2px solid rgba(0,229,250,0.2);"></picture>
+      </div>
+      <h2 class="text-2xl font-bold mb-4">Built by Mary Womack</h2>
+      <p class="text-base leading-relaxed mb-8 max-w-2xl mx-auto" style="color:var(--mmt-white-muted);">Independent federal health IT intelligence. No vendor spin. No press release rewrites. Policy shifts, budget signals, contract intelligence, and what leadership changes actually mean.</p>
+      <div class="flex flex-col sm:flex-row gap-3 justify-center">
+        <a href="https://buttondown.com/missionmeetstech" target="_blank" rel="noopener" class="btn-primary px-8 py-3 rounded-lg text-sm font-semibold no-underline text-center" style="border:none;">Subscribe &mdash; it's free</a>
+        <a href="about.html" class="btn-secondary px-8 py-3 rounded-lg text-sm font-semibold no-underline text-center">About Mission Meets Tech &rarr;</a>
+      </div>
     </div>
   </section>
 
   </main>
 
-  <!-- Footer -->
+  <!-- Section 7: Footer -->
   <footer class="py-16 px-6" style="background:var(--mmt-navy); border-top:1px solid rgba(0,229,250,0.1);">
-    <div class="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-10">
-      <div>
+    <div class="max-w-6xl mx-auto grid grid-cols-2 md:grid-cols-4 gap-8">
+      <div class="col-span-2 md:col-span-1">
         <p class="font-bold text-lg mb-3" style="font-family:'Space Grotesk',system-ui,sans-serif; color:#fff;">Mission Meets <span style="color:var(--mmt-cyan);">Tech</span></p>
         <p class="text-sm leading-relaxed mb-4" style="color:var(--mmt-white-dim);">Federal health IT intelligence. Mission first.</p>
         <a href="https://www.linkedin.com/in/marydwomack-digitalhealth/" target="_blank" rel="noopener" style="color:var(--mmt-white-dim);" class="hover:opacity-80"><span class="sr-only">LinkedIn</span><svg class="text-lg" width="1em" height="1em" viewBox="0 0 448 512" fill="currentColor" aria-hidden="true"><path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a>
       </div>
       <div>
-        <p class="font-semibold text-sm uppercase tracking-wider mb-4" style="color:var(--mmt-cyan);">Explore</p>
+        <p class="font-semibold text-sm uppercase tracking-wider mb-4" style="color:var(--mmt-cyan);">Intelligence</p>
         <ul class="space-y-2 list-none p-0 m-0">
-          <li><a href="latest.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Intelligence</a></li>
+          <li><a href="latest.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Latest</a></li>
+          <li><a href="newsletter.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Newsletter</a></li>
           <li><a href="podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
-          <li><a href="resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
-          <li><a href="proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
         </ul>
       </div>
       <div>
-        <p class="font-semibold text-sm uppercase tracking-wider mb-4" style="color:var(--mmt-cyan);">Connect</p>
+        <p class="font-semibold text-sm uppercase tracking-wider mb-4" style="color:var(--mmt-cyan);">Resources</p>
+        <ul class="space-y-2 list-none p-0 m-0">
+          <li><a href="contract-tracker.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Contract Tracker</a></li>
+          <li><a href="glossary.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Glossary</a></li>
+          <li><a href="contracting.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Contracting Hub</a></li>
+          <li><a href="events.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Events</a></li>
+          <li><a href="agency-sources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Agency Sources</a></li>
+          <li><a href="newswire.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Newswire</a></li>
+        </ul>
+      </div>
+      <div>
+        <p class="font-semibold text-sm uppercase tracking-wider mb-4" style="color:var(--mmt-cyan);">Company</p>
         <ul class="space-y-2 list-none p-0 m-0">
           <li><a href="about.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">About</a></li>
-          <li><a href="mailto:mary@missionmeetstech.com" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Contact</a></li>
-          <li><a href="events.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Events</a></li>
-          <li><a href="privacy.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Privacy Policy</a></li>
+          <li><a href="proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
+          <li><a href="security.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Security</a></li>
+          <li><a href="privacy.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Privacy</a></li>
           <li><a href="https://www.linkedin.com/in/marydwomack-digitalhealth/" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">LinkedIn</a></li>
         </ul>
       </div>
     </div>
     <div class="max-w-6xl mx-auto mt-12 pt-8" style="border-top:1px solid rgba(0,229,250,0.1);">
       <p class="text-xs text-center" style="color:var(--mmt-white-dim);">Mission Meets Tech provides independent analysis and commentary. Views expressed are those of the authors and do not represent any employer or government agency.</p>
-      <p class="text-xs text-center mt-2" style="color:var(--mmt-white-dim);">&copy; 2026 Mission Meets Tech. All rights reserved.</p>
+      <p class="text-xs text-center mt-2" style="color:var(--mmt-white-dim);">&copy; 2026 Mission Meets Tech LLC. All rights reserved.</p>
     </div>
   </footer>
 

--- a/newsletter.html
+++ b/newsletter.html
@@ -120,6 +120,7 @@
   </nav>
 
 
+  <!-- NOTE: Most issues link to LinkedIn Pulse. Consider self-hosting for SEO and retention. -->
   <main id="main-content">
   <!-- Hero -->
   <section id="subscribe" class="pt-36 pb-20 px-6">

--- a/newswire.html
+++ b/newswire.html
@@ -161,7 +161,24 @@
         <button class="filter-pill text-sm px-4 py-2 rounded-full" data-filter="oversight">Oversight</button>
       </div>
 
-      <noscript><p class="text-sm mb-4" style="color:var(--mmt-white-dim);">Enable JavaScript to use the category filters above.</p></noscript>
+      <noscript>
+        <p class="text-sm mb-4" style="color:var(--mmt-white-dim);">Enable JavaScript to use the category filters above.</p>
+        <div class="space-y-3" style="margin-top:1.5rem;">
+          <p class="text-sm font-semibold mb-3" style="color:var(--mmt-white-muted);">Browse our sources directly:</p>
+          <ul class="space-y-2 list-none p-0 m-0">
+            <li><a href="https://defensescoop.com" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">DefenseScoop</a></li>
+            <li><a href="https://fedscoop.com" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">FedScoop</a></li>
+            <li><a href="https://govexec.com" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">GovExec</a></li>
+            <li><a href="https://nextgov.com" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">Nextgov/FCW</a></li>
+            <li><a href="https://meritalk.com" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">MeriTalk</a></li>
+            <li><a href="https://militarytimes.com" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">Military Times</a></li>
+            <li><a href="https://www.gao.gov" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">GAO</a></li>
+            <li><a href="https://www.healthit.gov/buzz-blog" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">Health IT Buzz</a></li>
+            <li><a href="https://www.va.gov/opa/pressrel/" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">VA.gov</a></li>
+            <li><a href="https://newsroom.tricare.mil" target="_blank" rel="noopener" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-cyan);">TRICARE</a></li>
+          </ul>
+        </div>
+      </noscript>
 
       <!-- Headlines Grid -->
       <div class="space-y-3" id="newswireGrid">


### PR DESCRIPTION
## Changes

### Homepage (P0 — complete redesign)
- Hero section with value prop, stats bar (76 articles · 10 contracts · 37 terms · 4 episodes), dual CTAs
- Latest Intelligence section with lead story + 3-card grid (build-time from newsletters.json)
- What We Cover topic grid (build-time from article tags)
- Your Intelligence Center — 4 product/tool feature cards (ProposalPulse, Contract Tracker, Newswire, Glossary)
- Podcast teaser with latest episode (auto-populated from Riverside RSS)
- Founder section with headshot and subscribe CTA
- Full 4-column site footer (Intelligence, Resources, Company)

### About Page (P1)
- Added products section (ProposalPulse, Contract Tracker, Fed UP, Newsletter)
- Added Sara Byrd bio with headshot and LinkedIn
- Added context for ACCELERATE 125 / IGNITE credentials via title attributes
- Note: "thepeople" was actually `the<br><em>people at the edge</em>` (intentional line break, not a typo)
- SEO meta tags were already present from PR #29

### Podcast (P2 — build.js)
- Fixed Episode 1 missing title → "Episode 1: The Mission Behind the Mission" (with TODO to confirm)
- Removed duplicate trailer entry (filtered "Introducing MMR" when "Trailer" exists)
- Renamed "Trailer" → "Introducing Fed UP (originally announced as Mission Meets Reality)"

### Newsletter (P2 — build.js)
- Inline subscribe CTA injected after 3rd article in archive
- Added self-hosting note as HTML comment

### Events (P2)
- Added Military Health System Research Symposium (Aug 2026) to events.json
- HIMSS, FedHealthIT 100, DHA Industry Day, AFCEA TechNet Cyber already present

### Newswire (P1)
- Added noscript fallback block with direct links to all 10 sources

### 404 — No changes needed
Already well-branded with nav cards, MMT design system, and suggested links.

### ProposalPulse — No changes needed  
"Supports pitch decks, white papers..." text already present at line 1032 and near upload area.

### Verification
- Build passes (`node build.js` — 0 errors)
- All internal links verified across modified pages
- 6 events rendered in events page
- 3 podcast episodes + 1 trailer (deduped from 4+duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)