### PR TITLE
sprint: stabilize subscriber surfaces + stage May 1 release

### DIFF
--- a/build.js
+++ b/build.js
@@ -108,7 +108,7 @@ function loadArticles() {
 
   // Skip files that start with `_` — those are templates / drafts.
   const files = fs.readdirSync(CONTENT_DIR).filter(f => f.endsWith('.md') && !f.startsWith('_'));
-  const articles = files.map(file => {
+  const articlesAll = files.map(file => {
     const raw = fs.readFileSync(path.join(CONTENT_DIR, file), 'utf8');
     const { data, content } = matter(raw);
     const html = marked(content);
@@ -127,6 +127,29 @@ function loadArticles() {
       canonicalUrl: `${SITE_URL}/newsletter/${data.slug || slugify(data.title)}/`,
     };
   });
+
+  // Future-date gating: hold articles with publish_date > today.
+  // The Netlify rebuild-trigger cron runs every 4 hours; once the
+  // article's publish date arrives (in UTC), the next build picks it
+  // up and it appears in /latest, /sitemap.xml, and the article page
+  // is generated. This is how Mary stages issues for "automatic
+  // release based on the schedule" without anyone having to merge a
+  // PR on publish day.
+  const now = Date.now();
+  const articles = articlesAll.filter((a) => {
+    if (!a.date) return true;
+    const t = new Date(a.date).getTime();
+    if (Number.isNaN(t)) return true;
+    if (t > now) {
+      console.log(`  ⏳ HOLDING (future-dated): ${a.file} (publish_date ${a.date})`);
+      return false;
+    }
+    return true;
+  });
+  const heldCount = articlesAll.length - articles.length;
+  if (heldCount > 0) {
+    console.log(`  Held ${heldCount} future-dated article(s); they will appear once publish_date arrives.`);
+  }
 
   // Sort by date descending (newest first)
   articles.sort((a, b) => new Date(b.date) - new Date(a.date));
@@ -2799,6 +2822,37 @@ function copyStaticFiles({ archive, feed, newsItems, contracts, contractArticleM
   // Dashboard sidebar injection for premium subpages
   // Wraps premium pages in the same dash-shell layout as premium/dashboard.html
   function injectDashShell(html, activePage) {
+    // 2026-04-28 double-sidebar fix: source pages premium/*.html ship
+    // with their own embedded dash-shell + dash-nav (a self-contained
+    // sidebar that pre-dates this canonical injection). When the
+    // injection then wrapped them in ANOTHER dash-shell, the page
+    // rendered TWO sidebars side-by-side.
+    //
+    // Strip the source's pre-existing dash-shell pieces so the
+    // canonical injected shell is the single source of truth across
+    // all premium pages.
+    if (/class\s*=\s*"dash-nav"/i.test(html)) {
+      html = html.replace(/<nav\s+class="dash-nav"[\s\S]*?<\/nav>/gi, '');
+    }
+    if (/class\s*=\s*"dash-shell"/i.test(html)) {
+      // Replace the source's opening <div class="dash-shell"> with a
+      // neutral <div> so its matching </div> still balances. This
+      // avoids any complex tag-counting and keeps the rest of the
+      // source markup intact.
+      html = html.replace(/<div\s+class="dash-shell"[^>]*>/gi, '<div data-dash-shell-stripped="true">');
+    }
+    if (/class\s*=\s*"dash-mobile-nav"/i.test(html)) {
+      html = html.replace(/<div\s+class="dash-mobile-nav"[\s\S]*?<\/div>/gi, '');
+    }
+    // Strip the source's standalone dash-header (the small "★ Premium
+    // Dashboard / email / Back to site / Sign out" strip). It
+    // duplicates info the injected shell now provides on hover.
+    if (/class\s*=\s*"dash-header"/i.test(html)) {
+      // The dash-header contains exactly one inner <div>, so the close
+      // pattern is `</div>\s*</div>` (inner close, then outer close).
+      html = html.replace(/<div\s+class="dash-header"[\s\S]*?<\/div>\s*<\/div>/gi, '');
+    }
+
     const dashCss = `
     .dash-shell { display:grid; grid-template-columns:220px 1fr; min-height:100dvh; }
     .dash-nav { background:var(--mmt-soft,#F3F4F6); border-right:1px solid var(--mmt-border,#D8E0E8); padding:24px 16px; }

--- a/capture-corner.html
+++ b/capture-corner.html
@@ -127,7 +127,7 @@
         <h1 class="cc-page-title">Capture Corner</h1>
         <p class="cc-page-subtitle">Weekly federal capture intelligence for defense and civilian contractors. Sourced signals, dated action windows, and the positioning logic behind each one.</p>
         <div style="display:flex; gap:12px; flex-wrap:wrap;">
-          <a href="/intel/capture-intelligence-this-issue/" class="cc-btn cc-btn-primary">Read this week's issue</a>
+          <a href="/capture-corner/latest" class="cc-btn cc-btn-primary">Read this week's issue</a>
           <a href="/pricing" class="cc-btn cc-btn-secondary">See premium plans</a>
         </div>
       </div>
@@ -174,7 +174,7 @@
         <h2>Read this week's issue</h2>
         <p>The current Capture Corner is live. Every signal below is verified, dated, and sourced.</p>
         <div style="display:flex; gap:12px; flex-wrap:wrap; justify-content:center;">
-          <a href="/intel/capture-intelligence-this-issue/" class="cc-btn cc-btn-primary">Open this week's issue</a>
+          <a href="/capture-corner/latest" class="cc-btn cc-btn-primary">Open this week's issue</a>
           <a href="/" class="cc-btn cc-btn-secondary">Back to home</a>
         </div>
       </div>

--- a/content/newsletter/2026-05-01-the-architecture-va-asks-for.md
+++ b/content/newsletter/2026-05-01-the-architecture-va-asks-for.md
@@ -1,0 +1,185 @@
+---
+title: "The Architecture VA Asks For Is Not the Architecture VA Buys"
+date: 2026-05-01
+slug: the-architecture-va-asks-for
+description: "On April 20, the VA Strategic Acquisition Center certified that only one source qualified to upgrade the National Teleradiology Program PACS. Three months earlier, five qualified sources had been delivering on a competing architecture. The procurement system that wrote one document and signed the other is the same system writing the EIS RFP right now."
+author: "Mary Womack"
+category: deep-dive
+visibility: public
+tags:
+  - "VA"
+  - "Enterprise Imaging"
+  - "EIS"
+  - "NTP"
+  - "Procurement"
+  - "GE HealthCare"
+  - "Intelerad"
+agencies:
+  - VA
+canonical_url: "https://missionmeetstech.com/newsletter/the-architecture-va-asks-for/"
+source: claude_newsletter_project
+capture_corner_teaser: "Three captures running in parallel. Request capabilities briefing with SAC-F Frederick. Track Radiology and Imaging FY2025 IDIQ task orders against the 13 EHRM deployment sites coming online in 2026 (Michigan Apr 11; Wave 2 Ohio/Kentucky June; Wave 3 Indiana Aug; Wave 4 Cleveland/Alaska Oct). Position for the technical wedge between current HL7 v2/DICOM and FHIR R4/USCDI mandate in the CCN Next Generation procurement."
+capture_corner:
+  - "Request a capabilities briefing with SAC-F Frederick this month for any firm pursuing EIS. Contracting office: Tara.Flores@va.gov, Katie.Hulse@va.gov, 202-306-4240. Submit a white paper that addresses the four points the NTP cancellation made unavoidable: data migration risk for the 17 billion image archive; operational continuity from VistA Imaging and CAMM 7 through the transition window; dual-EHR MPI architecture covering both SSN and EDIPI; long-term support stability for a contract that will run a decade."
+  - "Track Radiology and Imaging FY2025 IDIQ task orders. The IDIQ closed March 31, 2026; task orders are imminent. Each of the 13 EHRM deployment sites in 2026 will generate modality refresh and integration work. Michigan went live April 11. Wave 2 sites in Ohio and Kentucky deploy in June. Wave 3 sites in Indiana deploy in August. Wave 4 brings Cleveland and Alaska online in October. Engagement timelines for site-level capture are now."
+  - "CCN Next Generation technical wedge: the gap between the current incumbent's HL7 v2 and DICOM architecture and the FHIR R4 and USCDI mandate the RFP creates. Medical IDIQ ceiling $700B per House Veterans' Affairs Committee testimony, January 22, 2026. The TPAs that win will need imaging exchange capability embedded in network infrastructure. There is no incumbent at the modernized architecture scale."
+  - "EIS evaluation criterion (analytical): the proposal that wins has to be a single accountable prime that owns end-to-end integration delivery, with federally proven track record at the 100-petabyte scale, that architects open at the layers where openness matters: cloud control plane, AI orchestration framework, modality conformance interfaces, imaging exchange standards. Single-prime accountability for delivery risk; architecturally open at the interfaces EIS actually requires to be modular for the next decade."
+  - "OCI window check: Any firm with advisory or analytical roles in the current GENESIS program should be examining its OCI exposure before the EIS solicitation drops, not after. EIS RFI close to RFP release is when the third-structure teaming gets built. By the time the RFP drops, teaming structures are largely fixed and the only variable is execution."
+---
+
+*On April 20, the VA Strategic Acquisition Center certified that only one source qualified to upgrade the National Teleradiology Program PACS. Three months earlier, five qualified sources had been delivering on a competing architecture. The procurement system that wrote one document and signed the other is the same system writing the EIS RFP right now.*
+
+---
+
+Friends,
+
+On April 20, 2026, the VA Strategic Acquisition Center signed a sole-source contract with Intelerad Medical Systems for $11,270,971. The award cited Federal Acquisition Regulation 6.302-1, the procurement statute permitting limited-source competition when only one responsible source qualifies. The specific justification on the SAM.gov notice was OEM proprietary technology. The certification is a formal determination on the federal record. Period of performance: April 20, 2026 through October 20, 2028.
+
+Three months earlier, VHA had cancelled a multi-vendor contract in which five qualified vendors had spent two years delivering Phase 1 of a competing architecture for the same teleradiology program. Frontier Acquisitions held the prime. Mach7 provided the vendor-neutral archive and the eUnity zero-footprint diagnostic viewer. Nuance provided voice recognition. Blackford provided AI integration with access to over 100 best-of-breed AI applications. Microsoft Azure provided the cloud platform. Phase 1 deployed mammography reading and stroke triage. The architecture worked.
+
+On Mach7's Q2 FY26 earnings call, covered by Defense World on January 31, 2026, CEO Teri Thomas confirmed Mach7 was no longer part of the VHA teleradiology program. She called the outcome "disappointing."
+
+Five other vendors qualified to deliver this architecture three months ago. Today the procurement record formally states that only one source qualifies. Both statements are accurate. Both come from the same procurement system. The gap between them is the issue.
+
+The Enterprise Imaging System RFP, the largest federal imaging procurement in history, is in acquisition strategy development right now. The same procurement system is writing it. Every firm pursuing EIS is positioning into a procurement that will produce the same gap unless someone names it.
+
+---
+
+## The 90-day sequence on the federal record
+
+Three dated events. All on the public record. Together they show how the federal health IT procurement system actually behaves.
+
+January 2026. VHA issued a Partial Stop Work Order on the NTP NextGen PACS multi-vendor consortium. Phase 1 had completed mammography go-live and stroke triage capability. Phase 2, the architectural expansion across additional Veterans Integrated Service Networks, will not proceed. Signify Research's February 2026 imaging informatics market update confirmed: "abandonment of the project will see the VHA remain with its existing solution provided by Intelerad."
+
+March 18, 2026. GE HealthCare closed its $2.3 billion all-cash acquisition of Intelerad. Intelerad's NTP PACS incumbency dates to November 2013. The combined entity now controls the modality OEM relationship at every VA facility, the National Teleradiology Program PACS position that has run on IntelePACS for over twelve years, the cloud hosting position on VA Enterprise Cloud, and an AI portfolio including AIR Recon DL deployed on VA CT systems. The press release described "an end-to-end, cloud-first and AI-enabled enterprise imaging solution."
+
+April 20, 2026. The VA Strategic Acquisition Center awarded Intelerad the sole-source upgrade contract. Solicitation 36C10B26Q0213. Award number 36C10B26C0038. $11,270,971 firm-fixed-price. FAR 6.302-1 sole-source justification. Period of performance through October 20, 2028.
+
+The contract obligates VA to keep NTP on Intelerad through October 2028. The EIS RFP is anticipated to release late FY2026 or early FY2027. The award comes after that. NTP runs on Intelerad through the entire transition window. The acquisition shapes what comes after October 2028.
+
+VHA wrote one architecture in the EIS RFI. VHA executed the opposite architecture at NTP. Both decisions came from the same procurement office. They are the same decision, made twice.
+
+---
+
+## The architecture VA asks for
+
+VHA's RFI Amendment 0003 from December 2024 lays out what EIS is supposed to be. Hybrid cloud-based vendor-neutral archive. FedRAMP-certified cloud across all storage tiers. Dual master patient index bridging VistA's SSN-based identity and Oracle Health's EDIPI-based identity. Universal zero-footprint web viewer. Specialty-specific AI integration across radiology, cardiology, endoscopy, dental, pathology, nuclear medicine, ophthalmology, and wound care. Bidirectional VA/DoD and community care imaging exchange. DICOM conformance to Joint VA/DoD Rev 3.3.
+
+Twenty-five million annual exams. One hundred petabytes. Seventeen billion images.
+
+This is the open architecture, multi-specialty, multi-vendor, FedRAMP-cloud thesis the imaging informatics industry has been building toward for a decade. Best-of-breed at every layer. Open at the integration points. The architecture VA's own RFI describes wanting.
+
+The architecture VA cancelled at NTP three months ago.
+
+---
+
+## The architecture VA buys
+
+The actual procurement record looks different. The April 20 award notice says no other source qualifies. Behind that certification sits a pattern that repeats across VA enterprise IT.
+
+VistA modernization was supposed to happen in 2014. The IaaMS contract from 2021 funds VistA Imaging through 2028. The Cerner contract from 2018 was supposed to replace VistA on a 10-year timeline. Eight years and $13.84 billion of obligations in, 10 of 164 sites are live. The transition runs at a pace that keeps VistA fully operational at the other 154. The NTP NextGen architecture from 2023 was supposed to deploy across additional VISNs through 2028. It was cancelled before Phase 2 to keep the incumbent fully operational at all 125 facilities.
+
+Each procurement told a story about what the operational system would accept. The operational system absorbs architectural transition only at a pace that keeps the incumbent fully operational in parallel.
+
+Defense Health shows the same pattern. The $96 million Oura wearables sole-source collapsed after WHOOP filed two GAO protests, and DHA acknowledged it could not audit the data the architecture required. The Digital Front Door prototype awards from December 2024 to BDR, Bluestaq, Clearstep, and Ernst & Young will not move to production. Budget pressures killed it. Each one promised an architectural transition the operational system could not absorb.
+
+The architecture document and the operational document never meet.
+
+---
+
+## Take the strongest version of the case
+
+The procurement officers who certified the Intelerad sole-source were doing their job correctly. The work they certified is real work. The systems they are buying continuity for run 24/7 teleradiology coverage for 125 facilities across all 18 VISNs, between 1.0 and 1.5 million studies annually. Stroke triage. Mammography. Acute reads where minutes change outcomes. The operational tolerance for transition disruption at that scale is genuinely low.
+
+VA OIG report 25-01255-242, published December 4, 2025, documents the continuity requirements in the kind of detail that makes the procurement decision look defensible on its own terms. The August 13, 2024 memorandum from the Assistant Under Secretary for Health for Clinical Services on NTP support changes is in the public record. The reasons for keeping the system stable are not invented.
+
+The DOGE contract environment of early 2025 pushed the calculation toward conservatism. VA cancelled approximately $1.8 billion in contracts in early 2025. Among the contracts initially canceled were the annual technical inspection contracts for radiation-producing medical equipment, the inspections legally required under NRC and Agreement State regulations before VA staff can operate CT scanners, MRI machines, and dental X-ray units. The reversal came after VA employees and external contractors pushed back. CNBC's reporting captured the operational reality plainly: a hospital cannot lack a radiology department. NTP NextGen's Phase 2 was a deployment expansion in that environment. A procurement officer choosing operational continuity over architectural advancement in early 2026 is not making an unreasonable choice.
+
+That is the strongest version of the case for what VHA did. A serious defender of the decision would make exactly this argument.
+
+The case is real. The cumulative pattern is the issue.
+
+Applied consistently across federal health IT procurement, this defense produces a system that cannot accept the architecture it asks for. Every individual procurement decision is defensible on continuity grounds. The cumulative pattern is a procurement system that writes one document for the public record and signs another. The defense for any single instance does not defend the system the instances aggregate into.
+
+---
+
+## What this means for EIS
+
+EIS asks for what NTP NextGen asked for, at twenty-five times the scale. The 100 petabytes that EIS must absorb are largely the petabytes IaaMS holds today. The 17 billion images come from VistA Imaging and CAMM 7. The dual MPI bridges the same VistA SSN and Oracle Health EDIPI architectures the EHRM transition is still working through. The specialty AI integration spans eight clinical domains. The bidirectional exchange has to function across VA, DoD, and community care simultaneously.
+
+The market is positioning around EIS the way it positioned around NTP NextGen. Industry briefings describe teaming structures with a vendor-neutral archive partner, a viewer partner, an AI orchestration partner, a cloud partner, and a small-business partner. Best-of-breed at every layer. Open architecture. Multi-vendor.
+
+That structure just lost at NTP.
+
+The architecture lost on procurement system fit. Five vendors could not deliver parallel incumbent operation through Phase 2 deployment at NTP scale. Whatever scored that risk at NTP will score it again at EIS, at twenty-five times the magnitude and across a longer transition window. The combined GE HealthCare and Intelerad enters the EIS evaluation as the only firm that has just demonstrated to the federal record that it qualifies as a single responsible source for VA enterprise imaging at scale.
+
+Best in KLAS 2026 helps with technical positioning, not procurement system fit. Agfa HealthCare won three best-in-segment awards in 2026: XERO Viewer for Universal Viewer (third consecutive year, 92.1%), VNA (second consecutive year, 89.8%), and PACS small/under 300k studies (93.2%). The only non-GE-Intelerad vendor with simultaneous best-in-class for VNA, Universal Viewer, and PACS. Sectra has held the number one PACS customer satisfaction position in North America for thirteen consecutive years. Visage 7 is already deployed across multiple VISN 23 sites and is expanding on VAEC.
+
+The challenger pool has the technical credentials the EIS RFI describes wanting. What it does not have is a documented track record at federal scale that lets a procurement officer write the FAR justification for selecting it without exposing the file to protest. A capture team that arrives at EIS with a five-vendor wiring diagram and KLAS rankings is answering the question VHA already answered against the same architecture.
+
+A team that arrives at EIS with a coherent integration story, a defensible plan for migrating 100 petabytes off VistA Imaging and CAMM 7 without operational disruption, and an explicit position on how the proposal handles the program management risk that just produced the NTP cancellation is answering a different question. That is the question the EIS evaluation is going to be asked, whether or not the RFI says so.
+
+---
+
+## What the proposal that wins has to be
+
+Two failure patterns are now visible on the federal record. The pure best-of-breed multi-vendor wiring diagram lost at NTP because the procurement system that scored it could not accept the integration risk at clinical scale. The pure incumbent continuity proposal cannot win EIS because EIS, on the RFI's own terms, requires real architectural transition: dual MPI bridging, a 100-petabyte archive migration, FHIR R4 community care imaging exchange, and specialty AI integration across eight clinical domains. The first proposal is the one VHA just rejected at smaller scale. The second proposal is the one the EIS RFI itself rejects in writing.
+
+The proposal that wins EIS has to be a third structure. A single accountable prime that owns end-to-end integration delivery, with federally proven track record at the 100-petabyte scale, that architects open at the layers where openness matters: the cloud control plane, the AI orchestration framework, the modality conformance interfaces, the imaging exchange standards. Single-prime accountability for delivery risk. Architecturally open at the interfaces that EIS actually requires to be modular for the next decade.
+
+A FAR justification has to be writable for whichever proposal wins. The procurement officer who selects the EIS prime will need to defend that selection on the federal record the same way the NTP sole-source was defended on April 20. The proposal that lets the procurement officer write that justification cleanly is the proposal positioned to win. Justification means demonstrated past performance at federal data migration scale. It means production deployment of multi-EHR integration in operational settings. It means FedRAMP-authorized cloud architecture combined with KLAS-validated clinical merit at the layers VA cares about. The justification gets written from the procurement officer's perspective, not the proposer's.
+
+No firm in the current VA enterprise imaging capture market combines all of these. The combined GE HealthCare and Intelerad has procurement system fit, federal scale, and KLAS-validated technical credentials, but it approaches EIS from incumbent continuity. Incumbent continuity is the position the EIS RFI itself rejects in writing. The KLAS-validated challengers (Agfa, Sectra, Visage) hold the architectural credentials and the clinical satisfaction track records. They lack the federal delivery track record at 100-petabyte scale that lets a procurement officer write the FAR justification cleanly. The federal systems integrators (Peraton, GDIT, Accenture Federal Services) hold operational scale at VA. Peraton specifically holds the IaaMS contract and runs VistA Imaging storage at scale. IaaMS is a storage-and-bridging position. None of the SI primes have demonstrated end-to-end clinical imaging architectural depth across the eight specialty AI domains EIS requires.
+
+The acquisition strategy window between the EIS RFI close and the RFP release is when the third structure gets built. By the time the RFP drops, the teaming structures are largely fixed and the only variable is execution. Capture teams building the integration story now are positioning into the question the evaluation will actually ask. Everyone else is positioning into a question the procurement system has already answered.
+
+---
+
+## Three captures running in parallel
+
+For BD and capture teams pursuing EIS, request a capabilities briefing with SAC-F Frederick this month. The contracting office is at Tara.Flores@va.gov, Katie.Hulse@va.gov, 202-306-4240. Submit a white paper that addresses the four points the NTP cancellation made unavoidable. Data migration risk for the 17 billion image archive. Operational continuity from VistA Imaging and CAMM 7 through the transition window. Dual-EHR MPI architecture covering both SSN and EDIPI. Long-term support stability for a contract that will run a decade. The white paper that lands is the one that names the procurement system pattern directly and offers a credible plan for not repeating it.
+
+For firms positioned for the Radiology and Imaging FY2025 IDIQ that closed March 31, 2026, task orders are imminent. Each of the 13 EHRM deployment sites in 2026 will generate modality refresh and integration work. The Michigan sites went live April 11. Wave 2 sites in Ohio and Kentucky deploy in June. Wave 3 sites in Indiana deploy in August. Wave 4 brings Cleveland and Alaska online in October. Engagement timelines for site-level capture are now.
+
+For firms tracking the CIES recompete, the technical wedge is the gap between the current incumbent's HL7 v2 and DICOM architecture and the FHIR R4 and USCDI mandate the CCN Next Generation RFP creates. The CCN Next Gen medical IDIQ has a $700 billion ceiling per House Veterans' Affairs Committee testimony from January 22, 2026. The TPAs that win will need imaging exchange capability embedded in network infrastructure. There is no incumbent at the modernized architecture scale.
+
+---
+
+## The teleradiologist and the room in Frederick
+
+Somewhere in the National Teleradiology Program, a radiologist is reading a stroke CT at 2:47 a.m. The patient is in a small VA medical center with no overnight radiology coverage. The image has traveled from the modality through the local PACS, into the VistA Imaging Exchange, across to the central exchange in VA Enterprise Cloud, and onto her workstation. She returns the read in under twelve minutes. The neurology team at the originating site decides on tPA.
+
+She reads on Intelerad's IntelePACS, the platform NTP has run since November 2013. Phase 1 of the cancelled NextGen PACS upgrade improved her viewer, her worklist, and her AI triage layer for stroke and mammography. Those improvements are deployed. Phase 2 was the architectural step that would have rolled the next-generation environment further across the VA enterprise. Phase 2 is gone.
+
+The contract that runs her workstation is locked in until October 20, 2028. The procurement that determines what platform replaces it after that date is being shaped right now, in an acquisition strategy room in Frederick, Maryland, by the same contracting office that just signed the FAR 6.302-1 certification. The room has the EIS RFI on one screen. The room has the OIG NTP review on another. The room knows what it just did at NTP. The room is being asked to shape the acquisition strategy for a procurement that, by the same logic the room just applied at NTP, cannot select the architecture the requirements describe.
+
+The reads continue.
+
+Whether EIS produces what its RFI describes depends on someone in that room naming the gap. The window closes when the RFP drops.
+
+Let's roll.
+
+— Mary
+
+Mission Meets Tech
+
+*The views expressed in this newsletter are my own and do not represent the official position of any organization. This content is for informational purposes only.*
+
+---
+
+## MMT Premium
+
+Today's free issue covers the analytical frame. Premium subscribers received the May Capture Intelligence Sheet this morning: the full procurement map, contracting officer contacts, action windows, and capture priorities across twelve signals in VA enterprise imaging.
+
+**Founding Member rate: $199/year**, locked permanently for the first 100 subscribers.
+**Standard rate:** $249/year or $29/month.
+
+Premium adds 48-hour early access to deep-dive analysis, monthly Capture Intelligence Sheets with sourced action windows, direct Q&A access (reply to any premium issue), and tool discounts: ProposalPulse $14.99 per assessment, MarketPulse $35 per brief.
+
+**Subscribe at missionmeetstech.com/pricing.**
+
+---
+
+## Sources
+
+Sources verified as of April 27, 2026. NTP NextGen PACS cancellation confirmed by Mach7 Technologies Q2 FY26 earnings call coverage in Defense World, January 31, 2026, in which CEO Teri Thomas confirmed Mach7 was no longer part of the VHA teleradiology program. Thomas called the outcome "disappointing." Cancellation corroborated by Signify Research Imaging Informatics Market Update, February 2026, which confirmed the project's "abandonment" and that "the VHA will remain with its existing solution provided by Intelerad." Sole-source upgrade contract 36C10B26C0038 awarded to Intelerad Medical Systems, Inc. (UEI D7K7H9E4MZV9) on April 20, 2026 under solicitation 36C10B26Q0213 confirmed via SAM.gov award notice; total value $11,270,971; firm-fixed-price; FAR 6.302-1 sole-source justification (only one responsible source, OEM proprietary); period of performance April 20, 2026 through October 20, 2028; awarding office VA Strategic Acquisition Center. Original NTP NextGen PACS consortium award structure (Frontier Acquisitions prime; Mach7 VNA and eUnity Diagnostic Viewer; Nuance voice recognition; Blackford AI; Microsoft Azure cloud) sourced from PRNewswire, September 6, 2023. Intelerad NTP PACS incumbency since November 2013 sourced from BusinessWire, November 12, 2013. GE HealthCare completion of $2.3 billion Intelerad acquisition on March 18, 2026, base purchase price, $270 million first-year revenue estimate with approximately 90% recurring, sourced from GE HealthCare press release distributed via BusinessWire and Yahoo Finance March 18, 2026; corroborated by Radiology Business, MassDevice, MPO, AuntMinnie, and Healthcare IT News (March 18-19, 2026). EIS scope figures (100 petabytes, 17 billion images, 25 million annual exams, dual MPI requirement) sourced directly from VHA RFI 36C10X25Q0015 Amendment 0003, December 2024. NTP scale (125 facilities across all 18 VISNs, 24/7 service) and August 13, 2024 NTP support reduction memorandum confirmed in VA OIG 25-01255-242, "Review of Veterans Health Administration's National Teleradiology Program," December 4, 2025. EHRM lifecycle facts (Cerner contract 2018, $13.84 billion obligations through Q2 FY2025, 10 of 164 sites live as of April 2026) sourced from VA FY2027 Congressional Budget Justification, GAO-26-108812, and prior MMT analysis. Peraton IaaMS contract value $497 million over 7 years awarded August 2021, scope of up to 300 VA sites and 28+ petabytes, sourced from VA OIT and federal procurement records. Oura wearables $96 million sole-source collapse after WHOOP GAO protests sourced from prior MMT analysis (MHS Triad coverage); Digital Front Door prototype award structure (BDR, Bluestaq, Clearstep, Ernst & Young; December 2024) and termination sourced from same. DOGE contract environment context (approximately $1.8 billion in VA contracts cancelled and partially reversed in early 2025, including radiation-producing equipment inspection contracts) sourced from CNBC and ABC News reporting February-March 2025. KLAS 2026 awards (Agfa best-in-class for XERO Viewer 92.1%, VNA 89.8%, PACS small 93.2%; Sectra #1 customer satisfaction 13 consecutive years; Visage active VAEC deployment in VISN 23) sourced from KLAS Research 2026 Best in KLAS reports. CCN Next Generation $700 billion medical IDIQ ceiling sourced from House Veterans' Affairs Committee hearing testimony, January 22, 2026.

--- a/data/may-1-release/contracts-tracker-update.md
+++ b/data/may-1-release/contracts-tracker-update.md
@@ -1,0 +1,245 @@
+# MMT Contracts Tracker: May 2026 Update
+
+**For:** missionmeetstech.com contracts page
+**Coverage:** VA Enterprise Imaging procurement activity
+**Last updated:** May 1, 2026
+**Format:** Public reference content; deeper analysis available to MMT Premium subscribers
+
+---
+
+## Section heading copy
+
+**Recommended heading for the tracker page section:**
+
+> ## VA Enterprise Imaging
+> The largest concentration of federal health IT procurement activity in active development right now. Twelve tracked signals, updated as the procurement record changes.
+
+---
+
+## Tracker entries (12 contracts/programs)
+
+Each entry below is structured for direct paste into a tracker page. Format includes solicitation number, status, value band, contracting officer where public, and a one-sentence "why it matters" line. Premium analysis sits behind the subscriber gate.
+
+---
+
+### 1. National Enterprise Imaging System (EIS)
+
+**Solicitation:** 36C10X25Q0015
+**Issuing Office:** VA SAC-Frederick
+**Status:** RFI closed December 20, 2024; acquisition strategy under development
+**Anticipated RFP:** Late FY2026 to early FY2027
+**Estimated Value:** Multi-billion (no announced ceiling)
+**NAICS:** 541511
+
+**Why it matters:** The marquee VA imaging procurement covers 25 million annual exams, 100 petabyte archive migration, and 17 billion images. Will define federal imaging architecture for the next decade.
+
+**Premium subscribers receive:** Full capture priorities, contracting officer engagement strategy, four-point white paper framework, and competitive teaming structure. May 1, 2026 Capture Intelligence Sheet.
+
+---
+
+### 2. Radiology and Imaging FY2025 IDIQ (Joint VA/DoD)
+
+**Solicitation:** 36H79725R0003
+**Issuing Office:** VA National Acquisition Center + DLA Troop Support
+**Status:** Solicitation closed March 31, 2026; awards imminent
+**Estimated Value:** $6.5 billion ceiling over 10 years
+**Contract Type:** Multiple-award IDIQ
+**NAICS / PSC:** 334517 / 6525
+
+**Why it matters:** The modality equipment vehicle covering imaging hardware, software, maintenance, and training across VA and DoD. Each EHRM go-live drives task order activity here.
+
+**Premium subscribers receive:** Site-by-site task order pipeline through October 2026, teaming guidance for non-awardees.
+
+---
+
+### 3. CIES Next Generation (Bi-Directional Image and Report Exchange)
+
+**Solicitation:** 36C10B26Q0076
+**Issuing Office:** VA Strategic Acquisition Center
+**Status:** RFI closed December 18, 2025; formal solicitation anticipated FY2026 to FY2027
+**Estimated Value:** $100 million+ (estimate)
+**Incumbent:** Medicom Technologies (17 of 18 VISNs)
+
+**Why it matters:** The CCN Next Generation RFP requires FHIR R4 / USCDI interoperability that the current CIES architecture does not natively deliver. The recompete will turn on architectural modernization.
+
+**Premium subscribers receive:** Counter-incumbent positioning analysis, technical wedge breakdown.
+
+---
+
+### 4. VHA Enterprise Mammography Tracking and Reporting System (MTRS)
+
+**Solicitation:** 36C10B26Q0339
+**Issuing Office:** Technology Acquisition Center, Eatontown, NJ
+**Status:** Sources Sought closed April 27, 2026; RFP pending
+**Estimated Value:** $5 million to $20 million over 5 years
+**Contract Type:** Single award (1 base + 4 options)
+
+**Why it matters:** Enterprise mammography compliance system for 88 VA mammography programs across 56 VAMC and Healthcare Systems. Dual EHR integration is the technical filter.
+
+**Premium subscribers receive:** Dual EHR integration scoring, competitive positioning analysis.
+
+---
+
+### 5. HINGE Radiation Oncology Platform (Health Information Gateway and Exchange)
+
+**Program:** VA National Radiation Oncology Program (NROP)
+**Status:** Sources Sought issued December 2025; RFP pending
+**Estimated Value:** $5 million to $15 million (estimate)
+
+**Why it matters:** Radiation oncology DICOM and FHIR data abstraction platform. Highly specialized, limited competition.
+
+**Premium subscribers receive:** Niche specialist positioning analysis.
+
+---
+
+### 6. VistA Imaging Sustainment (T4NG2 Re-Compete)
+
+**Current Contract:** 36C10B23N10240027
+**Issuing Office:** Technology Acquisition Center, Eatontown, NJ
+**Status:** T4NG expires June 30, 2026; T4NG2 task order recompete
+**Set-Aside:** SDVOSB
+**Incumbent:** Clear Vantage Point Solutions, LLC
+**Current Value:** $24.2 million / 5 years
+
+**Why it matters:** Closed competitive field for SDVOSB primes with VistA Imaging operational experience.
+
+**Premium subscribers receive:** SDVOSB JV positioning guidance.
+
+---
+
+### 7. IaaMS Re-Compete (Peraton)
+
+**Current Contract:** Fixed-price $497 million / 7 years (awarded August 2021)
+**Status:** Anticipated re-compete approximately FY2028
+**Incumbent:** Peraton (Chantilly, VA)
+**Scope:** 300 VA sites; 28+ petabytes; VAEC integrated
+
+**Why it matters:** The re-compete intersects with EIS. Whether IaaMS becomes a storage utility layer beneath the EIS VNA, or is folded into the EIS contract, remains an open Government decision.
+
+**Premium subscribers receive:** EIS-IaaMS unified narrative analysis.
+
+---
+
+### 8. EHRM Site-by-Site Imaging Integration
+
+**Status:** Active task-order pipeline through early 2030s
+**Scope per site:** CAMM appliance, Skyvue viewer, CCIA, HL7 reconfiguration, PACS re-validation, VIX update, DICOM conformance retesting, user training
+
+**Live sites as of April 27, 2026:** 10 total
+- Five original sites (Spokane, Walla Walla, Roseburg, White City/Southern Oregon, Columbus/Central Ohio): live 2020-2022
+- North Chicago/Lovell Federal (joint VA/DoD): live March 2024
+- Ann Arbor, Battle Creek, Detroit, Saginaw Michigan: live April 11, 2026
+
+**2026 Wave 2 (June):** Chillicothe OH, Cincinnati OH, Cincinnati-Fort Thomas KY, Dayton OH (4 sites)
+**2026 Wave 3 (August):** Fort Wayne IN, Marion IN, Indianapolis Roudebush IN (3 sites)
+**2026 Wave 4 (October):** Louis Stokes Cleveland OH, Alaska VA Healthcare System (2 sites)
+
+**Total 2026 deployments:** 13 sites
+**Remaining after 2026:** ~145 sites (164 total VAMCs minus 19 live by end of 2026)
+
+**Why it matters:** Repeatable per-site service package. Predictable scope. Multi-year demand through early 2030s; VA targets 26 additional sites in 2027 and 28 more in 2028 per FY2027 Budget in Brief.
+
+**Premium subscribers receive:** Engagement strategy by site, vehicle access guidance.
+
+---
+
+### 9. CCN Next Generation Imaging Exchange Implications
+
+**Solicitation:** 36C10G26R0003 issued December 2025; Amendment 002 posted April 25, 2026
+**Structure:** Two regions: East (29 states + DC, VI, PR) and West (21 states + Pacific territories)
+**Value:** $700 billion medical IDIQ ceiling per House Veterans' Affairs Committee testimony, January 22, 2026
+**Combined program ceiling:** Approaches $1 trillion across medical, dental, and ancillary vehicles
+
+**Why it matters:** TPAs that win must embed imaging exchange capability in network infrastructure. FHIR R4 / USCDI mandate creates subcontracting opportunity for firms with the modernized architecture.
+
+**Premium subscribers receive:** TPA positioning analysis, subcontracting strategy.
+
+---
+
+### 10. NTP PACS Continuity (Intelerad / GE HealthCare)
+
+**Solicitation:** 36C10B26Q0213
+**Award Contract ID:** 36C10B26C0038
+**Awardee:** Intelerad Medical Systems, Inc. (UEI D7K7H9E4MZV9)
+**Status:** Awarded April 20, 2026; sole-source firm-fixed-price; FAR 6.302-1 (only one responsible source)
+**Value:** $11,270,971
+**Period of Performance:** April 20, 2026 through October 20, 2028
+**Issuing Office:** VA Strategic Acquisition Center
+**Platform:** IntelePACS v5.7 on VAEC/AWS
+**Scope:** 125 VA facilities, all 18 VISNs, 24/7 teleradiology
+**System Owner:** Jennifer Gersten (VHA 11DIAG)
+
+**Why it matters:** GE HealthCare's $2.3 billion acquisition of Intelerad closed March 18, 2026. Five weeks later, VA awarded Intelerad a sole-source upgrade contract running through October 2028, past the expected EIS award window. The combined entity controls modality OEM, NTP PACS, VAEC hosting, and AI portfolio across VA. Material implication for EIS competitive positioning.
+
+**Premium subscribers receive:** Full sequence analysis in the Friday May 1 Capture Intelligence Sheet and the same-day public newsletter.
+
+---
+
+### 11. Dragon Medical One / Nuance SaaS
+
+**Award ID:** 36C10B25F0110
+**Vehicle:** NASA SEWP V (NNG15SC27B) via Carahsoft
+**Value:** $49,335,481.52
+**Period:** June 1, 2025 to May 31, 2028
+**Authorization:** FedRAMP Moderate
+
+**Why it matters:** Entrenched enterprise speech and reporting position through May 2028. PowerScribe One is the AI-powered radiology reporting platform.
+
+**Premium subscribers receive:** Recompete cycle pressure analysis.
+
+---
+
+### 12. VA AI Infrastructure (FY2027)
+
+**Status:** FY2027 Congressional Budget Justification request
+**Value:** $47.8 million for Decision Intelligence and Automation (10.9% increase over FY2026 enacted)
+**Driver:** AI Infrastructure solution for piloting and scaling clinical AI tools
+
+**Why it matters:** VA's 2025 AI Use Case Inventory documents 367 use cases department-wide, 253 in VHA. Standardized inference layer is the next major task-order opportunity.
+
+**Premium subscribers receive:** AI infrastructure capture priorities.
+
+---
+
+## Bottom-of-page CTA copy
+
+**Recommended copy at the bottom of the tracker page:**
+
+> ## Need the deeper layer?
+>
+> The tracker above shows what is in motion. MMT Premium subscribers receive the May 2026 Capture Intelligence Sheet: the full procurement map, contracting officer contacts, action windows, and capture priorities across all twelve signals. Plus 48-hour early access to deep-dive analysis, direct Q&A access, and tool discounts.
+>
+> **Founding Member rate: $199/year**, locked permanently for the first 100 subscribers.
+> **Standard rate:** $249/year or $29/month.
+>
+> [Subscribe at missionmeetstech.com/pricing →](https://missionmeetstech.com/pricing)
+
+---
+
+## Implementation notes
+
+For paste into existing tracker page or new dedicated page:
+
+- Each entry is self-contained; can be reordered without breaking dependencies
+- Solicitation numbers should ideally hyperlink to SAM.gov where the entry is public
+- Entry 8 (EHRM) and Entry 10 (NTP) reference live operational status; recommend timestamping last updated
+- Entry 9 (CCN Next Gen) cites $700B medical IDIQ ceiling; ensure consistency with any existing site copy on CCN Next Gen
+- Heading hierarchy: page-level H1 (e.g., "Contracts I'm Tracking"), section H2 ("VA Enterprise Imaging"), entry H3 (each contract title)
+
+For a JSON-driven tracker (similar to newsletters.json), the entries map to:
+
+```json
+{
+  "title": "National Enterprise Imaging System (EIS)",
+  "solicitation": "36C10X25Q0015",
+  "agency": "VA",
+  "status": "RFI closed; acquisition strategy",
+  "anticipated_release": "FY2026-FY2027",
+  "value_band": "Multi-billion",
+  "naics": "541511",
+  "why_it_matters": "Marquee VA imaging procurement...",
+  "premium_link": "/premium/may-2026-capture-sheet"
+}
+```
+
+Twelve entries total. Recommend deploying as a new `/contracts` page (or section within `/resources`) rather than overloading the home page.

--- a/data/may-1-release/premium-capture-sheet.md
+++ b/data/may-1-release/premium-capture-sheet.md
@@ -1,0 +1,334 @@
+# Capture Intelligence Sheet: VA Enterprise Imaging
+## Procurement Map, Action Windows, and Capture Priorities
+
+**Issue Date:** Friday, May 1, 2026
+**Publication:** Mission Meets Tech Premium
+**Coverage Period:** Active through Q3 FY2026
+
+---
+
+Friends,
+
+This is the May Capture Intelligence Sheet. Coverage focuses on VA enterprise imaging, the largest concentration of federal health IT procurement activity in active development right now. Twelve sourced signals, every one with a confidence label and an action window.
+
+Free readers see the analytical frame in the public newsletter on LinkedIn the same day. Premium subscribers receive the procurement map below: contract numbers, contracting officers, value bands, action timing, and what to do this week.
+
+---
+
+## What changed in the last 90 days
+
+Three movements reshape VA imaging capture in the same fiscal quarter.
+
+VHA cancelled the NTP NextGen PACS multi-vendor consortium in January 2026 and stayed with the Intelerad incumbent. GE HealthCare closed its $2.3 billion acquisition of Intelerad on March 18, 2026, consolidating the modality OEM, the cancelled-program incumbent, and the VAEC cloud hosting position into a single combined entity. VA deployed Oracle Health Millennium at four Michigan sites on April 11, 2026, restarting EHRM after a three-year operational pause and triggering site-by-site imaging integration demand.
+
+The marquee procurement, the National Enterprise Imaging System (EIS), is in acquisition strategy development between RFI close and RFP release. This is the window when requirements get shaped.
+
+---
+
+## Twelve Signals, With Action Windows
+
+### Signal 1: National Enterprise Imaging System (EIS)
+
+**Solicitation:** 36C10X25Q0015
+**Issuing Office:** VA Strategic Acquisition Center - Frederick (SAC-F)
+**Confidence:** Verified. RFI published; scope figures sourced directly from RFI Amendment 0003 (December 2024)
+**Stage:** RFI closed December 20, 2024; acquisition strategy under development
+**Anticipated RFP:** Late FY2026 or early FY2027
+**Estimated Value:** Multi-billion (no announced ceiling)
+
+**Verified scope per RFI Amendment 0003:** 25+ million annual exams, ~100 petabyte archive migration covering ~17 billion images from VistA Imaging and CAMM 7, hybrid cloud-based VNA with FedRAMP-certified cloud, dual MPI bridging VistA SSN and Oracle Health EDIPI, universal zero-footprint web viewer, specialty AI across radiology, cardiology, endoscopy, dental, pathology, nuclear medicine, ophthalmology, and wound care, bidirectional VA/DoD and community care imaging exchange, DICOM conformance to Joint VA/DoD Rev 3.3.
+
+**Action window (now through RFP drop):**
+- Request capabilities briefing with SAC-F Frederick (Tara.Flores@va.gov; Katie.Hulse@va.gov; 202-306-4240)
+- Submit white paper addressing four points: data migration risk mitigation for the 100 PB / 17 billion image archive, operational continuity from existing VistA Imaging and CAMM 7, dual-EHR MPI architecture, and long-term support stability
+- Build teaming structure: T4NG2 prime + FedRAMP cloud partner + VNA technology anchor + AI integration capability + SDVOSB or SDVOSB JV
+
+**What the NTP NextGen cancellation tells you about EIS evaluation:** Integration risk and program management continuity will be weighted heavily. Best-of-breed teaming without a coherent integration story is the pattern VHA just declined to continue.
+
+---
+
+### Signal 2: Radiology and Imaging FY2025 IDIQ (Joint VA/DoD)
+
+**Solicitation:** 36H79725R0003
+**Joint Program:** VA National Acquisition Center + Defense Logistics Agency Troop Support
+**Confidence:** Verified. Solicitation closed March 31, 2026
+**Stage:** Awards and first task orders imminent
+**Estimated Value:** $6.5 billion ceiling over 10 years
+**Contract Type:** Multiple-award IDIQ
+**NAICS / PSC:** 334517 / 6525
+**Contracting Officer:** LaTonya Whiteside (latonya.whiteside@va.gov)
+
+**Action window (Q3 FY2026):** This vehicle will issue task orders against the 13 EHRM deployment sites in 2026 (Michigan live April 11; Wave 2 Ohio and Kentucky June; Wave 3 Indiana August; Wave 4 Cleveland OH and Alaska October). Each site generates modality refresh and integration task order demand. Firms on the IDIQ activate for site-level capture now. Firms not on the IDIQ identify awardees once posted and pursue teaming agreements before task orders flow.
+
+---
+
+### Signal 3: CIES Next Generation (Bi-Directional Image and Report Exchange)
+
+**Solicitation:** 36C10B26Q0076
+**Issuing Office:** VA Strategic Acquisition Center
+**Confidence:** Verified. RFI closed December 18, 2025
+**Stage:** Anticipated formal solicitation FY2026 to FY2027
+**Incumbent:** Medicom Technologies (17 of 18 VA VISNs)
+**Contracting Officer:** Laura Startek (Laura.Startek@va.gov)
+
+**Current architecture:** HL7 v2 and DICOM, VAEC-hosted, integrating with VistA Imaging, PACS, and Enterprise Precision Scanning and Indexing. Volume: over 5 million annual studies.
+
+**Why the recompete looks different than the incumbent:** The CCN Next Generation RFP (36C10G26R0003), issued December 2025 with Amendment 002 posted April 25, 2026, explicitly requires EHR interoperability with Oracle Health and direct medical record exchange between community providers and VA. That mandate forces FHIR R4 and USCDI-compliant exchange, which the current Medicom architecture does not natively deliver at scale.
+
+**Action window (now):** Build FHIR R4 / USCDI capability stack. Engage Laura Startek at SAC. Position for the formal solicitation by surfacing the technical gap between current incumbent architecture and the CCN Next Gen interoperability requirement. The incumbent has near-universal VISN penetration; the recompete will turn on architectural modernization, not relationship continuity.
+
+---
+
+### Signal 4: VHA Enterprise Mammography Tracking and Reporting System (MTRS)
+
+**Solicitation:** 36C10B26Q0339
+**Issuing Office:** Technology Acquisition Center, Eatontown, NJ
+**Confidence:** Verified. Sources Sought closed April 27, 2026
+**Stage:** RFP pending
+**Estimated Value:** $5 million to $20 million over 5 years (1 base + 4 options)
+**Contracting Officer:** Terricia Lloyd (Terricia.Lloyd@va.gov; 512-981-4453)
+
+**Scope:** Enterprise mammography tracking, reporting, and compliance for 88 in-house VA mammography programs across 56 VAMC and Healthcare Systems. Integration required with VistA, Oracle Health Millennium, and existing PACS.
+
+**Action window (now through RFP drop):** Low competition, high specificity. The dual EHR integration requirement is the technical filter. Firms with documented HL7 v2 plus FHIR R4 mammography reporting integration experience pass. Firms without it do not. Follow SAM.gov for RFP release.
+
+---
+
+### Signal 5: HINGE Radiation Oncology Platform (Health Information Gateway and Exchange)
+
+**Program:** VA National Radiation Oncology Program (NROP)
+**Confidence:** Verified. Sources Sought issued December 2025
+**Stage:** RFP pending
+**Estimated Value:** $5 million to $15 million (estimate)
+
+**Scope:** Sustainment and enhancement of HINGE, a DICOM and FHIR data abstraction and aggregation platform for radiation oncology quality surveillance. Interfaces with CPRS/VistA, treatment delivery systems via DICOM, treatment planning systems, and FHIR.
+
+**Action window (now):** Highly specialized vertical. Radiation oncology DICOM expertise plus FHIR aggregation experience is the qualifier. Limited competition.
+
+---
+
+### Signal 6: VistA Imaging Sustainment Re-Compete
+
+**Current Contract:** 36C10B23N10240027
+**Confidence:** Verified. Current contract value $24.2 million over 5 years
+**Stage:** T4NG expires June 30, 2026; re-compete as T4NG2 task order
+**Set-Aside:** SDVOSB
+**Incumbent:** Clear Vantage Point Solutions, LLC (SDVOSB JV; T4NG2 awardee)
+**Issuing Office:** Technology Acquisition Center, Eatontown, NJ
+
+**Action window (Q3 FY2026):** SDVOSB set-aside means a closed competitive field. Firms with SDVOSB status and VistA Imaging operational experience are the eligible pool. Position immediately for T4NG2 task order release.
+
+---
+
+### Signal 7: IaaMS (Peraton) Future Re-Compete
+
+**Current Contract:** Fixed-price, $497 million, 7 years, awarded August 2021
+**Confidence:** Verified. Primary contract value sourced from VA OIT and federal procurement records
+**Incumbent:** Peraton (Chantilly, VA)
+**Stage:** Anticipated re-compete approximately FY2028
+**Scope:** VistA Imaging storage at up to 300 VA sites; 28+ petabytes active; integrates on-premises and VAEC cloud
+
+**Why this matters more than the timing suggests:** The IaaMS re-compete intersects with EIS. The Government must decide whether to extend IaaMS as a storage utility layer beneath a new EIS VNA or subsume IaaMS functions into the EIS contract. That sequencing decision has not been made publicly. Firms that build an EIS-IaaMS transition narrative now have a differentiated story when the EIS RFP drops.
+
+**Action window (now through FY2027):** Position for both EIS and IaaMS as a unified narrative. Required credentials: VAEC and AWS storage architecture, large-scale federal data migration, multi-site deployment track record at the 300-site scale.
+
+---
+
+### Signal 8: EHRM Site-by-Site Imaging Integration
+
+**Stage:** Active task-order pipeline through early 2030s
+**Confidence:** Verified. Deployment schedule confirmed through VA EHRM published cadence
+**Live Sites as of April 27, 2026:** 10 (5 original West/Midwest, North Chicago/Lovell joint VA-DoD, plus 4 Michigan sites live April 11, 2026)
+**2026 Wave 2 (June):** Chillicothe OH, Cincinnati OH, Cincinnati-Fort Thomas KY, Dayton OH (4 sites)
+**2026 Wave 3 (August):** Fort Wayne IN, Marion IN, Indianapolis Roudebush IN (3 sites)
+**2026 Wave 4 (October):** Louis Stokes Cleveland OH, Alaska VA Healthcare System (2 sites)
+**Total 2026 deployments:** 13 sites
+**Remaining:** ~145 sites (164 total VAMCs minus 19 live by end of 2026 per VA FY2027 Budget in Brief); VA targets 26 additional sites in 2027 and 28 more in 2028
+
+**Repeatable per-site service package:**
+- CAMM Appliance installation and configuration
+- Skyvue Diagnostic Image Viewer deployment
+- CCIA (Cerner CVIX Integration Adaptor) installation
+- HL7 interface reconfiguration from VistA v2 to Oracle Health v2/FHIR R4
+- PACS HL7 interface re-validation
+- VIX service configuration update
+- DICOM conformance re-testing for connected modalities
+- User training for radiologists, technologists, and PACS administrators
+
+**Action window (site-by-site):** Engage Michigan site program managers now. Wave 2 sites (June) need integration kick-off in May. Wave 3 sites (August) need kick-off in July. Wave 4 sites (October) need kick-off in August. Vehicle: T4NG2 or Oracle Health partner ecosystem. Revenue model is task order per deployment wave with predictable scope.
+
+---
+
+### Signal 9: CCN Next Generation Imaging Exchange Requirement
+
+**RFP Released:** December 2025 (36C10G26R0003); Amendment 002 posted April 25, 2026
+**Confidence:** Verified. RFP and program structure confirmed via House Veterans' Affairs Committee testimony, January 22, 2026
+**Structure:** Two regions: CCN Next Gen East (29 states + DC, VI, PR) and CCN Next Gen West (21 states + Pacific territories)
+**Value:** $700 billion medical IDIQ ceiling for the medical vehicle (36C10G26R0003); combined service categories including dental and ancillary vehicles approach $1 trillion combined ceiling
+**Current Contracts Expiring:** TriWest (2 regions) and Optum Serve (3 regions) contracts expire 2026
+
+**The imaging implication:** The RFP requires direct medical record sharing between community providers and VA, plus interoperability with Oracle Health and TRICARE. VA is investing $300 million to modernize EHR system infrastructure specifically for CCN Next Gen interoperability. For imaging, this means community radiology imaging exchange must use FHIR R4 and USCDI-compliant exchange. This is more sophisticated than the current HL7 v2 / DICOM CIES architecture. The TPAs selected for CCN Next Gen will need imaging exchange capability embedded in network infrastructure, creating subcontracting opportunity.
+
+**Action window (through FY2026):** Subcontracting positioning with the eventual CCN Next Gen TPAs. The medical IDIQ ceiling is the headline; the imaging exchange subcomponent is a structurally mandated technical requirement with no incumbent at scale.
+
+---
+
+### Signal 10: NTP PACS Continuity (Intelerad / GE HealthCare)
+
+**Confidence:** Verified to primary source. Sole-source contract 36C10B26C0038 awarded to Intelerad Medical Systems, Inc. (UEI D7K7H9E4MZV9) on April 20, 2026 under solicitation 36C10B26Q0213, total value $11,270,971, firm-fixed-price, FAR 6.302-1 sole-source justification (only one responsible source, OEM proprietary), period of performance April 20, 2026 through October 20, 2028. Sourced from SAM.gov award notice. Intelerad's NTP PACS incumbency since November 2013 sourced from BusinessWire, November 12, 2013. NextGen PACS cancellation confirmed by Mach7 Q2 FY26 earnings call (January 31, 2026, Defense World) and Signify Research (February 2026). GE/Intelerad acquisition closed March 18, 2026 per GE HealthCare press release on BusinessWire.
+**Platform:** IntelePACS v5.7, hosted on VA Enterprise Cloud (VAEC/AWS)
+**Scope:** 125 VA facilities across all 18 VISNs, 24/7 teleradiology reads
+**System Owner:** Jennifer Gersten (Jennifer.Gersten@va.gov; 319-430-3592), VHA 11DIAG National Radiology Program
+**ISSO:** Erick Davis (Erick.Davis@va.gov; 512-326-6178)
+**Contracting officials on award:** Created by sean.mcavoy1@va.gov; approved by kathryn.pantages@va.gov
+
+**The combined entity's VA asset map:** GE HealthCare modalities at all VA facilities, GE Centricity PACS and Centricity Cardiology Enterprise on the VA-approved HL7 interface list, GE AIR Recon DL deployed for VA CT image enhancement, and Intelerad IntelePACS on VAEC for NTP under contract 36C10B26C0038 through October 2028. End-to-end stack across modality, PACS, AI, and cloud.
+
+**The procurement signal:** FAR 6.302-1 is the statute reserved for procurements where only one responsible source can perform the work, typically because of OEM proprietary technology. The contracting officer's certification on the SAM.gov award notice is a formal determination, not a preference. The period of performance through October 20, 2028 means VA is buying continuity through the EIS RFP release window (anticipated late FY2026 to early FY2027) and well past the expected EIS award date.
+
+**Antitrust and OCI consideration:** Combined modality OEM plus NTP PACS incumbent plus established VAEC cloud position could trigger competitive concerns in the EIS procurement. FAR organizational conflict of interest rules may require firewalls between modality sales activities and EIS proposal activities.
+
+---
+
+### Signal 11: Speech and Reporting (Nuance / Microsoft)
+
+**Contract:** Dragon Medical One Enterprise-Wide Speech Recognition SaaS
+**Award ID:** 36C10B25F0110
+**Confidence:** Verified. Contract distributed via NASA SEWP V (NNG15SC27B) through Carahsoft
+**Value:** $49,335,481.52
+**Period:** June 1, 2025 to May 31, 2028
+**Authorization:** FedRAMP Moderate; compatible with VA CPRS and Oracle Health Cerner Millennium
+
+**Position:** Nuance/Microsoft is the entrenched enterprise speech and reporting vendor for VHA. PowerScribe One is the AI-powered radiology reporting platform. This is essentially sole-source territory through May 2028.
+
+---
+
+### Signal 12: VA AI Infrastructure Spend
+
+**Confidence:** Verified. Figures sourced from FY2027 VA Congressional Budget Justification
+**FY2027 request:** $47.8 million for Decision Intelligence and Automation, a $4.7 million (10.9%) increase over FY2026 enacted
+**Driver:** AI Infrastructure solution for piloting and scaling clinical AI tools across clinical domains
+**Scale:** VA's 2025 AI Use Case Inventory (released January 2026) documents 367 AI use cases department-wide, up from 227 in 2024 net. 72 use cases were retired during the same cycle, so gross new additions exceed the net 62% figure. 253 of 367 are in VHA healthcare contexts. Approximately 100,000 VA employees use generative AI tools.
+
+**Action window (FY2027 markup, now through summer 2026):** AI infrastructure investment is the next major task-order layer. Firms with FedRAMP-authorized clinical AI inference platforms, model evaluation tooling, and DICOM-compatible AI orchestration are positioned for the standardized inference layer VA is funding.
+
+---
+
+## Competitive Hierarchy at a Glance
+
+| Tier | Vendor(s) | VA Position | Watch For |
+|---|---|---|---|
+| Combined Incumbent | GE HealthCare + Intelerad | NTP PACS, modality OEM at all VA facilities, AIR Recon DL, VAEC hosting | Antitrust/OCI exposure on EIS; KLAS satisfaction historically below average |
+| Established Challengers | Agfa, Sectra, Visage | Agfa best-in-KLAS 2026 across VNA, Universal Viewer, and PACS small; Sectra #1 PACS 13 consecutive years; Visage active VAEC deployment in VISN 23 | Limited federal contracting infrastructure; clinical satisfaction is the strength |
+| Component Specialists | Philips, Siemens, Fujifilm, Carestream | Approved PACS interfaces; specialty cardiology depth | Not positioned as enterprise VNA prime competitors |
+| Speech/Reporting | Nuance/Microsoft | Sole-source position through May 2028 | Recompete cycle pressure starting late 2027 |
+| Community Exchange | Medicom Technologies | 17 of 18 VISNs | Architecture mismatch with CCN Next Gen FHIR R4 mandate |
+| Storage Infrastructure | Peraton | $497M IaaMS, 28+ PB, 300 sites | Re-compete intersects EIS in FY2028 |
+
+**Agfa is the most underestimated EIS competitor.** Best in KLAS 2026 across XERO Viewer (Universal Viewer, third consecutive year, 92.1% score), VNA (second consecutive year, 89.8% score), and PACS small/under 300k studies (93.2% score). Recent enterprise wins include Tampa General Hospital/University of South Florida and a major teleradiology group selecting Agfa's Enterprise Imaging Cloud SaaS. The only non-GE/Intelerad vendor with simultaneous Best in KLAS recognition for VNA, Universal Viewer, and PACS.
+
+---
+
+## Three Things Most Capture Teams Are Missing
+
+**One.** The NTP NextGen cancellation is a procurement signal, not a data point. VHA cancelled a multi-vendor best-of-breed consortium and stayed with the incumbent in the same quarter as the broader DOGE contract environment. This tells EIS proposers that integration risk, program management continuity, and transition complexity will be weighted heavily, possibly heavier than technical superiority of any individual component. A best-of-breed team without a coherent integration story is the loss pattern VHA just demonstrated.
+
+**Two.** IaaMS and EIS will intersect, and the boundary is not yet decided. The $497 million Peraton IaaMS contract expires approximately August 2028. The EIS archive must migrate from or subsume IaaMS storage. Whether IaaMS becomes a storage utility layer beneath EIS, or is folded into the EIS contract, is a sequencing question the Government has not answered publicly. Firms that build the EIS-IaaMS transition story have a differentiated narrative.
+
+**Three.** The CCN Next Generation RFP creates a new imaging exchange interoperability mandate. The medical IDIQ has a $700 billion ceiling. The FHIR R4 / USCDI requirement directly obsoletes the current CIES HL7 v2 / DICOM architecture. The TPAs that win CCN Next Gen need imaging exchange capability embedded in their network infrastructure. There is no incumbent at scale for the modernized architecture.
+
+---
+
+## What to Do This Week
+
+If your firm is building toward EIS:
+
+- Send a capabilities briefing request to SAC-F Frederick this week. The acquisition strategy window closes when the RFP drops.
+- Map your team to four required capability layers: T4NG2 prime (required for task order flow), FedRAMP cloud partner, VNA technology anchor (Agfa, Sectra, or Visage if you are not GE/Intelerad), AI integration capability, and an SDVOSB or SDVOSB JV partner.
+- Draft a four-point white paper covering data migration risk for the 100 PB / 17 billion image archive, operational continuity from VistA Imaging and CAMM 7, dual-EHR MPI architecture, and long-term support stability. Submit to SAC-F.
+
+If your firm is building toward EHRM imaging integration:
+
+- Engage Michigan site program managers now. The four sites that went live April 11 are still in stabilization.
+- Pre-position for Wave 2 (June). Chillicothe, Cincinnati, Cincinnati-Fort Thomas KY, Dayton. Integration kick-off needs to start in May. Wave 3 (August) covers Fort Wayne, Marion, Indianapolis. Wave 4 (October) covers Cleveland and Alaska.
+- Vehicle access: T4NG2 prime team or Oracle Health partner ecosystem.
+
+If your firm is building toward CIES or CCN Next Gen imaging exchange:
+
+- Build the FHIR R4 / USCDI capability stack. The architectural gap is the wedge.
+- Engage Laura Startek at SAC for the CIES recompete cycle.
+- Identify likely CCN Next Gen TPA awardees and pursue subcontracting positioning for embedded imaging exchange capability.
+
+---
+
+## What to Watch Next
+
+- EIS RFP release window: late FY2026 to early FY2027. SAM.gov 36C10X25Q0015.
+- Radiology and Imaging IDIQ award notices: expected Q3 FY2026.
+- CIES Next Generation formal solicitation: anticipated FY2026 to FY2027.
+- MTRS RFP release: following Sources Sought close (April 27, 2026).
+- HINGE NROP RFP: following Sources Sought (December 2025).
+- VA Wave 2 EHRM go-live: June 2026 (Ohio, Kentucky). Wave 3 August 2026 (Indiana). Wave 4 October 2026 (Cleveland OH, Alaska).
+- T4NG expiration: June 30, 2026.
+- IaaMS re-compete pre-solicitation: approximately FY2027 to FY2028.
+- VHA RISE reorganization milestones: 18 VISNs to 5 regions over 18-24 months from early 2026.
+
+---
+
+Let's roll.
+
+— Mary
+
+Mission Meets Tech
+
+*The views expressed in this newsletter are my own and do not represent the official position of any organization. This content is for informational purposes only.*
+
+---
+
+## Premium Subscriber Notice
+
+This Capture Intelligence Sheet is part of your Mission Meets Tech Premium subscription. Free readers receive the analytical frame in the public newsletter the same day; the procurement map, contract numbers, contracting officer contacts, and action windows above are the premium layer.
+
+Questions on a specific signal? Reply directly to this issue. Selected questions are answered in the next Capture Intelligence Sheet.
+
+Tools at your subscriber rate: ProposalPulse $14.99 per assessment (vs. $19.99 standard) and MarketPulse $35 per brief (vs. $50 standard). missionmeetstech.com.
+
+---
+
+## Sources
+
+*Sources verified as of April 27, 2026.*
+
+EIS scope figures (100 petabytes, 17 billion images, 25 million annual exams, dual MPI requirement) sourced directly from VHA RFI 36C10X25Q0015 Amendment 0003, December 2024.
+
+NTP NextGen PACS cancellation confirmed by Mach7 Technologies Q2 FY26 earnings call covered by Defense World on January 31, 2026, in which CEO Teri Thomas confirmed Mach7 was no longer part of the VHA teleradiology program. Thomas called the outcome "disappointing." Corroborated by Signify Research Imaging Informatics Market Update, February 2026, which confirmed VHA "abandonment of the project will see the VHA remain with its existing solution provided by Intelerad" and that the cancellation impacts Mach7 Technologies, Nuance, Blackford, and Microsoft.
+
+Intelerad sole-source upgrade contract 36C10B26C0038 verified to SAM.gov award notice published April 20, 2026 (19:00:39 UTC), notice type code "a" (Award Notice). Solicitation 36C10B26Q0213. Awardee Intelerad Medical Systems, Inc., 800 De Maisonneuve Blvd East, 14th Floor, Montreal, Quebec; UEI D7K7H9E4MZV9. Total value $11,270,971; potential $11.3M. Firm-fixed-price; FAR 6.302-1 sole-source justification (only one responsible source, OEM proprietary). Period of performance April 20, 2026 through October 20, 2028 (2 years, 6 months). Awarding office VA Strategic Acquisition Center. Created by sean.mcavoy1@va.gov; approved by kathryn.pantages@va.gov. Status open as of April 27, 2026; 1.0% complete; $3.7M obligated; $7.6M backlog.
+
+Original NTP NextGen PACS consortium award structure (Frontier Acquisitions prime; Mach7 VNA and eUnity Diagnostic Viewer; Nuance voice recognition; Blackford AI; Microsoft Azure cloud) sourced from PRNewswire, September 6, 2023, and Mach7 ASX disclosure structure (Phase I A$11.7M with potential expansion to A$59.6M total).
+
+Intelerad NTP PACS incumbency since November 2013 sourced from BusinessWire, November 12, 2013.
+
+GE HealthCare completion of $2.3 billion Intelerad acquisition on March 18, 2026 sourced from GE HealthCare press release distributed via BusinessWire and Yahoo Finance March 18, 2026; corroborated by Radiology Business, MassDevice, MPO, and Healthcare IT News (March 18-19, 2026). Intelerad first-year revenue estimate of approximately $270 million with approximately 90% recurring sourced from same release.
+
+CCN Next Generation $700 billion medical IDIQ ceiling sourced from House Veterans' Affairs Committee hearing testimony, January 22, 2026. CCN Next Gen RFP (36C10G26R0003) issued December 2025 with original responses due March 16, 2026, Amendment 002 posted April 25, 2026, East/West two-region structure and EHR interoperability requirements (Oracle Health, TRICARE), sourced from VA SAM.gov publication and HigherGov contract record. $300 million VA EHR infrastructure modernization investment supporting CCN Next Gen interoperability sourced from VA OIT FY2027 Congressional Budget Justification.
+
+VA OIG 25-01255-242, "Review of Veterans Health Administration's National Teleradiology Program," December 4, 2025, confirms NTP scale (125 facilities, all 18 VISNs, 24/7 teleradiology service) and references the August 13, 2024 Assistant Under Secretary for Health for Clinical Services memorandum on NTP support reduction.
+
+VA EHRM deployment status as of April 27, 2026: 10 sites live (5 original West/Midwest sites, North Chicago/Lovell, plus 4 Michigan sites live April 11, 2026). Wave 2 (June 2026) covers Chillicothe OH, Cincinnati OH, Cincinnati-Fort Thomas KY, Dayton OH (4 sites). Wave 3 (August 2026) covers Fort Wayne IN, Marion IN, Indianapolis Roudebush IN (3 sites). Wave 4 (October 2026) covers Louis Stokes Cleveland OH and Alaska VA Healthcare System (2 sites). Sourced from VA EHRM program documentation, VA FY2027 Budget in Brief, and Oracle Health deployment announcements.
+
+VA OIG status of 32 open EHRM recommendations as of FY2027 Congressional Budget Justification (Section III, January 2026) reflects ongoing closure activity from 27 open recommendations as of FY2026 IT Budget Submission (May 2025). VA OIG does not publish a single cumulative outage count; third-party figures ranging from 340 to 400 should be treated as directional only.
+
+Joint VA/DoD DICOM Modality Conformance Requirements Rev 3.3 (December 2024) governs all VA imaging modality acquisitions. VA-Approved DICOM Modality Interfaces and VA-Approved PACS HL7 Interface lists current as of April 2026.
+
+KLAS 2026 awards: Agfa HealthCare best in KLAS for XERO Viewer (Universal Viewer, third consecutive year, 92.1%), VNA (second consecutive year, 89.8%), and PACS small/under 300k studies (93.2%); Sectra PACS #1 in customer satisfaction in North America 13 consecutive years; Visage Imaging #2 momentum, most net-new enterprise selections; GE HealthCare (Global Viewer) recovering from historically low scores, up 6+ points in 2025.
+
+Nuance Dragon Medical One contract value $49,335,481.52, distributed via NASA SEWP V contract NNG15SC27B through Carahsoft Technology Corporation, Award ID 36C10B25F0110, period June 1, 2025 to May 31, 2028, sourced from federal procurement records.
+
+Peraton IaaMS contract value $497 million over 7 years awarded August 2021, scope of up to 300 VA sites and 28+ petabytes, sourced from VA OIT and federal procurement records.
+
+VA AI Use Case Inventory January 2026 (web compliance update April 2026): 367 use cases department-wide (up from 227 in 2024 net), 72 use cases retired during the same cycle. 253 of 367 in VHA healthcare contexts. FY2027 AI budget of $47.8 million for Decision Intelligence and Automation sourced from VA FY2027 Congressional Budget Justification.
+
+DOGE contract environment context (approximately $1.8 billion in VA contracts cancelled and partially reversed in early 2025, including initially-targeted radiation-producing equipment inspection contracts) sourced from CNBC and ABC News reporting February-March 2025; reversal of inspection contracts confirmed in same coverage.
+
+VHA RISE reorganization announcement (December 14, 2025) and structure (18 VISNs to 5 regions over 18-24 months) sourced from VA announcements and Congressional testimony, December 2025 to February 2026.

--- a/docs/manual-subscriber-smoke-checklist.md
+++ b/docs/manual-subscriber-smoke-checklist.md
@@ -21,13 +21,20 @@ Visit each route and verify it loads (200) and looks intentional:
 - [ ] `/ask-mtt` → same
 - [ ] `/compliance-check` → redirects to `/premium/compliance-check.html`, then to `/dashboard.html` sign-in form
 - [ ] `/signal-chain` → redirects to `/premium/signal-chain.html`, then to `/dashboard.html` sign-in form
-- [ ] `/capture-corner` → 200, locked teaser visible, no `████` blocks
+- [ ] `/capture-corner` → 200, locked teaser visible, **primary CTA `Read this week's issue` points to `/capture-corner/latest`** (not the old `/intel/...` route), no `████` blocks
+- [ ] `/capture-corner/latest` → 302 → resolves to a real Capture Intelligence page with current month/issue label
 - [ ] `/contract-tracker` → 200, vendor/value/NAICS show "Premium" placeholders, scanner shows last-scan date OR honest "no scan yet" message
 - [ ] `/idiq-tracker` → 200, "28 vehicles" gate card visible (not empty), no `████`
-- [ ] `/tools` → 200, every premium tool listed with a working link
+- [ ] `/tools` → 200, every premium tool listed with a working link, RFP Shredder card carries `PRIVATE BETA` chip
+- [ ] `/rfp-shredder` → 200, "Private Beta" status block visible, page does NOT claim live analysis runs on this domain
 - [ ] `/help` → 200
 - [ ] `/pricing` → 200, three Stripe Payment Links work (don't actually purchase)
 - [ ] `/dashboard` → sign-in form
+- [ ] `/latest` → newest source-of-truth article (from `content/newsletter/`) appears at top of main archive list, not just in editor's-picks tiles
+- [ ] `/pursuit-calendar` (after sign-in) → page title is `Pursuit Calendar — 90-Day Deadline Tracker — MMT Premium` (NOT `Premium Dashboard`); RFI / Industry Day / Final RFP / Proposal Due / Recompete / Award all visible as category labels; freshness banner present
+- [ ] `/premium/briefings` (after sign-in) → H1 is `The Friday Brief`; no raw `<!-- BUILD:BRIEF_ARCHIVE -->` markers; ≥1 archive card; title is NOT `Monthly Briefs`
+- [ ] All premium pages render with **exactly one sidebar** — if you see two side-by-side sidebars, the double-sidebar regression is back; check `injectDashShell` in `build.js`
+- [ ] Homepage `Choose a Tool` CTA href is `/tools` (not `/resources#paid-tools`) — verify by hovering on desktop and inspecting on mobile
 
 ## Founding/Premium pass
 

--- a/docs/may-1-release-runbook.md
+++ b/docs/may-1-release-runbook.md
@@ -1,0 +1,67 @@
+# May 1, 2026 Release Runbook
+
+Three artifacts are staged in this repo for the Friday May 1, 2026 release. The newsletter article auto-publishes via future-date gating in build.js. The tracker update and premium capture sheet require Mary's action.
+
+## Schedule (anchored on 09:00 ET LinkedIn newsletter)
+
+| Time (ET) | Action | Artifact | Owner |
+|---|---|---|---|
+| 06:00 | Email Premium Capture Sheet to subscribers | `data/may-1-release/premium-capture-sheet.md` | Mary (manual; email or gated web) |
+| **09:00** | **LinkedIn newsletter publishes** (anchor) | LinkedIn native | **Mary (Taplio scheduling)** |
+| 09:00–11:00 | Site article goes live automatically | `content/newsletter/2026-05-01-the-architecture-va-asks-for.md` | Auto (next Netlify rebuild after midnight UTC May 1) |
+| 09:15 | Personal LinkedIn teaser post | LinkedIn personal feed | Mary (manual) |
+| 12:00 | Contracts tracker update deploys | `data/may-1-release/contracts-tracker-update.md` | Mary or agent (commit content into `/contract-tracker` or paste into `/resources`) |
+| 16:00 | newsletters.json refresh | Auto via build | Auto (Netlify cron rebuild every 4 hours picks up the May 1 article) |
+
+## How "automatic release" actually works
+
+`build.js` `loadArticles()` filters out any article whose `publish_date` is in the future relative to the build time. Once the wall clock crosses 2026-05-01 00:00 (local server time), the article is included on the next build. The `rebuild-trigger` Netlify scheduled function runs every 4 hours, so the article appears on missionmeetstech.com no later than 04:00 ET on May 1.
+
+To pull it in earlier on May 1 (e.g. exactly at 09:00 ET to match the LinkedIn anchor), Mary or any agent can:
+
+```bash
+# Force a Netlify build at 09:00 ET on May 1
+curl -X POST -d '{}' "$NETLIFY_BUILD_HOOK_URL"
+```
+
+Or push any commit on May 1 to trigger a build.
+
+## Staged files
+
+- `content/newsletter/2026-05-01-the-architecture-va-asks-for.md` — the public newsletter, frontmatter complete, future-date-gated. Will auto-publish on May 1.
+- `data/may-1-release/premium-capture-sheet.md` — the Premium Capture Intelligence Sheet (VA Enterprise Imaging). Source for the 06:00 ET email blast. Not deployed to the public site.
+- `data/may-1-release/contracts-tracker-update.md` — the May 2026 Contracts Tracker update. Twelve VA Enterprise Imaging tracker entries. Mary integrates into `contracts.json` or pastes into `/contract-tracker.html` on May 1 at 12:00 ET.
+
+## Pre-flight (Thursday April 30 EOD)
+
+- [ ] All three files reviewed and final
+- [ ] Future-date gate verified: `node build.js` → output mentions "HOLDING (future-dated): 2026-05-01-the-architecture-va-asks-for.md"
+- [ ] LinkedIn newsletter scheduled in Taplio for 09:00 ET May 1
+- [ ] Premium subscriber list export ready for 06:00 ET email
+- [ ] No competing major announcements Friday morning (VA SAM.gov, DHA news, GE HealthCare investor calendar)
+
+## Publish-day verification (Friday May 1, 09:30 ET)
+
+```bash
+# Confirm the article is on the live site
+curl -Ls https://missionmeetstech.com/latest | grep -E "Architecture VA Asks" | head -3
+
+# Confirm the article page renders
+curl -Ls https://missionmeetstech.com/newsletter/the-architecture-va-asks-for/ | grep -oE "<title>[^<]+" | head -1
+
+# Confirm sitemap has it
+curl -Ls https://missionmeetstech.com/sitemap.xml | grep -E "the-architecture-va-asks-for"
+
+# Confirm deploy-id
+curl -Ls https://missionmeetstech.com/deploy-id.txt | head -3
+```
+
+## Rollback
+
+If a substantive error surfaces post-publish:
+
+1. **Premium sheet error:** send corrected version to subscriber list within 4 hours with subject `[CORRECTION] Capture Intelligence Sheet — [field corrected]`.
+2. **Newsletter error:** edit `content/newsletter/2026-05-01-the-architecture-va-asks-for.md` directly, push, deploy. Add an italic editor's note at the bottom: `[Updated May 1, 2026, HH:MM ET to correct (specific item).]`
+3. **Tracker error:** push GitHub commit and trigger Netlify redeploy.
+
+Standing rule: a correction issued within hours preserves credibility. A silent edit destroys it.

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   # validate-dist.js fails the build if dist/ contains any public-facing
   # drift pattern from docs/site-spec.md §14a. If it exits non-zero,
   # Netlify will refuse to deploy.
-  command = "node scripts/sync-newsletters.js; node scripts/sync-linkedin-newsletter.js; node build.js && node scripts/validate-dist.js && node scripts/validate-routes.js && node scripts/newsletter-inventory.js"
+  command = "node scripts/sync-newsletters.js; node scripts/sync-linkedin-newsletter.js; node build.js && node scripts/validate-dist.js && node scripts/validate-routes.js && node scripts/newsletter-inventory.js && node scripts/capture-corner-inventory.js"
 
 [functions]
   directory = "netlify/functions"
@@ -320,6 +320,14 @@
   to = "/capture-corner.html"
   status = 200
 
+# /capture-corner/latest is the stable URL that always resolves to the
+# newest eligible Capture Intelligence issue. The redirect target is
+# kept up to date by scripts/capture-corner-inventory.js.
+[[redirects]]
+  from = "/capture-corner/latest"
+  to = "/intel/capture-intelligence-this-issue/"
+  status = 302
+
 [[redirects]]
   from = "/compliance-check"
   to = "/compliance-check.html"
@@ -444,11 +452,6 @@
 [[redirects]]
   from = "/signal-chain"
   to = "/premium/signal-chain.html"
-  status = 200
-
-[[redirects]]
-  from = "/capture-corner"
-  to = "/capture-corner.html"
   status = 200
 
 [[redirects]]

--- a/netlify/functions/lib/company-alignment.js
+++ b/netlify/functions/lib/company-alignment.js
@@ -344,6 +344,7 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
       verdict: "NO-BID",
       color: "#E63946",
       band: "blocked",
+      composite: 0,
       reason: "OCI exclusion blocks pursuit.",
     };
   }
@@ -352,6 +353,7 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
       verdict: "MONITOR",
       color: "#457B9D",
       band: "in_flight",
+      composite: companyFit?.score || 50,
       reason: "Already in flight — defend current submission, do not double-pursue.",
     };
   }
@@ -360,6 +362,7 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
       verdict: "DEFEND",
       color: "#15803D",
       band: "incumbent",
+      composite: Math.max(75, companyFit?.score || 75),
       reason: "Defensive recompete — incumbency is the strongest possible position.",
     };
   }
@@ -371,6 +374,7 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
         verdict: "MONITOR",
         color: "#457B9D",
         band: "no_profile_partial",
+        composite: marketScore || 0,
         reason: "Generic preliminary score — sources timed out and no company profile is loaded. Complete your company profile and re-score before any bid/no-bid decision.",
       };
     }
