### PR TITLE
fix: about page — badge context and br spacing

### DIFF
--- a/about.html
+++ b/about.html
@@ -818,7 +818,7 @@
   <div class="hero-text">
     <p class="hero-eyebrow">About the Platform</p>
     <h1 class="hero-headline">
-      Intelligence built for the<br><em>people at the edge.</em>
+      Intelligence built for the <br><em>people at the edge.</em>
     </h1>
     <p class="hero-sub">
       Federal health IT is too important — and too complex — to be covered with press releases and surface-level takes. Mission Meets Tech translates policy into practice for the people who build, buy, and operate the systems that support military and veteran healthcare.
@@ -843,7 +843,7 @@
     <p class="section-label">Why This Exists</p>
     <div class="origin-grid">
       <div class="origin-statement">
-        The gap isn't technical.<br>It's <em>translational.</em>
+        The gap isn't technical. <br>It's <em>translational.</em>
       </div>
       <div class="origin-body">
         <p>Federal health IT sits at the intersection of national security, healthcare delivery, and technology modernization. The decisions made inside DHA, VA, and Congress ripple through an ecosystem of contractors, clinicians, and service members who depend on these systems working.</p>
@@ -877,8 +877,8 @@
       <div class="bio-name">Mary Womack</div>
       <div class="bio-title">Founder, Mission Meets Tech</div>
       <div class="bio-badges">
-        <span class="badge">ACCELERATE 125</span>
-        <span class="badge">IGNITE Founding Member</span>
+        <span class="badge" title="AFWERX defense innovation program">ACCELERATE 125 (AFWERX defense innovation program)</span>
+        <span class="badge" title="Bunker Labs veteran entrepreneur program">IGNITE Founding Member (Bunker Labs veteran entrepreneur program)</span>
       </div>
       <a href="https://www.linkedin.com/in/marydwomack-digitalhealth/" class="bio-linkedin" target="_blank" rel="noopener">
         <svg width="14" height="14" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>


### PR DESCRIPTION
## Summary
- Add AFWERX/Bunker Labs program context to ACCELERATE 125 and IGNITE badges
- Add space before `<br>` tags in hero headline ("the<br>" → "the <br>") and origin statement ("technical.<br>" → "technical. <br>")

1 file, 4 lines changed. No content, layout, or nav changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)