### PR TITLE
feat: dynamic homepage stats from build data

### DIFF
--- a/build.js
+++ b/build.js
@@ -1726,6 +1726,11 @@ function copyStaticFiles({ archive, feed, newsItems, contracts }) {
     '<!-- BUILD:CONTRACT_TRACKER -->': generateContractTrackerHtml(contracts),
     '<!-- BUILD:CONTRACT_SUMMARY -->': generateContractSummaryHtml(contracts),
     '<!-- BUILD:EVENTS_LIST -->': generateEventsListHtml(),
+    // Dynamic stats
+    '<!-- BUILD:STAT_ARTICLES -->': String(archive.length),
+    '<!-- BUILD:STAT_CONTRACTS -->': String(contracts.length),
+    '<!-- BUILD:STAT_TERMS -->': String(fs.existsSync(path.join(__dirname, 'glossary')) ? fs.readdirSync(path.join(__dirname, 'glossary')).filter(f => f.endsWith('.html') && f !== 'index.html').length : 0),
+    '<!-- BUILD:STAT_EPISODES -->': String(feed && feed.items ? feed.items.filter(ep => !/^(Trailer|Introducing)/i.test(ep.title || '')).length : 0),
     '<!-- BUILD:JSONLD_TOPICS -->': generateJsonLdTopics(archive),
     '<!-- BUILD:JSONLD_LATEST -->': generateJsonLdLatest(archive),
     '<!-- BUILD:JSONLD_NEWSLETTER -->': generateJsonLdNewsletter(archive),

--- a/index.html
+++ b/index.html
@@ -162,13 +162,13 @@
       <p class="text-lg md:text-xl max-w-2xl mx-auto mb-6 leading-relaxed" style="color:var(--mmt-white-muted);">Federal Health IT Intelligence for Defense Contractors and Government Decision-Makers</p>
       <!-- Stats Bar -->
       <div class="flex flex-wrap justify-center gap-x-6 gap-y-2 mb-8">
-        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);">76 articles</span>
+        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);"><!-- BUILD:STAT_ARTICLES --> articles</span>
         <span class="hidden sm:inline text-sm" style="color:rgba(0,229,250,0.3);">&middot;</span>
-        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);">10 contracts tracked</span>
+        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);"><!-- BUILD:STAT_CONTRACTS --> contracts tracked</span>
         <span class="hidden sm:inline text-sm" style="color:rgba(0,229,250,0.3);">&middot;</span>
-        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);">37 terms defined</span>
+        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);"><!-- BUILD:STAT_TERMS --> terms defined</span>
         <span class="hidden sm:inline text-sm" style="color:rgba(0,229,250,0.3);">&middot;</span>
-        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);">4 podcast episodes</span>
+        <span class="text-sm font-medium" style="color:var(--mmt-white-dim);"><!-- BUILD:STAT_EPISODES --> podcast episodes</span>
       </div>
       <!-- Trust Badges -->
       <div class="flex flex-wrap justify-center gap-4 mb-8">


### PR DESCRIPTION
## Summary
Replace hardcoded "76 articles / 10 contracts / 37 terms / 4 episodes" with build-time placeholders that auto-update from actual data on every deploy.

2 files (index.html, build.js).

🤖 Generated with [Claude Code](https://claude.com/claude-code)