@@ -379,6 +383,7 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
         verdict: "QUALIFY",
         color: "#15803D",
         band: "no_profile_strong",
+        composite: marketScore,
         reason: "Generic preliminary score — strong market signal, but no company profile is loaded. Complete your profile to convert this into a company-fit verdict.",
       };
     }
@@ -386,6 +391,7 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
       verdict: "CAPTURE_VALIDATION",
       color: "#92710A",
       band: "no_profile_weak",
+      composite: marketScore || 0,
       reason: "Generic preliminary score — market signal is thin and no company profile is loaded. Treat as capture-research required, not no-bid.",
     };
   }
@@ -401,6 +407,7 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
       verdict: "CAPTURE_VALIDATION",
       color: "#92710A",
       band: "signals_present",
+      composite,
       reason: `${(signals || []).length} positive signal${signals.length === 1 ? "" : "s"} present (${signals.map((s) => s.tag).join(", ")}) — capture validation required, not no-bid.`,
     };
   }
@@ -409,15 +416,16 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
       verdict: "MONITOR",
       color: "#457B9D",
       band: "partial_data",
+      composite,
       reason: "Some upstream sources timed out — score may be understated. Monitor and re-run rather than no-bid.",
     };
   }
 
-  if (composite >= 75) return { verdict: "PURSUE", color: "#15803D", band: "high", reason: "Strong market signal and company fit." };
-  if (composite >= 60) return { verdict: "QUALIFY", color: "#457B9D", band: "medium_high", reason: "Material signal — qualify with capture-team validation." };
-  if (composite >= 45) return { verdict: "MONITOR", color: "#92710A", band: "medium", reason: "Mixed signal — monitor and re-evaluate at next catalyst." };
-  if (composite >= 30) return { verdict: "CAPTURE_VALIDATION", color: "#F97316", band: "low", reason: "Thin signal — capture validation required before any bid commitment." };
-  return { verdict: "NO-BID", color: "#E63946", band: "very_low", reason: "Both market signal and company fit are weak; no positive signals detected." };
+  if (composite >= 75) return { verdict: "PURSUE", color: "#15803D", band: "high", composite, reason: "Strong market signal and company fit." };
+  if (composite >= 60) return { verdict: "QUALIFY", color: "#457B9D", band: "medium_high", composite, reason: "Material signal — qualify with capture-team validation." };
+  if (composite >= 45) return { verdict: "MONITOR", color: "#92710A", band: "medium", composite, reason: "Mixed signal — monitor and re-evaluate at next catalyst." };
+  if (composite >= 30) return { verdict: "CAPTURE_VALIDATION", color: "#F97316", band: "low", composite, reason: "Thin signal — capture validation required before any bid commitment." };
+  return { verdict: "NO-BID", color: "#E63946", band: "very_low", composite, reason: "Both market signal and company fit are weak; no positive signals detected." };
 }
 
 module.exports = {

--- a/netlify/functions/lib/pursuit-score-engine.js
+++ b/netlify/functions/lib/pursuit-score-engine.js
@@ -583,6 +583,15 @@ async function scorePursuit({ keyword, agency, naics, subscriberContext }) {
       agency: resolvedAgency,
       naics: resolvedNaics,
     },
+    // The composite score is the headline number — it combines market
+    // signal (weighted 0.55), company fit (0.45), and a positive-signal
+    // bonus, then runs through the verdict thresholds. The UI ring
+    // displays compositeScore so the verdict and the visible number
+    // tell the same story. totalScore (sum of 4 market dimensions) is
+    // kept as the secondary "Market signal" sub-label for the dimension
+    // breakdown panel — it answers "what's federal data telling us
+    // about this opportunity, ignoring our company?"
+    compositeScore: combined.composite ?? totalScore,
     totalScore,
     verdict: combined.verdict,
     verdictColor: combined.color,

--- a/netlify/functions/lib/signal-chain-query-builder.js
+++ b/netlify/functions/lib/signal-chain-query-builder.js
@@ -12,6 +12,67 @@
 // only federal/military-authored papers show up.
 // ============================================================
 
+// Common typos in federal-health-IT and procurement vocabulary that we
+// silently correct before building the query. Subscribers expect the
+// tool to be tolerant of misspellings — losing a quota slot to a typo
+// that produces "0/100 QUIET across all 5 layers" is the failure mode
+// Signal Chain was caught in (2026-04-28). Keep the list small and
+// high-confidence. Do not auto-correct ambiguous user intent.
+const COMMON_TYPOS = {
+  "governence":   "governance",
+  "goverance":    "governance",
+  "governce":     "governance",
+  "governence,":  "governance",
+  "interopability":"interoperability",
+  "interopabiliy":"interoperability",
+  "telehealh":    "telehealth",
+  "telehelath":   "telehealth",
+  "moderniztion": "modernization",
+  "modernzation": "modernization",
+  "acquistion":   "acquisition",
+  "acqusition":   "acquisition",
+  "appropritions":"appropriations",
+  "appropations": "appropriations",
+  "biosurveilance":"biosurveillance",
+  "cybersecruity":"cybersecurity",
+  "cybersecurty": "cybersecurity",
+  "veterens":     "veterans",
+  "milityary":    "military",
+  "miliatry":     "military",
+  "elecrtronic":  "electronic",
+  "electronc":    "electronic",
+  "infrastucture":"infrastructure",
+  "infastructure":"infrastructure",
+  "anaylytics":   "analytics",
+  "analyitcs":    "analytics",
+  "geneisis":     "genesis",
+  "genisis":      "genesis",
+};
+
+/**
+ * Correct common federal-vocabulary typos token-by-token. Returns
+ * { corrected, changed: boolean, replacements: [[from, to], ...] }.
+ * The replacements list is surfaced in the response so subscribers see
+ * "We searched 'data governance' (corrected from 'data governence')."
+ */
+function correctCommonTypos(input) {
+  const raw = String(input || "");
+  if (!raw.trim()) return { corrected: raw, changed: false, replacements: [] };
+  const replacements = [];
+  const corrected = raw.replace(/\b[a-z]+\b/gi, (token) => {
+    const fix = COMMON_TYPOS[token.toLowerCase()];
+    if (fix) {
+      replacements.push([token, fix]);
+      // Preserve original casing
+      if (token === token.toUpperCase()) return fix.toUpperCase();
+      if (token[0] === token[0].toUpperCase()) return fix[0].toUpperCase() + fix.slice(1);
+      return fix;
+    }
+    return token;
+  });
+  return { corrected, changed: corrected !== raw, replacements };
+}
+
 const STOPWORDS = new Set([
   "the","a","an","and","or","for","of","to","in","on","at","by","with","as",
   "is","are","was","were","be","been","being","have","has","had","do","does",
@@ -100,12 +161,54 @@ const USASPENDING_AGENCY_NAMES = {
   GSA: "General Services Administration",
 };
 
+// Suggested broader/related queries that produce non-empty results
+// at each agency. When all 5 layers return zero, the response includes
+// these as fallback options so the user has something to click into
+// instead of staring at "0/100 QUIET". Conservative list — these are
+// programs / vehicles known to have active federal data signal.
+const FALLBACK_SUGGESTIONS = {
+  DHA: [
+    { label: "MHS GENESIS",          query: "MHS GENESIS",          reason: "DoD's electronic health record platform — active signal across all 5 layers" },
+    { label: "DHMSM",                query: "DHMSM",                reason: "Defense Healthcare Management Systems Modernization" },
+    { label: "DHA Data Governance",  query: "DHA data governance",  reason: "Active solicitation HT001126RE011" },
+    { label: "TRICARE",              query: "TRICARE modernization", reason: "Persistent active signal — purchased care + benefits" },
+  ],
+  VA: [
+    { label: "VA EHRM",              query: "VA EHRM",              reason: "Oracle Health rollout, 13 sites in 2026" },
+    { label: "CCN Next Gen",         query: "CCN Next Gen",         reason: "Community care network recompete, $700B medical IDIQ" },
+    { label: "VA OIT Franchise Fund",query: "VA OIT Franchise Fund",reason: "Recurring infrastructure recompete window" },
+    { label: "VA Enterprise Imaging",query: "VA Enterprise Imaging",reason: "EIS RFI — largest federal imaging procurement in history" },
+  ],
+  HHS: [
+    { label: "CDC Data Modernization", query: "CDC Data Modernization Initiative", reason: "Active modernization initiative" },
+    { label: "ARPA-H",               query: "ARPA-H",               reason: "Advanced Research Projects Agency for Health" },
+    { label: "CMS interoperability", query: "CMS interoperability", reason: "Active CMS rules + technology spend" },
+  ],
+  DoD: [
+    { label: "JWCC",                 query: "JWCC",                 reason: "Joint Warfighting Cloud Capability — active task orders" },
+    { label: "Software Acquisition Pathway", query: "Software Acquisition Pathway", reason: "DoD preferred software path" },
+  ],
+  GSA: [
+    { label: "OASIS+",               query: "OASIS+",               reason: "Multi-award professional services vehicle" },
+    { label: "GSA MAS",              query: "GSA MAS modernization", reason: "Schedule program activity" },
+    { label: "SEWP VI",              query: "SEWP VI",              reason: "Successor IT vehicle in active competition" },
+  ],
+};
+
+function fallbackSuggestionsFor(agency) {
+  return FALLBACK_SUGGESTIONS[agency] || FALLBACK_SUGGESTIONS.DHA;
+}
+
 module.exports = {
   STOPWORDS,
   AGENCY_CONTEXT,
+  COMMON_TYPOS,
+  correctCommonTypos,
   buildQueryTerms,
   buildPubMedQuery,
   USAJOBS_ORG_CODES,
   FR_AGENCY_SLUGS,
   USASPENDING_AGENCY_NAMES,
+  FALLBACK_SUGGESTIONS,
+  fallbackSuggestionsFor,
 };

--- a/netlify/functions/signal-chain.js
+++ b/netlify/functions/signal-chain.js
@@ -23,7 +23,7 @@ const { searchTrials } = require("./lib/clinicaltrials-api");
 const { searchPubMed, fetchPubMedSummaries } = require("./lib/pubmed-api");
 const { searchJobs } = require("./lib/usajobs-api");
 const { detectVehicles, expandedSearchTerms } = require("./lib/known-vehicles");
-const { buildQueryTerms, buildPubMedQuery, FR_AGENCY_SLUGS, USASPENDING_AGENCY_NAMES } = require("./lib/signal-chain-query-builder");
+const { buildQueryTerms, buildPubMedQuery, FR_AGENCY_SLUGS, USASPENDING_AGENCY_NAMES, correctCommonTypos, fallbackSuggestionsFor } = require("./lib/signal-chain-query-builder");
 const { searchCorpus } = require("./lib/content-index");
 const fs = require("fs");
 const path = require("path");
@@ -558,6 +558,18 @@ exports.handler = async (event) => {
     return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: "QUERY_TOO_SHORT", message: "Enter at least 3 characters." }) };
   }
 
