### PR TITLE
feat: events — calendar export, type badges, suggest CTA

### DIFF
--- a/build.js
+++ b/build.js
@@ -1251,12 +1251,26 @@ function generateEventsListHtml() {
     'conference': '<svg width="1em" height="1em" viewBox="0 0 640 512" fill="currentColor" aria-hidden="true"><path d="M48 0C21.5 0 0 21.5 0 48V464c0 26.5 21.5 48 48 48h96V432c0-26.5 21.5-48 48-48s48 21.5 48 48v80h96V48c0-26.5-21.5-48-48-48H48zM64 240c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V240zm112-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H176c-8.8 0-16-7.2-16-16V240c0-8.8 7.2-16 16-16zM64 112c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112zM176 96h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H176c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16zM352 0c-17.7 0-32 14.3-32 32v480h64V368c0-26.5 21.5-48 48-48s48 21.5 48 48v144h64V32c0-17.7-14.3-32-32-32H352z"/></svg>',
     'webinar': '<svg width="1em" height="1em" viewBox="0 0 576 512" fill="currentColor" aria-hidden="true"><path d="M0 128C0 92.7 28.7 64 64 64H320c35.3 0 64 28.7 64 64V384c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128zM559.1 99.8c10.4 5.6 16.9 16.4 16.9 28.2V384c0 11.8-6.5 22.6-16.9 28.2s-23 5-32.9-1.6l-96-64L416 336V176l14.2-9.5 96-64c9.8-6.5 22.4-7.2 32.9-1.6z"/></svg>',
     'deadline': '<svg width="1em" height="1em" viewBox="0 0 512 512" fill="currentColor" aria-hidden="true"><path d="M256 0a256 256 0 1 1 0 512A256 256 0 1 1 256 0zM232 120V256c0 8 4 15.5 10.7 20l96 64c11 7.4 25.9 4.4 33.3-6.7s4.4-25.9-6.7-33.3L280 243.2V120c0-13.3-10.7-24-24-24s-24 10.7-24 24z"/></svg>',
+    'awards': '<svg width="1em" height="1em" viewBox="0 0 576 512" fill="currentColor" aria-hidden="true"><path d="M400 0H176c-26.5 0-48.1 21.8-47.1 48.2c.2 5.3 .4 10.6 .7 15.8H24C10.7 64 0 74.7 0 88c0 92.6 33.5 157 78.5 200.7c44.3 43.1 98.3 64.8 138.1 75.8c13.6 3.8 23.4 16.2 23.4 30.3V416H192c-17.7 0-32 14.3-32 32s14.3 32 32 32H384c17.7 0 32-14.3 32-32s-14.3-32-32-32H336V394.8c0-14.1 9.8-26.5 23.4-30.3c39.7-11 93.8-32.7 138.1-75.8C542.5 245 576 180.6 576 88c0-13.3-10.7-24-24-24H446.4c.3-5.2 .5-10.4 .7-15.8C448.1 21.8 426.5 0 400 0z"/></svg>',
+    'industry-day': '<svg width="1em" height="1em" viewBox="0 0 640 512" fill="currentColor" aria-hidden="true"><path d="M48 0C21.5 0 0 21.5 0 48V464c0 26.5 21.5 48 48 48h96V432c0-26.5 21.5-48 48-48s48 21.5 48 48v80h96V48c0-26.5-21.5-48-48-48H48zM64 240c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V240zm112-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H176c-8.8 0-16-7.2-16-16V240c0-8.8 7.2-16 16-16zM64 112c0-8.8 7.2-16 16-16h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112zM176 96h32c8.8 0 16 7.2 16 16v32c0 8.8-7.2 16-16 16H176c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16zM352 0c-17.7 0-32 14.3-32 32v480h64V368c0-26.5 21.5-48 48-48s48 21.5 48 48v144h64V32c0-17.7-14.3-32-32-32H352z"/></svg>',
   };
   const typeColors = {
     'conference': 'var(--mmt-cyan)',
     'webinar': 'var(--mmt-green)',
     'deadline': '#FBBF24',
+    'awards': '#FBBF24',
+    'industry-day': 'var(--mmt-green)',
   };
+
+  // Generate Google Calendar link
+  function calendarLink(e) {
+    const start = e.date.replace(/-/g, '');
+    const end = e.endDate ? e.endDate.replace(/-/g, '') : start;
+    const name = encodeURIComponent(e.name);
+    const loc = encodeURIComponent(e.location || '');
+    const desc = encodeURIComponent(e.description || '');
+    return `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${name}&dates=${start}/${end}&location=${loc}&details=${desc}`;
+  }
 
   // Group: upcoming vs past
   const upcoming = events.filter(e => new Date(e.date) >= now);
@@ -1282,7 +1296,8 @@ function generateEventsListHtml() {
                   <span class="text-xs whitespace-nowrap px-2 py-1 rounded capitalize" style="background:rgba(0,229,250,0.1); color:${color};">${escapeHtml(e.type)}</span>
                 </div>
                 <p class="text-xs mb-2" style="color:var(--mmt-white-dim);">${calendarSvg}${escapeHtml(dateStr)}${endStr}${e.location ? ` &middot; ${escapeHtml(e.location)}` : ''}</p>
-                <p class="text-sm leading-relaxed" style="color:var(--mmt-white-muted);">${escapeHtml(e.description)}</p>
+                <p class="text-sm leading-relaxed mb-2" style="color:var(--mmt-white-muted);">${escapeHtml(e.description)}</p>
+                <span class="text-xs font-medium no-underline" style="color:var(--mmt-cyan);" onclick="event.preventDefault();event.stopPropagation();window.open('${calendarLink(e)}','_blank');">Add to Calendar</span>
               </div>
             </div>
           </a>\n`;

--- a/events.html
+++ b/events.html
@@ -176,6 +176,12 @@
     </div>
   </section>
 
+  <section class="py-8 px-6">
+    <div class="max-w-3xl mx-auto text-center">
+      <p class="text-sm" style="color:var(--mmt-white-dim);">Know about an event we're missing? Email <a href="mailto:mary@missionmeetstech.com" class="no-underline" style="color:var(--mmt-cyan);">mary@missionmeetstech.com</a></p>
+    </div>
+  </section>
+
   </main>
 
   <!-- Footer -->

--- a/events.json
+++ b/events.json
@@ -13,7 +13,7 @@
     "date": "2026-04-15",
     "location": "Washington, DC",
     "url": "https://www.fedhealthit.com",
-    "type": "conference",
+    "type": "awards",
     "description": "Annual recognition of the top 100 leaders driving federal health IT transformation."
   },
   {


### PR DESCRIPTION
## Summary
- Add "Add to Calendar" Google Calendar link to each event card
- Support awards and industry-day event types with distinct badge colors
- Add "Know about an event we're missing?" footer CTA
- FedHealthIT 100 Awards now tagged as "awards" type

3 files (events.json, build.js, events.html). Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)