### PR TITLE
feat: events — registration links for upcoming events

### DIFF
--- a/build.js
+++ b/build.js
@@ -1297,7 +1297,11 @@ function generateEventsListHtml() {
                 </div>
                 <p class="text-xs mb-2" style="color:var(--mmt-white-dim);">${calendarSvg}${escapeHtml(dateStr)}${endStr}${e.location ? ` &middot; ${escapeHtml(e.location)}` : ''}</p>
                 <p class="text-sm leading-relaxed mb-2" style="color:var(--mmt-white-muted);">${escapeHtml(e.description)}</p>
-                <span class="text-xs font-medium no-underline" style="color:var(--mmt-cyan);" onclick="event.preventDefault();event.stopPropagation();window.open('${calendarLink(e)}','_blank');">Add to Calendar</span>
+                <span class="flex flex-wrap gap-3 items-center">
+                  <span class="text-xs font-medium no-underline" style="color:var(--mmt-cyan); cursor:pointer;" onclick="event.preventDefault();event.stopPropagation();window.open('${calendarLink(e)}','_blank');">Add to Calendar</span>
+                  ${e.registrationUrl ? `<span class="text-xs font-medium no-underline" style="color:var(--mmt-green, #00FF85); cursor:pointer;" onclick="event.preventDefault();event.stopPropagation();window.open('${escapeHtml(e.registrationUrl)}','_blank');">Register &rarr;</span>` : ''}
+                  ${e.registrationNote ? `<span class="text-xs" style="color:var(--mmt-white-dim);">${escapeHtml(e.registrationNote)}</span>` : ''}
+                </span>
               </div>
             </div>
           </a>\n`;

--- a/events.json
+++ b/events.json
@@ -13,6 +13,7 @@
     "date": "2026-04-15",
     "location": "Washington, DC",
     "url": "https://www.fedhealthit.com",
+    "registrationUrl": "https://www.fedhealthit.com",
     "type": "awards",
     "description": "Annual recognition of the top 100 leaders driving federal health IT transformation."
   },
@@ -21,6 +22,7 @@
     "date": "2026-05-20",
     "location": "Falls Church, VA",
     "url": "https://www.health.mil",
+    "registrationNote": "Check SAM.gov for registration details",
     "type": "conference",
     "description": "Defense Health Agency engagement with industry partners on upcoming acquisition priorities."
   },
@@ -29,6 +31,7 @@
     "date": "2026-05-21",
     "location": "Bethesda North Marriott Hotel & Conference Center, Rockville, MD",
     "url": "https://fedhealth.pscouncil.org/",
+    "registrationUrl": "https://fedhealth.pscouncil.org/",
     "type": "conference",
     "description": "Senior executives from industry and government discuss critical policy and acquisition priorities in civilian and military health, with speakers from HHS, VA, and DoD."
   },
@@ -38,6 +41,7 @@
     "endDate": "2026-06-04",
     "location": "Baltimore Convention Center, Baltimore, MD",
     "url": "https://events.afcea.org/afceacyber26/Public/enter.aspx",
+    "registrationUrl": "https://events.afcea.org/afceacyber26/Public/enter.aspx",
     "type": "conference",
     "description": "Cybersecurity conference with federal health IT security tracks covering HIPAA, zero trust, and health data protection."
   },
@@ -47,6 +51,7 @@
     "endDate": "2026-08-27",
     "location": "Kissimmee, FL",
     "url": "https://www.health.mil",
+    "registrationNote": "Registration typically opens May 2026",
     "type": "conference",
     "description": "Premier scientific meeting for military and federal health research, combat casualty care, and operational medicine."
   },
@@ -56,6 +61,7 @@
     "endDate": "2026-12-04",
     "location": "Washington, DC",
     "url": "https://www.amsus.org",
+    "registrationNote": "Registration typically opens summer 2026",
     "type": "conference",
     "description": "Society of Federal Health Professionals annual meeting covering military medicine, VA health, and public health."
   }


### PR DESCRIPTION
## Summary
- Add registrationUrl to FedHealthIT 100, PSC FedHealth, AFCEA TechNet
- Add registrationNote for DHA Industry Day, MHSRS, AMSUS (registration not yet open)
- Build.js renders green "Register →" link and info notes on event cards

2 files (events.json, build.js). Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)