+  // Typo correction — silently fix common federal-vocab misspellings
+  // before we burn API quota on a query that returns 0 results across
+  // every layer. The corrected topic is what reaches the upstream APIs;
+  // the original is preserved on the response so the user sees a
+  // "We searched 'X' (corrected from 'Y')." line in the UI.
+  const _typoFix = correctCommonTypos(topic);
+  const originalTopic = topic;
+  if (_typoFix.changed) {
+    console.log(`signal-chain: typo correction "${topic}" -> "${_typoFix.corrected}" (${_typoFix.replacements.map(([f,t]) => `${f}→${t}`).join(", ")})`);
+    topic = _typoFix.corrected;
+  }
+
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
   const entitlement = await loadEntitlement(supabase, email);
   if (!entitlement.ok) {
@@ -625,8 +637,21 @@ exports.handler = async (event) => {
   const composite = computeComposite(layers);
   const { verdict, captureAlert, color } = getVerdict(composite);
 
+  // Empty-result intelligence — when composite is effectively zero
+  // across all 5 layers, surface fallback suggestions so the
+  // subscriber has somewhere productive to click instead of staring
+  // at "0/100 QUIET". This is the 2026-04-28 Signal Chain failure
+  // mode: misspelled query → all layers return 0 → user perceives
+  // the tool as broken.
+  const layerScores = Object.values(layers || {}).map((l) => l && typeof l.score === "number" ? l.score : 0);
+  const allLayersEmpty = layerScores.every((s) => s === 0);
+  const empty_state = (composite < 5 && allLayersEmpty);
+  const suggestions = empty_state ? fallbackSuggestionsFor(resolvedAgency).slice(0, 4) : [];
+
   const card = {
     topic,
+    original_topic: originalTopic !== topic ? originalTopic : undefined,
+    typo_corrections: _typoFix.changed ? _typoFix.replacements : undefined,
     agency: resolvedAgency,
     composite,
     verdict,
@@ -642,6 +667,11 @@ exports.handler = async (event) => {
       topKeywords: terms.topKeywords,
     },
     layers,
+    empty_state,
+    suggestions,
+    empty_state_message: empty_state
+      ? `No federal data signal for "${topic}" at ${resolvedAgency || "any agency"} this window. Try one of the active programs below, or broaden your terms.`
+      : undefined,
   };
 
   // Write to cache (non-blocking)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Mission Meets Tech website with auto-updating podcast episodes",
   "scripts": {
-    "build": "node scripts/sync-newsletters.js; node build.js && node scripts/validate-dist.js && node scripts/validate-routes.js && node scripts/newsletter-inventory.js",
+    "build": "node scripts/sync-newsletters.js; node build.js && node scripts/validate-dist.js && node scripts/validate-routes.js && node scripts/newsletter-inventory.js && node scripts/capture-corner-inventory.js",
     "build:no-validate": "node scripts/sync-newsletters.js; node build.js",
     "validate-dist": "node scripts/validate-dist.js",
     "validate-routes": "node scripts/validate-routes.js",

--- a/premium/pursuit-score.html
+++ b/premium/pursuit-score.html
@@ -198,7 +198,10 @@
             </div>
 
             <div style="margin-top:16px;">
-              <div style="font-size:12px;text-transform:uppercase;letter-spacing:0.08em;font-weight:700;color:var(--mmt-text-secondary);margin-bottom:8px;">Dimension breakdown</div>
+              <div style="display:flex;align-items:baseline;justify-content:space-between;margin-bottom:8px;">
+                <div style="font-size:12px;text-transform:uppercase;letter-spacing:0.08em;font-weight:700;color:var(--mmt-text-secondary);">Dimension breakdown</div>
+                <div style="font-size:12px;color:var(--mmt-text-secondary);">Market signal: <strong id="ps-market-signal" style="color:var(--mmt-navy);">0</strong> / 100</div>
+              </div>
               <div id="ps-dims"></div>
             </div>
             <div id="ps-awardees" style="margin-top:20px;"></div>
@@ -324,7 +327,13 @@
       lastScore = card;
       document.getElementById('ps-result').style.display = 'block';
 
-      var total = card.totalScore || card.total || 0;
+      // The big ring shows the composite score (verdict-aligned). The
+      // market-only totalScore is a secondary metric shown inside the
+      // dimension-breakdown panel so subscribers can see the federal
+      // data signal independently of company fit.
+      var total = (typeof card.compositeScore === 'number' ? card.compositeScore
+                : (card.totalScore || card.total || 0));
+      var marketSignal = card.totalScore || card.total || 0;
       var verdict = card.verdict || 'MONITOR';
       var verdictLabel = VERDICT_LABELS[verdict] || verdict;
       document.getElementById('ps-verdict').textContent = verdictLabel;
@@ -414,6 +423,8 @@
         else ringEl.textContent = total;
       }
       requestAnimationFrame(animate);
+      var marketEl = document.getElementById('ps-market-signal');
+      if (marketEl) marketEl.textContent = marketSignal;
 
       var resolved = card.resolved || {};
       var resolvedParts = [];

--- a/premium/signal-chain.html
+++ b/premium/signal-chain.html
@@ -352,6 +352,63 @@
       alertEl.textContent = r.verdict;
       alertEl.style.background = r.verdictColor || '#6B7280';
 
+      // Typo-correction notice — silently fix common federal-vocab
+      // misspellings before searching, surface the correction so the
+      // user knows what we actually queried.
+      var typoEl = document.getElementById('sc-typo-notice');
+      if (!typoEl) {
+        typoEl = document.createElement('div');
+        typoEl.id = 'sc-typo-notice';
+        typoEl.style.cssText = 'background:rgba(146,113,10,0.08);border:1px solid rgba(146,113,10,0.25);color:#5a4307;padding:10px 14px;border-radius:8px;font-size:13px;margin:0 0 14px;line-height:1.5;display:none;';
+        var resultEl = document.getElementById('sc-result');
+        if (resultEl && resultEl.firstChild) resultEl.insertBefore(typoEl, resultEl.firstChild);
+      }
+      if (r.original_topic && r.typo_corrections && r.typo_corrections.length) {
+        var corr = r.typo_corrections.map(function(p) { return '<strong>' + escapeHtml(p[0]) + '</strong>&nbsp;\u2192&nbsp;<strong>' + escapeHtml(p[1]) + '</strong>'; }).join(', ');
+        typoEl.innerHTML = 'We searched <strong>"' + escapeHtml(r.topic) + '"</strong> (corrected from "' + escapeHtml(r.original_topic) + '" \u2014 ' + corr + ').';
+        typoEl.style.display = 'block';
+      } else {
+        typoEl.style.display = 'none';
+      }
+
+      // Empty-state suggestions — when composite is effectively zero
+      // across all 5 layers, render a "Try one of these instead" tile
+      // so subscribers have somewhere productive to click.
+      var emptyEl = document.getElementById('sc-empty-suggestions');
+      if (!emptyEl) {
+        emptyEl = document.createElement('div');
+        emptyEl.id = 'sc-empty-suggestions';
+        emptyEl.style.cssText = 'background:#fff;border:1px solid var(--mmt-border);border-radius:12px;padding:18px 20px;margin:0 0 16px;display:none;';
+        var resultEl2 = document.getElementById('sc-result');
+        if (resultEl2 && resultEl2.firstChild) resultEl2.insertBefore(emptyEl, resultEl2.firstChild.nextSibling || null);
+      }
+      if (r.empty_state && Array.isArray(r.suggestions) && r.suggestions.length) {
+        var chips = r.suggestions.map(function(s) {
+          return '<button type="button" class="sc-suggest-btn" data-q="' + escapeHtml(s.query) + '" style="display:block;width:100%;text-align:left;background:var(--mmt-soft,#F3F4F6);border:1px solid var(--mmt-border);border-radius:8px;padding:10px 14px;margin:6px 0;cursor:pointer;font:inherit;">' +
+                 '<strong style="color:var(--mmt-navy);">' + escapeHtml(s.label) + '</strong>' +
+                 '<div style="font-size:12px;color:var(--mmt-text-secondary);margin-top:2px;">' + escapeHtml(s.reason) + '</div>' +
+                 '</button>';
+        }).join('');
+        emptyEl.innerHTML =
+          '<div style="font-size:11px;font-weight:800;letter-spacing:0.08em;text-transform:uppercase;color:#92710A;margin-bottom:6px;">No federal data signal this window</div>' +
+          '<p style="font-size:13px;color:var(--mmt-text);line-height:1.55;margin:0 0 12px;">' + escapeHtml(r.empty_state_message || '') + '</p>' +
+          '<div>' + chips + '</div>';
+        emptyEl.style.display = 'block';
+        // Wire chip clicks
+        var btns = emptyEl.querySelectorAll('.sc-suggest-btn');
+        for (var i = 0; i < btns.length; i++) {
+          btns[i].addEventListener('click', function() {
+            var q = this.getAttribute('data-q');
+            var topicInput = document.getElementById('sc-topic');
+            if (topicInput) topicInput.value = q;
+            var runBtn = document.getElementById('sc-run');
+            if (runBtn) runBtn.click();
+          });
+        }
+      } else {
+        emptyEl.style.display = 'none';
+      }
+
       // Capture Alert banner
       var banner = document.getElementById('sc-capture-banner');
       if (r.captureAlert) {

--- a/scripts/capture-corner-inventory.js
+++ b/scripts/capture-corner-inventory.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// capture-corner-inventory.js
+//
+// Emits reports/capture-corner-inventory.json. Records:
+//   - all known Capture Intelligence / Capture Corner issues in the repo
+//   - which one is "newest eligible" (canonical /capture-corner/latest target)
+//   - whether the redirect target in netlify.toml is up-to-date
+//
+// Today there is exactly one canonical issue at
+// /intel/capture-intelligence-this-issue/. When Mary adds dated issues,
+// drop them under data/may-1-release/ or premium/captures/ and this
+// script picks them up automatically.
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const REPORT = path.join(ROOT, "reports/capture-corner-inventory.json");
+
+// Known canonical and dated capture-intel locations.
+const candidates = [];
+
+// 1. The canonical "this issue" page.
+const canonical = path.join(ROOT, "intel-capture-intelligence.html");
+if (fs.existsSync(canonical)) {
+  candidates.push({
+    id: "canonical",
+    path: "intel-capture-intelligence.html",
+    url: "/intel/capture-intelligence-this-issue/",
+    publish_date: null,
+    description: "The canonical Capture Intelligence 'this issue' page. Replaced as Mary publishes new issues.",
+  });
+}
+
+// 2. Dated capture-corner files in data/ or premium/captures/
+const datedRoots = [
+  path.join(ROOT, "data/may-1-release"),
+  path.join(ROOT, "premium/captures"),
+];
+for (const root of datedRoots) {
+  if (!fs.existsSync(root)) continue;
+  for (const f of fs.readdirSync(root)) {
+    if (!/\.(md|html)$/.test(f)) continue;
+    const full = path.join(root, f);
+    // Look for a date in the filename
+    const dateMatch = f.match(/(\d{4}-\d{2}-\d{2})/);
+    candidates.push({
+      id: f,
+      path: path.relative(ROOT, full),
+      url: null, // not yet routed; Mary chooses route on deploy
+      publish_date: dateMatch ? dateMatch[1] : null,
+      description: "Dated capture-intelligence draft. Not yet wired to a public URL.",
+    });
+  }
+}
+
+// Pick the newest eligible (publish_date <= today, prefer dated over canonical).
+const today = new Date().toISOString().slice(0, 10);
+const eligible = candidates.filter((c) => !c.publish_date || c.publish_date <= today);
+const dated = eligible.filter((c) => c.publish_date && c.url).sort((a, b) => b.publish_date.localeCompare(a.publish_date));
+const newest = dated[0] || eligible.find((c) => c.id === "canonical") || null;
+
+// Read the netlify.toml redirect target for /capture-corner/latest
+const tomlText = fs.existsSync(path.join(ROOT, "netlify.toml")) ? fs.readFileSync(path.join(ROOT, "netlify.toml"), "utf8") : "";
+const redirectMatch = tomlText.match(/from\s*=\s*"\/capture-corner\/latest"\s*\n\s*to\s*=\s*"([^"]+)"/);
+const redirectTarget = redirectMatch ? redirectMatch[1] : null;
+const redirectStale = !!(newest && newest.url && redirectTarget && redirectTarget !== newest.url);
+
+const report = {
+  generated_at: new Date().toISOString(),
+  candidate_count: candidates.length,
+  newest_eligible: newest,
+  redirect_target_in_netlify_toml: redirectTarget,
+  redirect_stale: redirectStale,
+  candidates,
+};
+
+if (!fs.existsSync(path.dirname(REPORT))) fs.mkdirSync(path.dirname(REPORT), { recursive: true });
+fs.writeFileSync(REPORT, JSON.stringify(report, null, 2));
+
+console.log(`capture-corner-inventory: candidates=${candidates.length} newest=${newest?.id || 'none'} redirect_target=${redirectTarget || 'none'} stale=${redirectStale}`);
+if (redirectStale) {
+  console.error(`capture-corner-inventory: FAIL — netlify.toml /capture-corner/latest points to ${redirectTarget} but newest is ${newest.url}`);
+  process.exit(1);
+}

--- a/scripts/newsletter-inventory.js
+++ b/scripts/newsletter-inventory.js
@@ -34,16 +34,19 @@ const KNOWN_RECENT_TITLES = [
 function listSourceArticles() {
   if (!fs.existsSync(NEWSLETTER_DIR)) return [];
   const out = [];
+  const now = Date.now();
   for (const f of fs.readdirSync(NEWSLETTER_DIR)) {
     if (!f.endsWith(".md") || f.startsWith("_")) continue;
     const raw = fs.readFileSync(path.join(NEWSLETTER_DIR, f), "utf8");
     const { data } = matter(raw);
     if (!data.title || !data.date) continue;
+    const dateMs = new Date(data.date).getTime();
     out.push({
       file: f,
       title: data.title,
       date: data.date,
       slug: data.slug || f.replace(/^\d{4}-\d{2}-\d{2}-/, "").replace(/\.md$/, ""),
+      future_dated: !Number.isNaN(dateMs) && dateMs > now,
     });
   }
   return out.sort((a, b) => new Date(b.date) - new Date(a.date));
@@ -59,7 +62,8 @@ function newestInDist() {
 }
 
 const sourceArticles = listSourceArticles();
-const newestSource = sourceArticles[0] || null;
+const newestSource = sourceArticles.find((a) => !a.future_dated) || null;
+const heldFutureArticles = sourceArticles.filter((a) => a.future_dated);
 const newestDist = newestInDist();
 
 const titlesPresent = new Set(sourceArticles.map((a) => a.title.trim().toLowerCase()));
@@ -80,6 +84,7 @@ const report = {
   in_sync: !!(newestSource && newestDist && (newestDist.slug === newestSource.slug)),
   imported_in_this_run: [],
   missing_known_titles: missing,
+  held_future_articles: heldFutureArticles.map((a) => ({ file: a.file, title: a.title, publish_date: a.date })),
 };
 
 if (!fs.existsSync(path.dirname(REPORT_PATH))) fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true });

--- a/scripts/ops-health-rollup.js
+++ b/scripts/ops-health-rollup.js
@@ -75,11 +75,14 @@ const newsletterDir = path.join(ROOT, "content/newsletter");
 let newest = null;
 if (fs.existsSync(newsletterDir)) {
   const matter = require(path.join(ROOT, "node_modules/gray-matter"));
+  const now = Date.now();
   for (const f of fs.readdirSync(newsletterDir)) {
     if (!f.endsWith(".md") || f.startsWith("_")) continue;
     const fm = matter(fs.readFileSync(path.join(newsletterDir, f), "utf8")).data;
     if (!fm.date || !fm.title) continue;
     const date = new Date(fm.date);
+    // Future-date gate: skip articles held by build.js until publish_date.
+    if (date.getTime() > now) continue;
     if (!newest || date > newest.date) newest = { date, slug: fm.slug || f.replace(/^\d{4}-\d{2}-\d{2}-/, "").replace(/\.md$/, ""), title: fm.title, file: f };
   }
 }
@@ -132,6 +135,76 @@ function walk(dir) {
 }
 if (fs.existsSync(DIST)) walk(DIST);
 out.sections.redactions = { block_char_count: blockChars };
+
+// Capture Corner inventory + redirect freshness
+{
+  const ccPath = path.join(ROOT, "reports/capture-corner-inventory.json");
+  if (fs.existsSync(ccPath)) {
+    const ccInv = JSON.parse(fs.readFileSync(ccPath, "utf8"));
+    out.sections.capture_corner_inventory = {
+      candidate_count: ccInv.candidate_count,
+      newest_id: ccInv.newest_eligible?.id || null,
+      newest_url: ccInv.newest_eligible?.url || null,
+      redirect_target: ccInv.redirect_target_in_netlify_toml,
+      redirect_stale: ccInv.redirect_stale,
+    };
+  } else {
+    out.sections.capture_corner_inventory = { error: "no inventory file" };
+  }
+}
+
+// Pursuit Calendar freshness state — read what the rendered page
+// reports in its freshness banner (text-level scrape).
+{
+  const calHtml = fs.existsSync(path.join(DIST, "premium/calendar.html"))
+    ? fs.readFileSync(path.join(DIST, "premium/calendar.html"), "utf8")
+    : "";
+  const m = calHtml.match(/data-testid="pc-freshness"[^>]*>([^<]+)</);
+  const titleHasGeneric = /<title>\s*Premium Dashboard\b/i.test(calHtml);
+  out.sections.pursuit_calendar = {
+    has_90day_signature: calHtml.includes("90-Day Deadline Tracker"),
+    title_is_generic: titleHasGeneric,
+    freshness_text: m ? m[1].trim() : null,
+    pursuit_categories_count: ["RFI", "Industry Day", "Final RFP", "Proposal Due", "Recompete", "Award"].filter((c) => calHtml.includes(c)).length,
+  };
+}
+
+// Tools hub completeness
+{
+  const toolsHtml = fs.existsSync(path.join(DIST, "tools.html"))
+    ? fs.readFileSync(path.join(DIST, "tools.html"), "utf8")
+    : "";
+  const expected = ["Pursuit Score", "Ask MMT", "Pursuit Calendar", "Compliance Check", "Signal Chain", "ProposalPulse", "MarketPulse", "Capture Corner", "Contract Tracker", "IDIQ Tracker", "RFP Shredder"];
+  const missing = expected.filter((t) => !toolsHtml.includes(t));
+  out.sections.tools_hub = { expected_count: expected.length, missing };
+}
+
+// Homepage Choose a Tool target
+{
+  const idxHtml = fs.existsSync(path.join(DIST, "index.html"))
+    ? fs.readFileSync(path.join(DIST, "index.html"), "utf8")
+    : "";
+  const ctas = (idxHtml.match(/<a[^>]*href="([^"]+)"[^>]*>\s*Choose a Tool/g) || []).map((s) => {
+    const m = s.match(/href="([^"]+)"/);
+    return m ? m[1] : null;
+  });
+  out.sections.homepage_choose_a_tool = {
+    cta_count: ctas.length,
+    targets: ctas,
+    all_point_to_tools: ctas.every((h) => h && (/^\/tools(\/|\?|$|#)/.test(h) || h === "/tools.html")),
+  };
+}
+
+// RFP Shredder status label
+{
+  const rfpHtml = fs.existsSync(path.join(DIST, "rfp-shredder.html"))
+    ? fs.readFileSync(path.join(DIST, "rfp-shredder.html"), "utf8")
+    : "";
+  out.sections.rfp_shredder = {
+    has_private_beta_label: /Private Beta|private[_\- ]beta/i.test(rfpHtml),
+    claims_live_without_flag: /(run a live|paste here for instant analysis)/i.test(rfpHtml) && !process.env.RFP_SHREDDER_LIVE,
+  };
+}
 
 // Founding env-var presence (presence only — never the value)
 out.sections.founding = {

--- a/scripts/validate-routes.js
+++ b/scripts/validate-routes.js
@@ -126,11 +126,16 @@ if (fs.existsSync(newsletterDir)) {
   if (matter) {
     const files = fs.readdirSync(newsletterDir).filter((f) => f.endsWith(".md") && !f.startsWith("_"));
     let newest = null;
+    const now = Date.now();
     for (const f of files) {
       const raw = fs.readFileSync(path.join(newsletterDir, f), "utf8");
       const fm = matter(raw).data;
       if (!fm.date || !fm.title) continue;
       const date = new Date(fm.date);
+      // Future-date gate: future-dated articles are intentionally
+      // held by build.js until publish_date arrives. Don't fail the
+      // /latest check for an article that hasn't published yet.
+      if (date.getTime() > now) continue;
       if (!newest || date > newest.date) newest = { date, slug: fm.slug || f.replace(/^\d{4}-\d{2}-\d{2}-/, "").replace(/\.md$/, ""), title: fm.title };
     }
     if (newest) {
@@ -193,8 +198,100 @@ if (indexHtml) {
   }
 }
 
+// Capture Corner stale-link guard: no built page may still point to
+// /intel/capture-intelligence-this-issue/ as a "this week's issue" CTA
+// — that's the old hardcoded route. Capture-corner.html's CTA must use
+// /capture-corner/latest. Other site pages can continue to deep-link
+// to /intel/... directly (that is still the canonical issue page).
+{
+  const ccHtml = readDistFile("/capture-corner");
+  if (ccHtml) {
+    if (/Read this week's issue|Open this week's issue/.test(ccHtml) && /href="\/intel\/capture-intelligence-this-issue/.test(ccHtml.match(/cc-btn cc-btn-primary[^<]*<[\s\S]{0,200}/g)?.join("\n") || "")) {
+      // Soft check — only fail if the primary CTA is hardcoded.
+      const primaryCta = ccHtml.match(/<a[^>]*class="cc-btn cc-btn-primary"[^>]*href="([^"]+)"/);
+      if (primaryCta && primaryCta[1] === "/intel/capture-intelligence-this-issue/") {
+        failures.push({ feature: "Capture Corner", url: "/capture-corner", kind: "primary_cta_hardcoded_to_intel_route", observed: primaryCta[1], expected: "/capture-corner/latest" });
+      }
+    }
+  }
+}
+
+// Pursuit Calendar generic-dashboard guard: the page must NOT be a
+// generic Premium Dashboard. Has to contain "90-Day Deadline Tracker"
+// AND distinct categories.
+{
+  const calHtml = readDistFile("/premium/calendar.html") || readDistFile("/pursuit-calendar");
+  if (calHtml) {
+    const hasTracker = calHtml.includes("90-Day Deadline Tracker");
+    const hasCategories = ["RFI", "Industry Day", "Final RFP", "Proposal Due"].filter((c) => calHtml.includes(c)).length >= 3;
+    if (!hasTracker) failures.push({ feature: "Pursuit Calendar", url: "/premium/calendar.html", kind: "calendar_missing_90day_tracker_signature" });
+    if (!hasCategories) failures.push({ feature: "Pursuit Calendar", url: "/premium/calendar.html", kind: "calendar_missing_pursuit_categories" });
+    // The page <title> must NOT be "Premium Dashboard" — only the
+    // small dash-shell chip can carry that text.
+    const titleMatch = calHtml.match(/<title>([^<]+)<\/title>/i);
+    if (titleMatch && /^Premium Dashboard\b/i.test(titleMatch[1].trim())) {
+      failures.push({ feature: "Pursuit Calendar", url: "/premium/calendar.html", kind: "calendar_title_is_generic_premium_dashboard", observed: titleMatch[1] });
+    }
+  }
+}
+
+// Friday Brief raw-marker guard: dist must NOT contain unsubstituted
+// BUILD:BRIEF_ARCHIVE or BUILD:BRIEF_LATEST markers.
+{
+  for (const p of ["/premium/briefings.html", "/premium/briefings"]) {
+    const bHtml = readDistFile(p);
+    if (bHtml && /<!--\s*BUILD:BRIEF_(ARCHIVE|LATEST)\s*-->/.test(bHtml)) {
+      failures.push({ feature: "Friday Brief Archive", url: p, kind: "raw_build_marker_leaked" });
+    }
+  }
+}
+
+// Stale paid-tools anchor guard: no built page may still point to
+// /resources#paid-tools or /resources.html#paid-tools.
+{
+  const fs2 = require("fs");
+  const path2 = require("path");
+  function walkDist(d) {
+    const out = [];
+    for (const e of fs2.readdirSync(d, { withFileTypes: true })) {
+      if (e.name === ".git") continue;
+      const full = path2.join(d, e.name);
+      if (e.isDirectory()) out.push(...walkDist(full));
+      else if (e.name.endsWith(".html")) out.push(full);
+    }
+    return out;
+  }
+  const distFiles = walkDist(DIST);
+  const offenders = [];
+  for (const f of distFiles) {
+    const txt = fs2.readFileSync(f, "utf8");
+    if (/href="(?:\/resources(?:\.html)?#paid-tools)"/.test(txt)) {
+      offenders.push(path2.relative(DIST, f));
+    }
+  }
+  if (offenders.length > 0) {
+    failures.push({ feature: "Homepage / nav", url: "*", kind: "stale_paid_tools_anchor_in_dist", offenders: offenders.slice(0, 5), total: offenders.length });
+  }
+}
+
+// RFP Shredder live-implication guard: the marketing page may not
+// claim live functionality unless an integration flag is set.
+{
+  const rfpHtml = readDistFile("/rfp-shredder");
+  if (rfpHtml) {
+    const claimsLive = /(run a live|live analysis runs on this domain|paste here for instant analysis)/i.test(rfpHtml);
+    const labelsBeta = /(Private Beta|private[_\- ]beta|in private beta)/i.test(rfpHtml);
+    if (claimsLive && !process.env.RFP_SHREDDER_LIVE) {
+      failures.push({ feature: "RFP Shredder", url: "/rfp-shredder", kind: "rfp_shredder_claims_live_without_integration_flag" });
+    }
+    if (!labelsBeta) {
+      failures.push({ feature: "RFP Shredder", url: "/rfp-shredder", kind: "rfp_shredder_missing_private_beta_label" });
+    }
+  }
+}
+
 if (failures.length === 0) {
-  console.log(`validate-routes: ✓ all ${registry.features.length} features resolve, signatures + archive + /latest + homepage CTA + calendar + tools hub checks pass`);
+  console.log(`validate-routes: ✓ all ${registry.features.length} features resolve, signatures + archive + /latest + homepage CTA + calendar + tools hub + capture-corner + brief + paid-tools-anchor + RFP-shredder checks pass`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

Two parallel deliverables on one branch:

1. **May 1 release staged for automatic publication** — newsletter article future-date-gated, Premium Capture Sheet + Contracts Tracker Update saved to `data/may-1-release/`, full runbook documented.
2. **Subscriber-surface stabilization sprint** — 8 tickets covering Capture Corner routing, Pursuit Calendar verification, Friday Brief regression guards, Tools hub, RFP Shredder safety, ops rollup extensions, validators.
3. **Bonus fix:** double-sidebar bug on every premium page (build's `injectDashShell` was wrapping pages whose source files already contained their own dash-shell). Fixed.

## Tickets completed

| # | Ticket | Status |
|---|---|---|
| 1 | Capture Corner `/capture-corner/latest` dynamic routing | ✓ |
| 2 | Pursuit Calendar 90-Day Deadline Tracker signature validation | ✓ |
| 3 | Friday Brief regression guard | ✓ |
| 4 | Tools hub + RFP Shredder Private Beta label | ✓ |
| 5 | Subscriber smoke checklist update | ✓ |
| 6 | Ops health rollup extensions | ✓ |
| 7 | RFP Shredder safety audit | ✓ |
| 8 | Regression validators consolidation | ✓ |

Plus: **double-sidebar bug** stripped pre-existing source-page dash-shells in `injectDashShell` so canonical injected sidebar is the single source of truth across all premium pages.

## Files changed

- `build.js` — future-date gating in `loadArticles`, double-sidebar strip in `injectDashShell`.
- `capture-corner.html` — primary CTAs now point to `/capture-corner/latest`.
- `content/newsletter/2026-05-01-the-architecture-va-asks-for.md` — staged future-dated article.
- `data/may-1-release/{contracts-tracker-update.md,premium-capture-sheet.md}` — staged for Mary's manual deploy on May 1.
- `docs/may-1-release-runbook.md` — full release schedule + verification + rollback.
- `docs/manual-subscriber-smoke-checklist.md` — added explicit checks for capture-corner CTA, /latest pursuit calendar title, brief markers, single-sidebar regression, homepage CTA href.
- `netlify.toml` — added `/capture-corner/latest` 302; removed duplicate `/capture-corner` redirect; build chain now runs `capture-corner-inventory.js`.
- `package.json` — same build chain extension.
- `scripts/capture-corner-inventory.js` (new) — emits `reports/capture-corner-inventory.json`.
- `scripts/newsletter-inventory.js` — honors future-date gate.
- `scripts/ops-health-rollup.js` — adds capture_corner_inventory, pursuit_calendar, tools_hub, homepage_choose_a_tool, rfp_shredder sections.
- `scripts/validate-routes.js` — capture-corner stale-link guard, calendar signature/title-not-generic guard, brief raw-marker guard, stale paid-tools-anchor guard, RFP Shredder live-implication guard.

## Local verification

- `node build.js` — 104 articles published, 1 HOLDING (May 1 future-dated), content-freshness audit passes
- `node scripts/validate-dist.js` — OK 308 dist pages
- `node scripts/validate-routes.js` — ✓ all 16 features + 11 signature checks pass
- `node scripts/capture-corner-inventory.js` — candidates=3, newest=canonical, redirect_target=/intel/capture-intelligence-this-issue/, stale=false
- `node scripts/ops-health-rollup.js` — routes 16/16, latest in /latest=true, brief cards=4, ████=0
- `npx vitest run tests/unit` — 145/145

Gate-check greps:
- ✓ No `BUILD:BRIEF_*` markers in dist
- ✓ Calendar contains "90-Day Deadline Tracker" + RFI/Industry Day/Final RFP/Proposal Due
- ✓ Briefings `<title>` is "The Friday Brief — MMT Premium"
- ✓ All 3 homepage `Choose a Tool` CTAs href=`/tools`
- ✓ Zero `/resources#paid-tools` anchors in dist
- ✓ Zero `████` blocks in dist
- ✓ Each premium page has exactly 1 `<nav class="dash-nav">` (double-sidebar fix verified)

## Test plan

- [ ] Mary reviews May 1 article body against the version in her Claude Project
- [ ] Mary confirms staged tracker + capture sheet content
- [ ] Merge → Netlify deploys → live curl gate checks pass
- [ ] May 1 at 09:00 ET: trigger Netlify rebuild via build hook to publish article on the LinkedIn anchor
- [ ] May 1 at 12:00 ET: Mary integrates contracts tracker update into `contracts.json` or pastes into `/contract-tracker.html`
- [ ] May 1 06:00 ET: Mary emails Premium Capture Sheet to subscribers (separate workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)