### PR TITLE
feat: OG meta tags for LinkedIn/social link previews

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,10 +6,17 @@
   <title>About — Mission Meets Tech</title>
   <meta name="description" content="Mission Meets Tech is an independent federal health IT intelligence platform. Founded by Mary Womack to serve defense health decision-makers.">
   <meta property="og:title" content="About — Mission Meets Tech">
-  <meta property="og:description" content="Independent federal health IT intelligence. Founded by Mary Womack to serve defense health decision-makers.">
+  <meta property="og:description" content="Mary Womack covers the gap between defense health policy and operational reality. Independent analysis for the people who build and buy federal health IT.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://missionmeetstech.com/about.html">
+  <meta property="og:url" content="https://missionmeetstech.com/about">
   <meta property="og:image" content="https://missionmeetstech.com/mmt-logo.png">
+  <meta property="og:image:width" content="200">
+  <meta property="og:image:height" content="200">
+  <meta property="og:site_name" content="Mission Meets Tech">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="About — Mission Meets Tech">
+  <meta name="twitter:description" content="Mary Womack covers the gap between defense health policy and operational reality. Independent analysis for the people who build and buy federal health IT.">
+  <meta name="twitter:image" content="https://missionmeetstech.com/mmt-logo.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
   <style>

--- a/build.js
+++ b/build.js
@@ -728,6 +728,14 @@ async function generateOgImages(articles, tags, contracts) {
     { filename: 'community.png', title: 'Community', subtitle: 'Join the Mission Meets Tech community', label: 'COMMUNITY' },
     { filename: 'events.png', title: 'Events Calendar', subtitle: 'Federal health IT conferences and deadlines', label: 'EVENTS' },
     { filename: 'refer.png', title: 'Share Mission Meets Tech', subtitle: 'Help grow the federal health IT community', label: 'REFER' },
+    { filename: 'marketpulse.png', title: 'MarketPulse', subtitle: 'On-demand federal health IT market intelligence', label: 'INTELLIGENCE' },
+    { filename: 'security.png', title: 'Data Security', subtitle: 'How we protect your proposal and research data', label: 'SECURITY' },
+    { filename: 'glossary.png', title: 'Federal Health IT Glossary', subtitle: '37 terms explained in plain language', label: 'GLOSSARY' },
+    { filename: 'contracting.png', title: 'Contracting Hub', subtitle: 'Federal health IT contract vehicles compared', label: 'CONTRACTING' },
+    { filename: 'getting-started.png', title: 'Getting Started', subtitle: 'New to federal health IT? Start here.', label: 'GUIDE' },
+    { filename: 'privacy.png', title: 'Privacy Policy', subtitle: 'How Mission Meets Tech handles your data', label: 'PRIVACY' },
+    { filename: 'terms.png', title: 'Terms of Service', subtitle: 'Mission Meets Tech usage terms', label: 'TERMS' },
+    { filename: 'agency-sources.png', title: 'Agency Sources', subtitle: 'Primary federal health IT data sources', label: 'SOURCES' },
   ];
 
   for (const page of staticPages) {
@@ -1681,6 +1689,14 @@ function copyStaticFiles({ archive, feed, newsItems, contracts }) {
     'newswire.html': 'newswire.png',
     'contract-tracker.html': 'contract-tracker.png',
     'events.html': 'events.png',
+    'marketpulse.html': 'marketpulse.png',
+    'security.html': 'security.png',
+    'glossary.html': 'glossary.png',
+    'contracting.html': 'contracting.png',
+    'getting-started.html': 'getting-started.png',
+    'privacy.html': 'privacy.png',
+    'terms.html': 'terms.png',
+    'agency-sources.html': 'agency-sources.png',
   };
 
   // Sort archive by date (newest first) for consistent display order


### PR DESCRIPTION
## Summary
- Add 8 missing pages to OG image map in build.js
- Generate 1200x630 branded OG images for marketpulse, security, glossary, contracting, getting-started, privacy, terms, agency-sources
- Add twitter:card tags to about.html
- Update about.html og:description

2 files, 25 lines. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)