### PR TITLE
fix: glossary nav — MarketPulse href correction

### DIFF
--- a/glossary/asd-ha.html
+++ b/glossary/asd-ha.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/ato.html
+++ b/glossary/ato.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/bpa.html
+++ b/glossary/bpa.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/carequality.html
+++ b/glossary/carequality.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/cmmc.html
+++ b/glossary/cmmc.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/connected-care.html
+++ b/glossary/connected-care.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -137,7 +137,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/contract-pricing.html
+++ b/glossary/contract-pricing.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/contracting-officer.html
+++ b/glossary/contracting-officer.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/cor.html
+++ b/glossary/cor.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/cots.html
+++ b/glossary/cots.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/crs.html
+++ b/glossary/crs.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -137,7 +137,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/dha.html
+++ b/glossary/dha.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -140,7 +140,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/dhp.html
+++ b/glossary/dhp.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/directtrust.html
+++ b/glossary/directtrust.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/ehealth-exchange.html
+++ b/glossary/ehealth-exchange.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/ehr.html
+++ b/glossary/ehr.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/far.html
+++ b/glossary/far.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/fedramp.html
+++ b/glossary/fedramp.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/fehrm.html
+++ b/glossary/fehrm.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/fhir.html
+++ b/glossary/fhir.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/fiscal-year.html
+++ b/glossary/fiscal-year.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/gao.html
+++ b/glossary/gao.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -137,7 +137,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/govcon.html
+++ b/glossary/govcon.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/gwac.html
+++ b/glossary/gwac.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/hl7.html
+++ b/glossary/hl7.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/idiq.html
+++ b/glossary/idiq.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/index.html
+++ b/glossary/index.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -385,7 +385,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/jlv.html
+++ b/glossary/jlv.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/joint-hie.html
+++ b/glossary/joint-hie.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/jomis.html
+++ b/glossary/jomis.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/medical-echelons.html
+++ b/glossary/medical-echelons.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/mhs-genesis.html
+++ b/glossary/mhs-genesis.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -140,7 +140,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/mhs.html
+++ b/glossary/mhs.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/mtf.html
+++ b/glossary/mtf.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/ndaa.html
+++ b/glossary/ndaa.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/nist-800-171.html
+++ b/glossary/nist-800-171.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/nist-800-53.html
+++ b/glossary/nist-800-53.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/opmed.html
+++ b/glossary/opmed.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/ota.html
+++ b/glossary/ota.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -137,7 +137,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/program-manager.html
+++ b/glossary/program-manager.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/pwin.html
+++ b/glossary/pwin.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/pws.html
+++ b/glossary/pws.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/rfi.html
+++ b/glossary/rfi.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/rfp.html
+++ b/glossary/rfp.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -140,7 +140,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/sam-gov.html
+++ b/glossary/sam-gov.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/service-components.html
+++ b/glossary/service-components.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/small-business-set-asides.html
+++ b/glossary/small-business-set-asides.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/sow.html
+++ b/glossary/sow.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/stigs.html
+++ b/glossary/stigs.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/t4ng.html
+++ b/glossary/t4ng.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/task-order.html
+++ b/glossary/task-order.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/tefca.html
+++ b/glossary/tefca.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -139,7 +139,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/tricare.html
+++ b/glossary/tricare.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/uscdi.html
+++ b/glossary/uscdi.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/va-ehr.html
+++ b/glossary/va-ehr.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -140,7 +140,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/vha.html
+++ b/glossary/vha.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/vista.html
+++ b/glossary/vista.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>

--- a/glossary/zero-trust.html
+++ b/glossary/zero-trust.html
@@ -66,7 +66,7 @@
         <a href="/podcast.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium hover:opacity-80" style="color:var(--mmt-white-muted);">About</a>
       </div>
       <button id="menuToggle" class="md:hidden text-white text-xl" aria-label="Toggle menu">
@@ -80,7 +80,7 @@
         <a href="/podcast.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Podcast</a>
         <a href="/resources.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">Resources</a>
         <a href="/proposal-pulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">ProposalPulse</a>
-        <a href="/tactical-brief.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
+        <a href="/marketpulse.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">MarketPulse</a>
         <a href="/about.html" class="text-sm font-medium" style="color:var(--mmt-white-muted);">About</a>
       </div>
     </div>
@@ -138,7 +138,7 @@
           <li><a href="/podcast.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Podcast</a></li>
           <li><a href="/resources.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">Resources</a></li>
           <li><a href="/proposal-pulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">ProposalPulse</a></li>
-          <li><a href="/tactical-brief.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
+          <li><a href="/marketpulse.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">MarketPulse</a></li>
           <li><a href="/my-reports.html" class="text-sm no-underline hover:opacity-80" style="color:var(--mmt-white-muted);">My Reports</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
All 58 glossary pages had MarketPulse nav link pointing to `/tactical-brief.html` instead of `/marketpulse.html`. This fixes the href only — no other changes.

58 files, 174 substitutions (href-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)