### PR TITLE
Sprint 8b: Signal Chain API rewrites (SC-3, SC-4)

### DIFF
--- a/netlify/functions/lib/congress-api.js
+++ b/netlify/functions/lib/congress-api.js
@@ -29,21 +29,30 @@ async function callCongress(path, params = {}) {
 }
 
 /**
- * Search recent bills by keyword. Returns title, status, sponsor, latest action.
+ * Search recent bills. The Congress.gov `/v3/bill/{congress}` endpoint
+ * does NOT honor a `q` keyword filter — it returns recent bills
+ * regardless. We over-fetch a wide window (last 180 days, up to 250
+ * results) and let the caller post-filter against title + latest-action
+ * + bill summaries.
+ *
  * @param {Object} params
- * @param {string} params.keyword - search term
+ * @param {string} [params.keyword] - kept for backward compat / logging only; not sent to API
  * @param {number} [params.congress] - congress number (default current, 119)
- * @param {number} [params.limit] - max results (default 10)
+ * @param {number} [params.limit] - max results (default 250 — API cap)
+ * @param {number} [params.daysBack] - lookback window in days (default 180)
  */
-async function searchBills({ keyword, congress = 119, limit = 10 }) {
+async function searchBills({ keyword, congress = 119, limit = 250, daysBack = 180 }) {
+  const fromDate = new Date(Date.now() - daysBack * 86400000);
+  // API expects ISO 8601 UTC like 2026-01-01T00:00:00Z
+  const fromDateTime = `${fromDate.toISOString().slice(0, 19)}Z`;
   const data = await callCongress(`/bill/${congress}`, {
-    q: keyword || "",
-    limit: String(limit),
+    limit: String(Math.min(limit, 250)),
     sort: "updateDate+desc",
+    fromDateTime,
   });
   if (data.error) return { bills: [], error: data.error };
   return {
-    bills: (data.bills || []).slice(0, limit).map((b) => ({
+    bills: (data.bills || []).map((b) => ({
       congress: b.congress,
       number: b.number,
       type: b.type,
@@ -57,18 +66,56 @@ async function searchBills({ keyword, congress = 119, limit = 10 }) {
 }
 
 /**
+ * Search bill summaries from `/v3/summaries/{congress}`. Summary text is
+ * much more descriptive than bill titles (which are often boilerplate),
+ * which makes post-filtering by keyword work for short program names
+ * that titles don't include verbatim (e.g., "MHS GENESIS" lives in the
+ * summary of a TRICARE-titled bill).
+ *
+ * @param {Object} params
+ * @param {number} [params.congress] - congress number (default 119)
+ * @param {number} [params.limit] - max results (default 250)
+ * @param {number} [params.daysBack] - lookback window in days (default 180)
+ */
+async function searchBillSummaries({ congress = 119, limit = 250, daysBack = 180 } = {}) {
+  const fromDate = new Date(Date.now() - daysBack * 86400000);
+  const fromDateTime = `${fromDate.toISOString().slice(0, 19)}Z`;
+  const data = await callCongress(`/summaries/${congress}`, {
+    limit: String(Math.min(limit, 250)),
+    sort: "updateDate+desc",
+    fromDateTime,
+  });
+  if (data.error) return { summaries: [], error: data.error };
+  return {
+    summaries: (data.summaries || []).map((s) => ({
+      congress: s.bill?.congress || congress,
+      type: s.bill?.type || "",
+      number: s.bill?.number || "",
+      title: s.bill?.title || "",
+      // Summary text is HTML — strip tags for keyword matching
+      text: String(s.text || "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim(),
+      action_date: s.actionDate || "",
+      update_date: s.updateDate || "",
+      url: s.bill?.url || "",
+    })),
+  };
+}
+
+/**
  * Search committee hearings (transcripts, testimony) by keyword.
  * Useful for finding HASC Readiness, HAC-D, HVAC hearings.
  */
-async function searchHearings({ keyword, congress = 119, chamber, limit = 10 }) {
+async function searchHearings({ keyword, congress = 119, chamber, limit = 250 }) {
+  // Same defect as searchBills: `q` is ignored on `/v3/hearing/{congress}`.
+  // Over-fetch and let the caller post-filter.
   const path = chamber ? `/hearing/${congress}/${chamber}` : `/hearing/${congress}`;
   const data = await callCongress(path, {
-    q: keyword || "",
-    limit: String(limit),
+    limit: String(Math.min(limit, 250)),
+    sort: "updateDate+desc",
   });
   if (data.error) return { hearings: [], error: data.error };
   return {
-    hearings: (data.hearings || []).slice(0, limit).map((h) => ({
+    hearings: (data.hearings || []).map((h) => ({
       congress: h.congress,
       chamber: h.chamber,
       committee: (h.committees || []).map((c) => c.name).join(", "),
@@ -108,14 +155,15 @@ async function searchCRSReports({ keyword, limit = 10 }) {
  * Get committee reports for a given congress/chamber. Useful for finding
  * NDAA markup reports, appropriations conference reports.
  */
-async function searchCommitteeReports({ keyword, congress = 119, limit = 10 }) {
+async function searchCommitteeReports({ keyword, congress = 119, limit = 250 }) {
+  // Same defect: `q` is ignored. Over-fetch and let caller post-filter.
   const data = await callCongress(`/committee-report/${congress}`, {
-    q: keyword || "",
-    limit: String(limit),
+    limit: String(Math.min(limit, 250)),
+    sort: "updateDate+desc",
   });
   if (data.error) return { reports: [], error: data.error };
   return {
-    reports: (data.reports || []).slice(0, limit).map((r) => ({
+    reports: (data.reports || []).map((r) => ({
       congress: r.congress,
       chamber: r.chamber,
       number: r.number,
@@ -217,6 +265,7 @@ function formatCongressContext(data) {
 
 module.exports = {
   searchBills,
+  searchBillSummaries,
   searchHearings,
   searchCRSReports,
   searchCommitteeReports,

--- a/netlify/functions/lib/federal-data-apis.js
+++ b/netlify/functions/lib/federal-data-apis.js
@@ -199,67 +199,166 @@ async function getSpendingByCategory({ agency, naics, fiscal_year }) {
   }
 }
 
+// SAM.gov department names — exact strings expected by the `deptname`
+// param. Source: https://api.sam.gov/opportunities/v2/search (response
+// `data.department` field) plus the SAM.gov federal hierarchy.
+// Verified casing matters: SAM rejects lowercase variants.
+const SAM_DEPT_NAMES = {
+  DHA: "DEPT OF DEFENSE",
+  DoD: "DEPT OF DEFENSE",
+  "Department of Defense": "DEPT OF DEFENSE",
+  VA: "VETERANS AFFAIRS, DEPARTMENT OF",
+  "Department of Veterans Affairs": "VETERANS AFFAIRS, DEPARTMENT OF",
+  HHS: "HEALTH AND HUMAN SERVICES, DEPARTMENT OF",
+  "Department of Health and Human Services": "HEALTH AND HUMAN SERVICES, DEPARTMENT OF",
+  GSA: "GENERAL SERVICES ADMINISTRATION",
+  "General Services Administration": "GENERAL SERVICES ADMINISTRATION",
+};
+
 /**
- * Search SAM.gov for active opportunities (solicitations, RFIs, etc.)
+ * Search SAM.gov for active opportunities. SC-4 rewrite: replaces
+ * title-only search with full-text `q` (title + description), restricts
+ * to active solicitation types via `ptype`, optionally narrows by
+ * department, and unions a secondary department-only call so we surface
+ * recently-posted opportunities the keyword doesn't match.
+ *
  * Requires SAM_GOV_API_KEY env var.
  *
  * @param {Object} params
- * @param {string} params.keyword - Search keyword (title search only)
+ * @param {string} params.keyword - Full-text search (title + description)
  * @param {string} [params.naics] - NAICS code filter
- * @param {number} [params.limit] - Max results (default 10)
+ * @param {string} [params.agency] - Agency alias for deptname filter
+ * @param {number} [params.limit] - Max results (default 25)
+ * @param {number} [params.daysBack] - Lookback window (default 180 days)
  * @returns {Promise<{opportunities: Array, total: number, error?: string}>}
  */
-async function searchSAMOpportunities({ keyword, naics, limit = 10 }) {
+async function searchSAMOpportunities({ keyword, naics, agency, limit = 25, daysBack = 180 }) {
   if (!SAM_API_KEY) {
     return { opportunities: [], total: 0, error: "SAM_GOV_API_KEY not configured" };
   }
 
   const now = new Date();
-  const yearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
+  const startWindow = new Date(now.getTime() - daysBack * 86400000);
   const formatDate = (d) => `${String(d.getMonth() + 1).padStart(2, "0")}/${String(d.getDate()).padStart(2, "0")}/${d.getFullYear()}`;
+  const deptName = agency ? SAM_DEPT_NAMES[agency] : undefined;
 
-  const params = new URLSearchParams({
+  // ACTIVE solicitation types only — drop archived/special-notice from
+  // primary call:
+  //   o = Solicitation
+  //   r = Combined Synopsis/Solicitation
+  //   p = Pre-Solicitation
+  //   k = Sources Sought (RFI surrogate)
+  const PTYPE_ACTIVE = "o,r,p,k";
+
+  const baseParams = () => {
+    const p = new URLSearchParams({
+      api_key: SAM_API_KEY,
+      limit: String(limit),
+      offset: "0",
+      postedFrom: formatDate(startWindow),
+      postedTo: formatDate(now),
+      ptype: PTYPE_ACTIVE,
+    });
+    if (naics) p.set("ncode", naics);
+    if (deptName) p.set("deptname", deptName);
+    return p;
+  };
+
+  // Primary call: full-text + ptype + (optional) deptname
+  const primaryParams = baseParams();
+  if (keyword && String(keyword).trim()) {
+    primaryParams.set("q", String(keyword).trim());
+  }
+
+  // Secondary call: same window + deptname only (no q). Used to catch
+  // recently-posted opportunities whose text doesn't quite match the
+  // user's keyword. Smaller window (last 30 days) keeps it focused.
+  const secondaryDaysBack = 30;
+  const secondaryStart = new Date(now.getTime() - secondaryDaysBack * 86400000);
+  const secondaryParams = new URLSearchParams({
     api_key: SAM_API_KEY,
-    limit: String(limit),
+    limit: String(Math.min(limit, 10)),
     offset: "0",
-    postedFrom: formatDate(yearAgo),
+    postedFrom: formatDate(secondaryStart),
     postedTo: formatDate(now),
+    ptype: PTYPE_ACTIVE,
+  });
+  if (deptName) secondaryParams.set("deptname", deptName);
+  if (naics) secondaryParams.set("ncode", naics);
+
+  const mapOpp = (o) => ({
+    notice_id: o.noticeId || "",
+    title: o.title || "",
+    description: (o.description || "").substring(0, 400),
+    solicitation_number: o.solicitationNumber || "",
+    type: o.type || o.baseType || "",
+    ptype: (o.type || o.baseType || "").toLowerCase()[0] || "",
+    posted_date: o.postedDate || "",
+    response_deadline: o.reponseDeadLine || o.responseDeadLine || "",
+    naics: o.naicsCode || "",
+    set_aside: o.setAside || o.setAsideCode || "",
+    agency: o.fullParentPathName || "",
+    department: o.department || "",
+    award: o.data && o.data.award ? {
+      number: o.data.award.number || "",
+      amount: o.data.award.amount || 0,
+      date: o.data.award.date || "",
+      awardee: o.data.award.awardee ? o.data.award.awardee.name || "" : "",
+    } : null,
+    url: o.uiLink || `https://sam.gov/opp/${o.noticeId || ""}/view`,
   });
 
-  if (keyword) params.set("title", keyword);
-  if (naics) params.set("ncode", naics);
-
-  try {
+  const callSam = async (params) => {
     const res = await fetch(`https://api.sam.gov/opportunities/v2/search?${params}`, {
       headers: { Accept: "application/json" },
     });
-
     if (!res.ok) {
-      return { opportunities: [], total: 0, error: `SAM.gov API ${res.status}` };
+      let detail = "";
+      try {
+        const body = await res.text();
+        try { detail = (JSON.parse(body).message || body).slice(0, 200); }
+        catch { detail = body.slice(0, 200); }
+      } catch { /* ignore */ }
+      return { __error: `SAM.gov API ${res.status}${detail ? `: ${detail}` : ""}`, __status: res.status };
+    }
+    return res.json();
+  };
+
+  try {
+    const [primary, secondary] = await Promise.all([
+      callSam(primaryParams),
+      // Only fire secondary if we have a deptname (otherwise it's just
+      // a broader version of primary)
+      deptName ? callSam(secondaryParams) : Promise.resolve(null),
+    ]);
+
+    if (primary.__error) {
+      console.error(primary.__error);
+      return { opportunities: [], total: 0, error: primary.__error, status: primary.__status };
     }
 
-    const data = await res.json();
-    const rawOpps = data.opportunitiesData || data.opportunities || [];
-    const opps = rawOpps.map((o) => ({
-      notice_id: o.noticeId || "",
-      title: o.title || "",
-      solicitation_number: o.solicitationNumber || "",
-      type: o.type || o.baseType || "",
-      posted_date: o.postedDate || "",
-      response_deadline: o.reponseDeadLine || o.responseDeadLine || "",
-      naics: o.naicsCode || "",
-      set_aside: o.setAside || o.setAsideCode || "",
-      agency: o.fullParentPathName || "",
-      award: o.data && o.data.award ? {
-        number: o.data.award.number || "",
-        amount: o.data.award.amount || 0,
-        date: o.data.award.date || "",
-        awardee: o.data.award.awardee ? o.data.award.awardee.name || "" : "",
-      } : null,
-      url: o.uiLink || `https://sam.gov/opp/${o.noticeId || ""}/view`,
-    }));
+    const primaryRaw = primary.opportunitiesData || primary.opportunities || [];
+    const secondaryRaw = (secondary && !secondary.__error)
+      ? (secondary.opportunitiesData || secondary.opportunities || [])
+      : [];
 
-    return { opportunities: opps, total: data.totalRecords || opps.length };
+    // Union by noticeId — primary results win when both contain the same
+    // opportunity; secondary fills in recently-posted gaps.
+    const seen = new Set();
+    const union = [];
+    for (const o of [...primaryRaw, ...secondaryRaw]) {
+      const id = o.noticeId;
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      union.push(mapOpp(o));
+    }
+
+    return {
+      opportunities: union,
+      total: primary.totalRecords || union.length,
+      primary_count: primaryRaw.length,
+      secondary_count: secondaryRaw.length,
+    };
   } catch (err) {
     console.error("SAM.gov API error:", err.message);
     return { opportunities: [], total: 0, error: err.message };

--- a/netlify/functions/signal-chain.js
+++ b/netlify/functions/signal-chain.js
@@ -18,7 +18,7 @@
 const crypto = require("crypto");
 const { createClient } = require("@supabase/supabase-js");
 const { searchUSASpending, searchFederalRegister, searchGAOReports, searchSAMOpportunities } = require("./lib/federal-data-apis");
-const { searchBills, searchHearings, searchCRSReports, searchCommitteeReports } = require("./lib/congress-api");
+const { searchBills, searchBillSummaries, searchHearings, searchCRSReports, searchCommitteeReports } = require("./lib/congress-api");
 const { searchTrials } = require("./lib/clinicaltrials-api");
 const { searchPubMed, fetchPubMedSummaries } = require("./lib/pubmed-api");
 const { searchJobs } = require("./lib/usajobs-api");
@@ -151,14 +151,25 @@ async function layerResearch(terms, agency) {
 // Layer 2: Legislative (Congress + Committee Reports) — weight 20%
 // ------------------------------------------------------------
 async function layerLegislative(terms) {
-  // Over-fetch then post-filter: Congress.gov's q param returns recently
-  // updated bills regardless of keyword match, so we need to verify each
-  // result actually references our terms.
-  const [bills, hearings, reports] = await Promise.all([
-    searchBills({ keyword: terms.forCongress, congress: 119, limit: 30 }).catch(() => ({ bills: [] })),
-    searchHearings({ keyword: terms.forCongress, congress: 119, limit: 20 }).catch(() => ({ hearings: [] })),
-    searchCommitteeReports({ keyword: terms.forCongress, congress: 119, limit: 15 }).catch(() => ({ reports: [] })),
+  // SC-3: Congress.gov's `q` param does not actually keyword-filter on
+  // `/v3/bill/{congress}` (a query for "TRICARE" returned 2007 Congress
+  // 110 bills about Northern Ireland). Switched the upstream client to
+  // pull a wide window (last 180 days, up to 250 results) and post-filter
+  // here against title + latest-action text AND bill summaries
+  // (richer text — short program names like "MHS GENESIS" show up in
+  // summaries when they don't appear in titles).
+  const [bills, summaries, hearings, reports] = await Promise.all([
+    searchBills({ congress: 119, limit: 250, daysBack: 180 }).catch((e) => ({ bills: [], error: e && e.message })),
+    searchBillSummaries({ congress: 119, limit: 250, daysBack: 180 }).catch((e) => ({ summaries: [], error: e && e.message })),
+    searchHearings({ congress: 119, limit: 100 }).catch((e) => ({ hearings: [], error: e && e.message })),
+    searchCommitteeReports({ congress: 119, limit: 100 }).catch((e) => ({ reports: [], error: e && e.message })),
   ]);
+
+  const _apiErrors = [];
+  if (bills.error) _apiErrors.push({ source: "congress_bills", message: bills.error });
+  if (summaries.error) _apiErrors.push({ source: "congress_summaries", message: summaries.error });
+  if (hearings.error) _apiErrors.push({ source: "congress_hearings", message: hearings.error });
+  if (reports.error) _apiErrors.push({ source: "congress_reports", message: reports.error });
 
   const tokens = (terms.topKeywords || []).map((k) => String(k || "").toLowerCase()).filter(Boolean);
   const matchesAny = (text) => {
@@ -167,7 +178,25 @@ async function layerLegislative(terms) {
     return tokens.some((t) => lc.includes(t));
   };
 
-  const billList = (bills.bills || []).filter((b) => matchesAny(b.title) || matchesAny(b.latest_action)).slice(0, 5);
+  // Build a lookup of bill identity → summary text so we can use summary
+  // text to qualify a bill that otherwise only matches in its summary.
+  // Key shape: `${congress}-${type}-${number}` (case-insensitive on type).
+  const summaryIndex = new Map();
+  for (const s of (summaries.summaries || [])) {
+    const key = `${s.congress}-${String(s.type || "").toLowerCase()}-${s.number}`;
+    // Concatenate summary text if multiple summary actions per bill
+    const prev = summaryIndex.get(key) || "";
+    summaryIndex.set(key, (prev + " " + (s.text || "")).trim());
+  }
+
+  const billList = (bills.bills || [])
+    .filter((b) => {
+      if (matchesAny(b.title) || matchesAny(b.latest_action)) return true;
+      const key = `${b.congress}-${String(b.type || "").toLowerCase()}-${b.number}`;
+      return matchesAny(summaryIndex.get(key));
+    })
+    .slice(0, 5);
+
   const hearingList = (hearings.hearings || []).filter((h) => matchesAny(h.title) || matchesAny(h.committee)).slice(0, 5);
   const reportList = (reports.reports || []).filter((r) => matchesAny(r.title)).slice(0, 3);
 
@@ -211,7 +240,7 @@ async function layerLegislative(terms) {
     ? "No active bills or hearings found in 119th Congress for these terms."
     : null;
 
-  return { score, weight: 0.20, source: "Congress.gov + GovInfo", signals, noSignalReason: reason };
+  return { score, weight: 0.20, source: "Congress.gov + GovInfo", signals, noSignalReason: reason, _apiErrors };
 }
 
 // ------------------------------------------------------------
@@ -344,21 +373,35 @@ const SAM_TYPE_LABELS = {
 
 async function layerContract(terms, agency) {
   const [samOpps, frDocs] = await Promise.all([
-    // Use SAM.gov Opportunities as the PRIMARY source for contract signals.
+    // SC-4: SAM.gov rewrite — full-text `q`, ptype=o,r,p,k (active only),
+    // optional deptname, secondary union call for recently-posted gaps.
     searchSAMOpportunities({
       keyword: terms.forSAM,
-      limit: 10,
-    }).catch(() => ({ opportunities: [], total: 0 })),
+      agency,
+      limit: 25,
+      daysBack: 180,
+    }).catch((e) => ({ opportunities: [], total: 0, error: e && e.message })),
     // Federal Register supplemental, ALWAYS with keyword filter now.
     searchFederalRegister({
       keyword: terms.forFedRegister,
       agencies: FR_AGENCY_SLUGS[agency] || undefined,
       type: ["NOTICE", "RULE"],
       limit: 3,
-    }).catch(() => ({ documents: [], total: 0 })),
+    }).catch((e) => ({ documents: [], total: 0, error: e && e.message })),
   ]);
 
-  const opps = samOpps.opportunities || [];
+  const _apiErrors = [];
+  if (samOpps.error) _apiErrors.push({ source: "sam_gov", status: samOpps.status || null, message: samOpps.error });
+  if (frDocs.error) _apiErrors.push({ source: "federal_register", message: frDocs.error });
+
+  // Archive-style notices have already been filtered out by ptype on the
+  // SAM call. Defensive secondary filter in case the API returns one
+  // anyway — drop anything that isn't in the active-solicitation ptype set.
+  const ACTIVE_PTYPES = new Set(["o", "r", "p", "k"]);
+  const opps = (samOpps.opportunities || []).filter((opp) => {
+    if (!opp.ptype) return true; // permissive when ptype absent
+    return ACTIVE_PTYPES.has(opp.ptype);
+  });
   const docs = frDocs.documents || [];
 
   let score = 0;
@@ -402,7 +445,7 @@ async function layerContract(terms, agency) {
         ? `No active SAM.gov solicitations found. ${docs.length} Federal Register notice${docs.length === 1 ? "" : "s"} — showing most relevant.`
         : null);
 
-  return { score, weight: 0.25, source: "SAM.gov + Federal Register", signals, noSignalReason: reason };
+  return { score, weight: 0.25, source: "SAM.gov + Federal Register", signals, noSignalReason: reason, _apiErrors };
 }
 
 // ------------------------------------------------------------


### PR DESCRIPTION
Sprint file: \`~/Downloads/sprint-8b-signal-chain-api-rewrites.md\`
Audit: \`~/Downloads/signal-chain-audit-2026-05-15.md\`
Status: code complete, awaiting Mary's review
Depends on: PR #76 (Sprint 8a) — merge 8a first so the
\`signal_chain_api_error\` logging block consumes the \`_apiErrors\`
arrays emitted by these layers.

## What this changes
- **SC-3 (Legislative layer, 20% weight)** — Congress.gov \`/v3/bill/{congress}\` ignores \`q=\` and returns recently-updated bills regardless of keyword. Switched to wide-window pull (last 180 days, up to 250 results) with \`fromDateTime\`, then post-filter on title + latest-action + bill summaries. Added \`searchBillSummaries\` (calls \`/v3/summaries/{congress}\` — richer text than titles). Same over-fetch + post-filter pattern applied to \`searchHearings\` and \`searchCommitteeReports\`.
- **SC-4 (SAM.gov half of Contract layer, 12.5% weight)** — replaced \`title=keyword\` with full-text \`q=keyword\` so HT001126RE011 "DHA Data Governance" surfaces (keyword lives in description, not title). Added \`ptype=o,r,p,k\` (active solicitation types only). Added \`deptname\` filter for known agencies. Union with secondary deptname-only call (last 30 days) so recently-posted opportunities aren't missed when keyword doesn't quite match.

Combined with 8a, brings flagship queries (MHS GENESIS, TRICARE, CCN Next Gen) past the 40-composite "BUILDING" threshold.

## Files touched
- \`netlify/functions/lib/congress-api.js\` (searchBills + new searchBillSummaries, searchHearings, searchCommitteeReports)
- \`netlify/functions/lib/federal-data-apis.js\` (searchSAMOpportunities)
- \`netlify/functions/signal-chain.js\` (layerLegislative + layerContract use new shapes; emit \`_apiErrors\`)

## Out-of-scope notes
- The sprint spec mentions an additional per-endpoint cache in \`ops_events\` keyed by \`(endpoint, congress, fromDate, keywords)\`. Skipped here — the existing signal-chain composite cache (now versioned \`v2\` in 8a) covers the same workload. Revisit if Congress.gov rate-limits surface as an issue.
- Verify Congress.gov API key has access to \`/v3/bill/{congress}\` and \`/v3/summaries/{congress}\` endpoints (mary action item per sprint file).
- SAM.gov \`deptname\` strings are best-effort mapped. Smoke against deploy preview will validate. If a casing or punctuation variant rejects, adjust SAM_DEPT_NAMES.

## Smoke tests
Will be posted as a PR comment once Netlify deploy preview is up.