### PR TITLE
fix: remove shield icon from about page CTA

### DIFF
--- a/about.html
+++ b/about.html
@@ -1065,7 +1065,7 @@
 <section class="cta-section">
   <div class="cta-glow"></div>
   <div class="cta-inner reveal">
-    <picture><source srcset="MMT_icon_128px.webp" type="image/webp"><img src="MMT_icon_128px.png" alt="" class="cta-logo" loading="lazy"></picture>
+    <p class="cta-logo" style="font-family:'Space Grotesk',system-ui,sans-serif; font-weight:700; font-size:1.5rem; color:#fff; margin-bottom:0;">Mission Meets <span style="color:#00E5FA;">Tech</span></p>
     <h2 class="cta-headline">Get the intelligence.<br>Stay ahead of the mission.</h2>
     <p class="cta-sub">Weekly analysis on federal health IT policy, defense technology, and the decisions shaping military and veteran healthcare. Free. No press releases.</p>
     <div class="cta-buttons">


### PR DESCRIPTION
## Summary
Remove MMT_icon_128px.png shield image from about.html CTA section. Replace with text wordmark.

1 file, 1 line changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)