### PR TITLE
fix: add MHSRS 2026 to events calendar

### DIFF
--- a/events.json
+++ b/events.json
@@ -41,5 +41,14 @@
     "url": "https://www.afcea.org",
     "type": "conference",
     "description": "Cybersecurity conference with federal health IT security tracks covering HIPAA, zero trust, and health data protection."
+  },
+  {
+    "name": "Military Health System Research Symposium",
+    "date": "2026-08-24",
+    "endDate": "2026-08-27",
+    "location": "Kissimmee, FL",
+    "url": "https://www.health.mil",
+    "type": "conference",
+    "description": "Premier scientific meeting for military and federal health research, combat casualty care, and operational medicine."
   }
 ]


### PR DESCRIPTION
## Summary
Add Military Health System Research Symposium (Aug 24-27, 2026, Kissimmee FL) to events.json.

1 file, 9 lines added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)