### PR TITLE
Sprint 9a: Pursuit Score 2.0 — Phase A + B (schema + state engine, flag-gated)

### DIFF
--- a/data/subscriber-context/mary-womack-seed.json
+++ b/data/subscriber-context/mary-womack-seed.json
@@ -82,5 +82,10 @@
     "Oracle Health",
     "GDIT"
   ],
-  "teaming_no_fly": []
+  "teaming_no_fly": [],
+  "position_history": [],
+  "jv_partnerships": [],
+  "agency_relationships": [],
+  "editorial_calendar": [],
+  "__v2_todo": "TODO(mary): backfill v2 fields. position_history needs AFS-on-HELM sub contract # + PoP + scope. jv_partnerships needs AFS partnership type (SBA M/P vs JV vs teaming) + dates + scope. agency_relationships optional but valuable (VA/DHA/DoD alumni/advisory seats). editorial_calendar needed if running Pursuit Score in platform mode. Until backfilled, HELM scoring lands on INSUFFICIENT_DATA per Sprint 9a acceptance test."
 }

--- a/migrations/20260516000000_subscriber_context_v2.sql
+++ b/migrations/20260516000000_subscriber_context_v2.sql
@@ -1,0 +1,113 @@
+-- ============================================================
+-- 20260516000000_subscriber_context_v2.sql
+--
+-- Subscriber Context v2 — adds position_history, jv_partnerships,
+-- agency_relationships, editorial_calendar JSONB columns so the
+-- Pursuit Score 2.0 state engine (Sprint 9a Phase B) can classify
+-- recommendation states like SUB_TO_INCUMBENT, JV_TEAMING,
+-- EDITORIAL_TARGET.
+--
+-- ADDITIVE ONLY + IDEMPOTENT. Every column is nullable with a
+-- '[]'::jsonb default so v1 readers (those still expecting only the
+-- 008 columns) stay green. v2 readers fall back to empty arrays
+-- when the column is absent.
+--
+-- Spec: ~/Downloads/sprint-9a-pursuit-score-phase-a-b.md
+-- Companion: pursuit-score-2.0-completion-spec.md, subscriber-context-v2.md
+--
+-- DO NOT APPLY TO PRODUCTION FROM THE WORKTREE. Mary runs this in
+-- Supabase SQL Editor per the overnight runbook migration gate.
+-- ============================================================
+
+-- Position history: roles held under prior contracts, especially
+-- relevant for SUB_TO_INCUMBENT classification.
+-- Element shape:
+--   {
+--     "contract_number": "HT0011-23-D-...",          (string|null)
+--     "agency": "DHA",                                (string)
+--     "program": "VA SCM DSO (HELM)",                 (string)
+--     "role": "sub|prime|jv_partner|teaming_partner", (enum)
+--     "prime_company": "Accenture Federal Services",  (string|null when self-prime)
+--     "scope": "Free-text scope summary",             (string)
+--     "start_date": "2024-06-01",                     (ISO date)
+--     "end_date": "2027-05-31"                        (ISO date|null when active)
+--   }
+ALTER TABLE subscriber_context
+  ADD COLUMN IF NOT EXISTS position_history jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- JV / mentor-protégé partnerships. Drives JV_TEAMING state.
+-- Element shape:
+--   {
+--     "partner_company": "Accenture Federal Services",
+--     "type": "sba_mentor_protege|jv_agreement|teaming_agreement",
+--     "uei": "ABCD12345678",                          (string|null)
+--     "start_date": "2024-01-15",
+--     "end_date": "2027-01-14",                       (ISO date|null)
+--     "scope_keywords": ["VA EHRM", "imaging", "MHS GENESIS"],
+--     "programs_in_scope": ["VA EHRM Restart", "VA Imaging Portfolio"]
+--   }
+ALTER TABLE subscriber_context
+  ADD COLUMN IF NOT EXISTS jv_partnerships jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- Agency-level relationships separate from prior contracts (alumni,
+-- advisory board seats, FACA, customer-of-record, etc.). Drives
+-- INSIDER_ACCESS scoring boost.
+-- Element shape:
+--   {
+--     "agency": "VA",
+--     "relationship_type": "alumni|advisory_board|faca|customer_of_record",
+--     "subject": "Veterans Health Administration OIT",
+--     "since": "2018-01-01",
+--     "active_through": null,                         (ISO date|null)
+--     "notes": "Free text"
+--   }
+ALTER TABLE subscriber_context
+  ADD COLUMN IF NOT EXISTS agency_relationships jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- Editorial calendar — programs Mary covers as journalist/analyst.
+-- Drives EDITORIAL_TARGET state in platform-mode Pursuit Score so
+-- the engine doesn't recommend "bid on this" for an article topic.
+-- Element shape:
+--   {
+--     "program": "MHS GENESIS Wave 2",
+--     "agency": "DHA",
+--     "next_coverage_date": "2026-06-15",
+--     "coverage_type": "newsletter|capture_corner|monthly_brief|podcast"
+--   }
+ALTER TABLE subscriber_context
+  ADD COLUMN IF NOT EXISTS editorial_calendar jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- Indexes — JSONB GIN indexes for the fields we filter on most often.
+-- All idempotent.
+CREATE INDEX IF NOT EXISTS subscriber_context_position_history_gin
+  ON subscriber_context USING GIN (position_history);
+CREATE INDEX IF NOT EXISTS subscriber_context_jv_partnerships_gin
+  ON subscriber_context USING GIN (jv_partnerships);
+
+-- Schema documentation. `oci_exclusions` already exists in 008;
+-- v2 tightens the expected element shape via comment only (no
+-- breaking schema change).
+COMMENT ON COLUMN subscriber_context.position_history IS
+  'v2: array of position records {contract_number, agency, program, role, prime_company, scope, start_date, end_date}. Role enum: sub|prime|jv_partner|teaming_partner. Drives SUB_TO_INCUMBENT classification in Pursuit Score 2.0.';
+COMMENT ON COLUMN subscriber_context.jv_partnerships IS
+  'v2: array of JV / mentor-protégé records {partner_company, type, uei, start_date, end_date, scope_keywords[], programs_in_scope[]}. Type enum: sba_mentor_protege|jv_agreement|teaming_agreement. Drives JV_TEAMING state.';
+COMMENT ON COLUMN subscriber_context.agency_relationships IS
+  'v2: array of agency relationship records {agency, relationship_type, subject, since, active_through, notes}. Type enum: alumni|advisory_board|faca|customer_of_record.';
+COMMENT ON COLUMN subscriber_context.editorial_calendar IS
+  'v2: array of editorial coverage records {program, agency, next_coverage_date, coverage_type}. Drives EDITORIAL_TARGET state in platform mode.';
+COMMENT ON COLUMN subscriber_context.oci_exclusions IS
+  'v2-tightened: array of OCI records. Element shape: {blocking_contract, blocked_scope, expires (ISO date|null), notes, agency (optional), program_scope (optional)}. No schema change in v2 — comment-only documentation.';
+
+-- Bump context_version on every row so the engine knows v2 fields
+-- are available. Idempotent — only fires once because the column
+-- already triggers via subscriber_context_version_trigger.
+-- This intentionally produces NO writes; the migration relies on
+-- the existing trigger to maintain context_version going forward.
+
+-- Rollback (manual, for reference only — do not run unless reverting):
+--   ALTER TABLE subscriber_context DROP COLUMN IF EXISTS position_history;
+--   ALTER TABLE subscriber_context DROP COLUMN IF EXISTS jv_partnerships;
+--   ALTER TABLE subscriber_context DROP COLUMN IF EXISTS agency_relationships;
+--   ALTER TABLE subscriber_context DROP COLUMN IF EXISTS editorial_calendar;
+--   DROP INDEX IF EXISTS subscriber_context_position_history_gin;
+--   DROP INDEX IF EXISTS subscriber_context_jv_partnerships_gin;

--- a/netlify/functions/lib/company-alignment.js
+++ b/netlify/functions/lib/company-alignment.js
@@ -430,11 +430,322 @@ function combineVerdict({ marketScore, partial, companyFit, capturePosition, sig
   return { verdict: "NO-BID", color: "#E63946", band: "very_low", composite, reason: "Both market signal and company fit are weak; no positive signals detected." };
 }
 
+// ============================================================
+// Pursuit Score v2 — Recommendation State Engine (Sprint 9a Phase B)
+//
+// Emits one of 11 recommendation states per pursuit-score-2.0
+// completion spec §2. Reads v2 subscriber_context fields
+// (position_history, jv_partnerships, agency_relationships,
+// editorial_calendar) with graceful v1 fallback to the existing
+// classifyCapturePosition.
+//
+// Behind PURSUIT_SCORE_V2 feature flag. Caller in pursuit-score-engine
+// switches based on flag state — when off, the v1 ladder runs unchanged.
+// ============================================================
+
+const RECOMMENDATION_STATES = {
+  PRIME_DIRECT:        "PRIME_DIRECT",        // No incumbency conflict; subscriber owns vehicle, capability, agency alignment
+  RECOMPETE_DEFENSE:   "RECOMPETE_DEFENSE",   // Subscriber is incumbent; defensive posture
+  SUB_TO_INCUMBENT:    "SUB_TO_INCUMBENT",    // Subscriber is sub on the incumbent contract (via position_history.role=sub)
+  JV_TEAMING:          "JV_TEAMING",          // Has formal JV / mentor-protégé with active partner relevant to scope
+  WATCH_RFI:           "WATCH_RFI",           // RFI / sources-sought open; shaping window — not yet a bid decision
+  WATCH_DRAFT_RFP:     "WATCH_DRAFT_RFP",     // Draft RFP / pre-solicitation; preparation window
+  OCI_BLOCKED:         "OCI_BLOCKED",         // OCI exclusion matches the opportunity scope
+  EDITORIAL_TARGET:    "EDITORIAL_TARGET",    // Platform-mode: in editorial_calendar, NOT a bid candidate
+  NEW_ENTRY_LONGSHOT:  "NEW_ENTRY_LONGSHOT",  // No incumbency, no JV, no agency relationship — green-field, low odds
+  NO_BID:              "NO_BID",              // On no_go_list OR explicit pass
+  INSUFFICIENT_DATA:   "INSUFFICIENT_DATA",   // Profile loaded but lacks the fields needed to classify confidently
+};
+
+// State → composite-score floor/ceiling. The combineVerdictV2 function
+// uses these to anchor the final composite around the state — so a
+// SUB_TO_INCUMBENT can't return CAPTURE_VALIDATION just because the
+// upstream USASpending call returned thin data (the 4/27 incident).
+const STATE_FLOORS = {
+  PRIME_DIRECT:       { floor: 70, ceiling: 100 },
+  RECOMPETE_DEFENSE:  { floor: 60, ceiling: 100 },
+  SUB_TO_INCUMBENT:   { floor: 60, ceiling: 95 },
+  JV_TEAMING:         { floor: 55, ceiling: 95 },
+  WATCH_RFI:          { floor: 40, ceiling: 70 },
+  WATCH_DRAFT_RFP:    { floor: 45, ceiling: 75 },
+  OCI_BLOCKED:        { floor: 0,  ceiling: 20 },
+  EDITORIAL_TARGET:   { floor: 0,  ceiling: 30 },
+  NEW_ENTRY_LONGSHOT: { floor: 20, ceiling: 50 },
+  NO_BID:             { floor: 0,  ceiling: 20 },
+  INSUFFICIENT_DATA:  { floor: 25, ceiling: 50 }, // permissive — don't bury an opp because the profile is sparse
+};
+
+/**
+ * Match a position_history record against an opportunity by program
+ * name token overlap (case-insensitive).
+ */
+function _positionMatchesOpp(position, kw) {
+  if (!position || !kw) return false;
+  const program = normalize(position.program || "");
+  if (!program) return false;
+  const programTokens = program.split(/\s+/).filter((t) => t.length > 2);
+  // Match if any 3+ char token of the program name appears in the keyword
+  // OR the keyword contains the full program name.
+  return programTokens.some((t) => kw.includes(t)) || kw.includes(program);
+}
+
+/**
+ * Match a jv_partnership against an opportunity via scope_keywords
+ * or programs_in_scope arrays.
+ */
+function _jvMatchesOpp(jv, kw, opp_agency) {
+  if (!jv || !kw) return false;
+  const scopeKeywords = Array.isArray(jv.scope_keywords) ? jv.scope_keywords.map(normalize) : [];
+  const programs = Array.isArray(jv.programs_in_scope) ? jv.programs_in_scope.map(normalize) : [];
+  for (const k of scopeKeywords) {
+    if (k && (kw.includes(k) || k.includes(kw))) return true;
+  }
+  for (const p of programs) {
+    if (p && (kw.includes(p) || p.includes(kw))) return true;
+  }
+  return false;
+}
+
+/**
+ * Match editorial calendar entry against an opportunity by program name.
+ */
+function _editorialMatchesOpp(entry, kw) {
+  if (!entry || !kw) return false;
+  const program = normalize(entry.program || "");
+  return program && (kw.includes(program) || program.includes(kw));
+}
+
+/**
+ * Classify the recommendation state for an opportunity against a v2
+ * subscriber_context profile.
+ *
+ * @param {Object|null} ctx — normalized v2 subscriber context
+ * @param {{ keyword: string, agency?: string, signals?: Array }} opp
+ * @returns {{ state: string, detail: string, reference?: Object, evidence?: Array }}
+ */
+function classifyRecommendationState(ctx, { keyword, agency, signals } = {}) {
+  if (!ctx) {
+    return { state: RECOMMENDATION_STATES.INSUFFICIENT_DATA, detail: "No subscriber_context loaded — cannot classify recommendation state." };
+  }
+  const kw = normalize(keyword);
+  if (!kw) {
+    return { state: RECOMMENDATION_STATES.INSUFFICIENT_DATA, detail: "No opportunity keyword provided." };
+  }
+
+  // Priority 1 — NO_BID (on no_go_list) trumps everything else.
+  const passed = (ctx.no_go_list || []).find((p) =>
+    p.name && (kw.includes(normalize(p.name)) || normalize(p.name).includes(kw))
+  );
+  if (passed) {
+    return {
+      state: RECOMMENDATION_STATES.NO_BID,
+      detail: `On the no-go list (${passed.reason || "reason not recorded"}).`,
+      reference: passed,
+    };
+  }
+
+  // Priority 2 — OCI_BLOCKED.
+  const oci = (ctx.oci_exclusions || []).find((o) =>
+    o.blocked_scope && normalize(o.blocked_scope).split(/\s+/).some((t) => t.length > 3 && kw.includes(t))
+  );
+  if (oci) {
+    return {
+      state: RECOMMENDATION_STATES.OCI_BLOCKED,
+      detail: `OCI exclusion: ${oci.notes || oci.blocked_scope}. Cannot pursue without OCI mitigation.`,
+      reference: oci,
+    };
+  }
+
+  // Priority 3 — EDITORIAL_TARGET (platform mode only — when the
+  // subscriber is acting as journalist/analyst on this program).
+  const editorial = (ctx.editorial_calendar || []).find((e) => _editorialMatchesOpp(e, kw));
+  if (editorial) {
+    return {
+      state: RECOMMENDATION_STATES.EDITORIAL_TARGET,
+      detail: `On editorial calendar (${editorial.coverage_type || "coverage"} planned for ${editorial.next_coverage_date || "unspecified date"}). Not a bid candidate in platform mode.`,
+      reference: editorial,
+    };
+  }
+
+  // Priority 4 — RECOMPETE_DEFENSE (incumbent on recompete).
+  const incumbent = (ctx.incumbent_positions || []).find((p) =>
+    p.name && (kw.includes(normalize(p.name)) || normalize(p.name).includes(kw))
+  );
+  if (incumbent) {
+    return {
+      state: RECOMMENDATION_STATES.RECOMPETE_DEFENSE,
+      detail: `Incumbent: ${incumbent.name}${incumbent.contract_number ? ` (${incumbent.contract_number})` : ""}. Defensive recompete posture.`,
+      reference: incumbent,
+    };
+  }
+
+  // Priority 5 — SUB_TO_INCUMBENT (v2 position_history with role=sub on
+  // an active position relevant to the opportunity scope).
+  const subPosition = (ctx.position_history || []).find((p) =>
+    (p.role === "sub" || p.role === "teaming_partner") &&
+    !p.end_date_passed &&
+    _positionMatchesOpp(p, kw)
+  );
+  if (subPosition) {
+    return {
+      state: RECOMMENDATION_STATES.SUB_TO_INCUMBENT,
+      detail: `Sub to ${subPosition.prime_company || "incumbent prime"} on ${subPosition.program}${subPosition.contract_number ? ` (${subPosition.contract_number})` : ""}. Capture posture: protect sub seat, position for next-cycle prime path.`,
+      reference: subPosition,
+    };
+  }
+
+  // Priority 6 — JV_TEAMING (v2 jv_partnerships with active partner whose
+  // scope_keywords or programs_in_scope cover the opp).
+  const jv = (ctx.jv_partnerships || []).find((j) => _jvMatchesOpp(j, kw, agency));
+  if (jv) {
+    return {
+      state: RECOMMENDATION_STATES.JV_TEAMING,
+      detail: `${jv.type === "sba_mentor_protege" ? "SBA mentor-protégé" : (jv.type === "jv_agreement" ? "Joint venture" : "Teaming agreement")} with ${jv.partner_company}. Active scope coverage.`,
+      reference: jv,
+    };
+  }
+
+  // Priority 7 — Active pursuit (IN_FLIGHT). In v2 this surfaces as
+  // RECOMPETE_DEFENSE-adjacent because we don't want to recommend
+  // pursuing something already in-flight. We model this as
+  // RECOMPETE_DEFENSE for state semantics (defensive posture on
+  // current pursuit).
+  const inflight = (ctx.active_pursuits || []).find((p) => (
+    (p.solicitation_number && kw.includes(normalize(p.solicitation_number))) ||
+    (p.name && (kw.includes(normalize(p.name)) || normalize(p.name).includes(kw)))
+  ));
+  if (inflight) {
+    return {
+      state: RECOMMENDATION_STATES.RECOMPETE_DEFENSE,
+      detail: `In-flight pursuit: ${inflight.name}${inflight.solicitation_number ? ` (${inflight.solicitation_number})` : ""}, stage: ${inflight.stage}. Defensive posture — do not recommend pursuing what's already submitted.`,
+      reference: inflight,
+    };
+  }
+
+  // Priority 8 — Shaping-window signals (RFI / Sources Sought / Draft RFP).
+  const signalTags = Array.isArray(signals) ? new Set(signals.map((s) => s.tag)) : new Set();
+  if (signalTags.has("RFI")) {
+    return {
+      state: RECOMMENDATION_STATES.WATCH_RFI,
+      detail: "RFI / sources-sought signal detected — pre-solicitation shaping window is open.",
+    };
+  }
+  if (signalTags.has("INDUSTRY_DAY")) {
+    return {
+      state: RECOMMENDATION_STATES.WATCH_DRAFT_RFP,
+      detail: "Industry Day signal — RFP typically follows in 60–120 days. Preparation window.",
+    };
+  }
+
+  // Priority 9 — PRIME_DIRECT (target_agencies alignment + capabilities
+  // overlap + no conflicts). This is a "no obstacles, you should bid"
+  // state. Requires the profile to have target_agencies and at least
+  // one of {vehicle_holdings, set_aside_certifications}.
+  const agencyAligned = agencyMatches(ctx.target_agencies, agency || keyword);
+  const hasCertifications = Array.isArray(ctx.set_aside_certifications) && ctx.set_aside_certifications.length > 0;
+  const hasVehicles = Array.isArray(ctx.vehicle_holdings) && ctx.vehicle_holdings.length > 0;
+  if (agencyAligned && (hasCertifications || hasVehicles)) {
+    return {
+      state: RECOMMENDATION_STATES.PRIME_DIRECT,
+      detail: `Direct prime path — ${agency || "agency"} is in your target list, ${hasVehicles ? "vehicle holdings" : "set-aside posture"} provides eligibility.`,
+    };
+  }
+
+  // Priority 10 — INSUFFICIENT_DATA when the profile is too sparse to
+  // classify confidently. Specifically: no v2 fields populated AND no
+  // active_pursuits / incumbent_positions reachable.
+  const v2Populated = (ctx.position_history || []).length > 0 ||
+                      (ctx.jv_partnerships || []).length > 0 ||
+                      (ctx.agency_relationships || []).length > 0;
+  const v1Populated = (ctx.active_pursuits || []).length > 0 ||
+                      (ctx.incumbent_positions || []).length > 0;
+  if (!v2Populated && !v1Populated) {
+    return {
+      state: RECOMMENDATION_STATES.INSUFFICIENT_DATA,
+      detail: "Subscriber profile is sparse (no position history, JV partnerships, active pursuits, or incumbent positions). Cannot classify recommendation state without more data.",
+    };
+  }
+
+  // Default — NEW_ENTRY_LONGSHOT.
+  return {
+    state: RECOMMENDATION_STATES.NEW_ENTRY_LONGSHOT,
+    detail: "No incumbency, JV, or agency relationship matches the opportunity. Treat as a green-field new entry with longshot odds.",
+  };
+}
+
+/**
+ * Apply v2 state floor/ceiling to a raw composite score.
+ *
+ * @param {string} state — one of RECOMMENDATION_STATES
+ * @param {number} rawComposite — 0–100 from market + fit blend
+ * @returns {{ verdict, color, band, composite, state, reason }}
+ */
+function combineVerdictV2(state, rawComposite, { reasoning } = {}) {
+  const bounds = STATE_FLOORS[state] || STATE_FLOORS[RECOMMENDATION_STATES.INSUFFICIENT_DATA];
+  const composite = Math.max(bounds.floor, Math.min(bounds.ceiling, Number(rawComposite) || 0));
+  // Verdict label derived from state primarily, composite secondarily.
+  let verdict, color, band;
+  switch (state) {
+    case RECOMMENDATION_STATES.PRIME_DIRECT:
+    case RECOMMENDATION_STATES.SUB_TO_INCUMBENT:
+    case RECOMMENDATION_STATES.JV_TEAMING:
+      verdict = "PURSUE";
+      color = "#15803D";
+      band = "high";
+      break;
+    case RECOMMENDATION_STATES.RECOMPETE_DEFENSE:
+      verdict = "DEFEND";
+      color = "#15803D";
+      band = "high";
+      break;
+    case RECOMMENDATION_STATES.WATCH_RFI:
+    case RECOMMENDATION_STATES.WATCH_DRAFT_RFP:
+      verdict = "WATCH";
+      color = "#457B9D";
+      band = "medium_high";
+      break;
+    case RECOMMENDATION_STATES.NEW_ENTRY_LONGSHOT:
+      verdict = "CAPTURE_VALIDATION";
+      color = "#F97316";
+      band = "low";
+      break;
+    case RECOMMENDATION_STATES.OCI_BLOCKED:
+    case RECOMMENDATION_STATES.NO_BID:
+      verdict = "NO-BID";
+      color = "#E63946";
+      band = "very_low";
+      break;
+    case RECOMMENDATION_STATES.EDITORIAL_TARGET:
+      verdict = "EDITORIAL_TARGET";
+      color = "#6B7280";
+      band = "very_low";
+      break;
+    case RECOMMENDATION_STATES.INSUFFICIENT_DATA:
+    default:
+      verdict = "INSUFFICIENT_DATA";
+      color = "#6B7280";
+      band = "medium";
+      break;
+  }
+  return {
+    verdict,
+    color,
+    band,
+    composite,
+    state,
+    reason: Array.isArray(reasoning) && reasoning.length ? reasoning.join(" ") : `State ${state}: composite ${composite}/100.`,
+  };
+}
+
 module.exports = {
   detectPositiveSignals,
   agencyMatches,
   classifyCapturePosition,
+  classifyRecommendationState,
+  combineVerdictV2,
   scoreCompanyFit,
   combineVerdict,
   POSITIVE_SIGNAL_PATTERNS,
+  RECOMMENDATION_STATES,
+  STATE_FLOORS,
 };

--- a/netlify/functions/lib/feature-flags.js
+++ b/netlify/functions/lib/feature-flags.js
@@ -25,6 +25,11 @@ const FLAG_DEFAULTS = {
   // Default "off"; flip to "on" to wrap legacy tool output in the v2 ToolEnvelope,
   // add subscriber profile gate, mode dispatcher, evidence panel, Monday Move.
   PREMIUM_TOOLS_V2: "off",
+  // Pursuit Score 2.0 (Sprint 9a Phase B + 9b + 9c). Default "off" —
+  // when on, routes the verdict combiner through classifyRecommendationState
+  // (11 states, v2 subscriber_context fields). When off, the v1 ladder
+  // (combineVerdict / classifyCapturePosition) stays live.
+  PURSUIT_SCORE_V2: "off",
 };
 
 let _logged = false;

--- a/netlify/functions/lib/pursuit-score-engine.js
+++ b/netlify/functions/lib/pursuit-score-engine.js
@@ -27,9 +27,13 @@ const { detectVehicles, expandedSearchTerms } = require("./known-vehicles");
 const {
   detectPositiveSignals,
   classifyCapturePosition,
+  classifyRecommendationState,
   scoreCompanyFit,
   combineVerdict,
+  combineVerdictV2,
+  RECOMMENDATION_STATES,
 } = require("./company-alignment");
+const { getFlag } = require("./feature-flags");
 const fs = require("fs");
 const path = require("path");
 
@@ -595,14 +599,36 @@ async function scorePursuit({ keyword, agency, naics, subscriberContext }) {
     idiqVehicle?.ceiling_usd ? `$${idiqVehicle.ceiling_usd}` : "",
   ].filter(Boolean).join(" \n ");
   const signals = detectPositiveSignals(signalText);
-  const combined = combineVerdict({
-    marketScore: totalScore,
-    partial,
-    companyFit,
-    capturePosition,
-    signals,
-    opportunity: { keyword, agency: resolvedAgency, naics: resolvedNaics },
-  });
+
+  // ---- Pursuit Score V2 — recommendation state engine (Sprint 9a Phase B)
+  // Behind PURSUIT_SCORE_V2 feature flag. Default OFF — v1 ladder
+  // (combineVerdict) stays as fallback so the existing UI doesn't
+  // regress when the v2 fields are unpopulated in the seed.
+  const PURSUIT_V2_ON = String(getFlag("PURSUIT_SCORE_V2") || "").toLowerCase() === "on";
+  let combined;
+  let recommendation = null;
+  if (PURSUIT_V2_ON) {
+    recommendation = classifyRecommendationState(subscriberContext, {
+      keyword,
+      agency: resolvedAgency,
+      signals,
+    });
+    combined = combineVerdictV2(recommendation.state, totalScore, {
+      reasoning: companyFit && Array.isArray(companyFit.reasoning) ? companyFit.reasoning : [],
+    });
+    combined.recommendation = recommendation;
+    // Preserve v1 capturePosition for UI back-compat
+    combined.capturePosition = capturePosition;
+  } else {
+    combined = combineVerdict({
+      marketScore: totalScore,
+      partial,
+      companyFit,
+      capturePosition,
+      signals,
+      opportunity: { keyword, agency: resolvedAgency, naics: resolvedNaics },
+    });
+  }
 
   const profileLoaded = !!(subscriberContext && subscriberContext.entity_name);
   const profileBanner = profileLoaded

--- a/netlify/functions/lib/subscriber-context.js
+++ b/netlify/functions/lib/subscriber-context.js
@@ -15,6 +15,13 @@
 /**
  * Load subscriber_context by email. Returns null (not error) when
  * no record exists — the caller handles the "no context" banner.
+ *
+ * v2 fields (position_history, jv_partnerships, agency_relationships,
+ * editorial_calendar) added by migration 20260516000000_subscriber_context_v2.
+ * v1 subscribers whose row predates the migration get '[]'::jsonb defaults.
+ * `normalizeContextV2` ensures the returned object always has v2 fields
+ * present (as empty arrays when absent), so the state engine never has
+ * to defensively `|| []` everywhere.
  */
 async function loadSubscriberContext(supabase, email) {
   if (!email) return null;
@@ -29,11 +36,44 @@ async function loadSubscriberContext(supabase, email) {
       console.warn("[subscriber-context] load error:", error.message);
       return null;
     }
-    return data || null;
+    if (!data) return null;
+    return normalizeContextV2(data);
   } catch (err) {
     console.warn("[subscriber-context] unexpected error:", err.message);
     return null;
   }
+}
+
+/**
+ * Coerce a subscriber_context row to the v2 shape. v2 fields default
+ * to empty arrays when null/undefined/absent (covers v1 rows pre-migration
+ * AND the seed-file JSON path where columns might just be missing).
+ * Never mutates the input.
+ *
+ * @param {Object} ctx — raw subscriber_context row OR seed-file JSON
+ * @returns {Object} normalized context with all v2 fields guaranteed
+ */
+function normalizeContextV2(ctx) {
+  if (!ctx) return null;
+  const arr = (v) => (Array.isArray(v) ? v : []);
+  return {
+    ...ctx,
+    // v1 fields — keep existing defaults
+    set_aside_certifications: arr(ctx.set_aside_certifications),
+    lanes: arr(ctx.lanes),
+    active_pursuits: arr(ctx.active_pursuits),
+    incumbent_positions: arr(ctx.incumbent_positions),
+    no_go_list: arr(ctx.no_go_list),
+    oci_exclusions: arr(ctx.oci_exclusions),
+    vehicle_holdings: arr(ctx.vehicle_holdings),
+    teaming_preferred: arr(ctx.teaming_preferred),
+    teaming_no_fly: arr(ctx.teaming_no_fly),
+    // v2 fields — gracefully default for v1 rows
+    position_history: arr(ctx.position_history),
+    jv_partnerships: arr(ctx.jv_partnerships),
+    agency_relationships: arr(ctx.agency_relationships),
+    editorial_calendar: arr(ctx.editorial_calendar),
+  };
 }
 
 /**
@@ -258,6 +298,7 @@ function validateReport({ reportHtml, ctx }) {
 
 module.exports = {
   loadSubscriberContext,
+  normalizeContextV2,
   formatContextBlock,
   contextSystemRules,
   noContextBanner,

--- a/scripts/validate-subscriber-context.js
+++ b/scripts/validate-subscriber-context.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// ============================================================
+// scripts/validate-subscriber-context.js
+//
+// Pre-deploy validator for subscriber_context v2 seed files.
+// Rejects malformed v2 rows: bad role enums, end_date < start_date,
+// missing required fields, broken JV/MP type values, etc.
+//
+// Usage:
+//   node scripts/validate-subscriber-context.js                   # validates all seed files
+//   node scripts/validate-subscriber-context.js path/to/seed.json # validates one file
+//
+// Exit codes:
+//   0 — all rows valid
+//   1 — one or more validation errors (prints details)
+//   2 — script error (file not found, bad JSON, etc.)
+// ============================================================
+
+const fs = require("fs");
+const path = require("path");
+
+const SEED_DIR = path.join(__dirname, "..", "data", "subscriber-context");
+
+// Enums per migration 20260516000000_subscriber_context_v2.sql
+const ROLE_ENUM = new Set(["sub", "prime", "jv_partner", "teaming_partner"]);
+const JV_TYPE_ENUM = new Set(["sba_mentor_protege", "jv_agreement", "teaming_agreement"]);
+const AGENCY_REL_ENUM = new Set(["alumni", "advisory_board", "faca", "customer_of_record"]);
+const COVERAGE_TYPE_ENUM = new Set(["newsletter", "capture_corner", "monthly_brief", "podcast"]);
+
+function isIsoDate(s) {
+  if (!s) return false;
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+function compareDates(a, b) {
+  if (!a || !b) return 0;
+  return new Date(a).getTime() - new Date(b).getTime();
+}
+
+function validatePositionHistory(arr, errors) {
+  for (let i = 0; i < arr.length; i++) {
+    const p = arr[i] || {};
+    const path = `position_history[${i}]`;
+    if (!p.agency) errors.push(`${path}.agency: required`);
+    if (!p.program) errors.push(`${path}.program: required`);
+    if (!ROLE_ENUM.has(p.role)) errors.push(`${path}.role: must be one of [${[...ROLE_ENUM].join(", ")}], got "${p.role}"`);
+    if (p.start_date && !isIsoDate(p.start_date)) errors.push(`${path}.start_date: must be ISO yyyy-mm-dd, got "${p.start_date}"`);
+    if (p.end_date && !isIsoDate(p.end_date)) errors.push(`${path}.end_date: must be ISO yyyy-mm-dd, got "${p.end_date}"`);
+    if (p.start_date && p.end_date && compareDates(p.start_date, p.end_date) > 0) {
+      errors.push(`${path}: start_date (${p.start_date}) must be <= end_date (${p.end_date})`);
+    }
+  }
+}
+
+function validateJvPartnerships(arr, errors) {
+  for (let i = 0; i < arr.length; i++) {
+    const j = arr[i] || {};
+    const path = `jv_partnerships[${i}]`;
+    if (!j.partner_company) errors.push(`${path}.partner_company: required`);
+    if (!JV_TYPE_ENUM.has(j.type)) errors.push(`${path}.type: must be one of [${[...JV_TYPE_ENUM].join(", ")}], got "${j.type}"`);
+    if (j.start_date && !isIsoDate(j.start_date)) errors.push(`${path}.start_date: must be ISO yyyy-mm-dd, got "${j.start_date}"`);
+    if (j.end_date && !isIsoDate(j.end_date)) errors.push(`${path}.end_date: must be ISO yyyy-mm-dd, got "${j.end_date}"`);
+    if (j.start_date && j.end_date && compareDates(j.start_date, j.end_date) > 0) {
+      errors.push(`${path}: start_date (${j.start_date}) must be <= end_date (${j.end_date})`);
+    }
+    if (j.scope_keywords && !Array.isArray(j.scope_keywords)) {
+      errors.push(`${path}.scope_keywords: must be array, got ${typeof j.scope_keywords}`);
+    }
+  }
+}
+
+function validateAgencyRelationships(arr, errors) {
+  for (let i = 0; i < arr.length; i++) {
+    const r = arr[i] || {};
+    const path = `agency_relationships[${i}]`;
+    if (!r.agency) errors.push(`${path}.agency: required`);
+    if (!AGENCY_REL_ENUM.has(r.relationship_type)) {
+      errors.push(`${path}.relationship_type: must be one of [${[...AGENCY_REL_ENUM].join(", ")}], got "${r.relationship_type}"`);
+    }
+    if (r.since && !isIsoDate(r.since)) errors.push(`${path}.since: must be ISO yyyy-mm-dd, got "${r.since}"`);
+    if (r.active_through && !isIsoDate(r.active_through)) {
+      errors.push(`${path}.active_through: must be ISO yyyy-mm-dd, got "${r.active_through}"`);
+    }
+  }
+}
+
+function validateEditorialCalendar(arr, errors) {
+  for (let i = 0; i < arr.length; i++) {
+    const e = arr[i] || {};
+    const path = `editorial_calendar[${i}]`;
+    if (!e.program) errors.push(`${path}.program: required`);
+    if (!e.agency) errors.push(`${path}.agency: required`);
+    if (e.next_coverage_date && !isIsoDate(e.next_coverage_date)) {
+      errors.push(`${path}.next_coverage_date: must be ISO yyyy-mm-dd, got "${e.next_coverage_date}"`);
+    }
+    if (e.coverage_type && !COVERAGE_TYPE_ENUM.has(e.coverage_type)) {
+      errors.push(`${path}.coverage_type: must be one of [${[...COVERAGE_TYPE_ENUM].join(", ")}], got "${e.coverage_type}"`);
+    }
+  }
+}
+
+function validateOne(filePath) {
+  const errors = [];
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    return { filePath, errors: [`Cannot read file: ${err.message}`] };
+  }
+  let row;
+  try {
+    row = JSON.parse(raw);
+  } catch (err) {
+    return { filePath, errors: [`Bad JSON: ${err.message}`] };
+  }
+
+  // v1 required fields (sanity check — these existed before v2)
+  if (!row.email) errors.push("email: required");
+  if (!row.entity_name) errors.push("entity_name: required");
+
+  // v2 fields — must be arrays if present (default is empty)
+  for (const fieldName of ["position_history", "jv_partnerships", "agency_relationships", "editorial_calendar"]) {
+    if (row[fieldName] !== undefined && !Array.isArray(row[fieldName])) {
+      errors.push(`${fieldName}: must be array, got ${typeof row[fieldName]}`);
+    }
+  }
+
+  if (Array.isArray(row.position_history)) validatePositionHistory(row.position_history, errors);
+  if (Array.isArray(row.jv_partnerships)) validateJvPartnerships(row.jv_partnerships, errors);
+  if (Array.isArray(row.agency_relationships)) validateAgencyRelationships(row.agency_relationships, errors);
+  if (Array.isArray(row.editorial_calendar)) validateEditorialCalendar(row.editorial_calendar, errors);
+
+  return { filePath, errors };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let files;
+  if (args.length > 0) {
+    files = args;
+  } else {
+    try {
+      files = fs.readdirSync(SEED_DIR)
+        .filter((f) => f.endsWith(".json"))
+        .map((f) => path.join(SEED_DIR, f));
+    } catch (err) {
+      console.error(`Cannot read seed dir ${SEED_DIR}: ${err.message}`);
+      process.exit(2);
+    }
+  }
+
+  if (files.length === 0) {
+    console.log("No seed files to validate.");
+    process.exit(0);
+  }
+
+  let totalErrors = 0;
+  for (const f of files) {
+    const result = validateOne(f);
+    const name = path.relative(process.cwd(), result.filePath);
+    if (result.errors.length === 0) {
+      console.log(`OK  ${name}`);
+    } else {
+      totalErrors += result.errors.length;
+      console.log(`FAIL ${name} (${result.errors.length} error${result.errors.length === 1 ? "" : "s"})`);
+      for (const e of result.errors) console.log(`     - ${e}`);
+    }
+  }
+
+  if (totalErrors > 0) {
+    console.error(`\n${totalErrors} validation error${totalErrors === 1 ? "" : "s"} across ${files.length} file${files.length === 1 ? "" : "s"}.`);
+    process.exit(1);
+  }
+  console.log(`\nAll ${files.length} seed file${files.length === 1 ? "" : "s"} valid.`);
+  process.exit(0);
+}
+
+if (require.main === module) main();
+module.exports = { validateOne, ROLE_ENUM, JV_TYPE_ENUM, AGENCY_REL_ENUM, COVERAGE_TYPE_ENUM };

--- a/tests/unit/pursuit-score-states.test.js
+++ b/tests/unit/pursuit-score-states.test.js
@@ -1,0 +1,219 @@
+// ============================================================
+// tests/unit/pursuit-score-states.test.js
+//
+// Sprint 9a Phase B acceptance — exercises every one of the 11
+// recommendation states emitted by classifyRecommendationState.
+// Uses in-memory subscriber-context fixtures; no Supabase required.
+// ============================================================
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyRecommendationState,
+  combineVerdictV2,
+  RECOMMENDATION_STATES,
+  STATE_FLOORS,
+} from "../../netlify/functions/lib/company-alignment.js";
+
+const baseCtx = {
+  email: "test@example.com",
+  entity_name: "Test Co LLC",
+  set_aside_certifications: [],
+  lanes: [],
+  active_pursuits: [],
+  incumbent_positions: [],
+  no_go_list: [],
+  oci_exclusions: [],
+  vehicle_holdings: [],
+  teaming_preferred: [],
+  teaming_no_fly: [],
+  // v2 fields
+  position_history: [],
+  jv_partnerships: [],
+  agency_relationships: [],
+  editorial_calendar: [],
+};
+
+describe("classifyRecommendationState — 11 states", () => {
+  it("NO_BID: opp on no_go_list takes priority over everything", () => {
+    const ctx = {
+      ...baseCtx,
+      no_go_list: [{ solicitation_number: "ABC123", name: "PEO DHMS Deployment", reason: "OCI conflict" }],
+    };
+    const r = classifyRecommendationState(ctx, { keyword: "PEO DHMS Deployment Solutions", agency: "DHA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.NO_BID);
+    expect(r.reference.reason).toMatch(/OCI conflict/);
+  });
+
+  it("OCI_BLOCKED: opp scope intersects oci_exclusions.blocked_scope", () => {
+    const ctx = {
+      ...baseCtx,
+      oci_exclusions: [{ blocking_contract: "X", blocked_scope: "MHS GENESIS work" }],
+    };
+    const r = classifyRecommendationState(ctx, { keyword: "MHS GENESIS Wave 2 modernization", agency: "DHA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.OCI_BLOCKED);
+  });
+
+  it("EDITORIAL_TARGET: opp matches editorial_calendar program", () => {
+    const ctx = {
+      ...baseCtx,
+      editorial_calendar: [{ program: "VA EHRM", agency: "VA", next_coverage_date: "2026-06-15", coverage_type: "newsletter" }],
+    };
+    const r = classifyRecommendationState(ctx, { keyword: "VA EHRM Wave 3", agency: "VA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.EDITORIAL_TARGET);
+  });
+
+  it("RECOMPETE_DEFENSE: subscriber is incumbent on the program", () => {
+    const ctx = {
+      ...baseCtx,
+      incumbent_positions: [{ contract_number: "36C10X19N0141", name: "VA HRO BPA", role: "prime" }],
+    };
+    const r = classifyRecommendationState(ctx, { keyword: "VA HRO BPA recompete", agency: "VA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.RECOMPETE_DEFENSE);
+  });
+
+  it("SUB_TO_INCUMBENT: position_history has role=sub on matching program", () => {
+    const ctx = {
+      ...baseCtx,
+      position_history: [{
+        contract_number: "VA-HELM-SUB-001",
+        agency: "VA",
+        program: "VA SCM DSO HELM",
+        role: "sub",
+        prime_company: "Accenture Federal Services",
+        scope: "Healthcare logistics modernization",
+        start_date: "2024-06-01",
+      }],
+    };
+    const r = classifyRecommendationState(ctx, { keyword: "VA SCM DSO HELM", agency: "VA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.SUB_TO_INCUMBENT);
+    expect(r.detail).toMatch(/Accenture/);
+  });
+
+  it("JV_TEAMING: jv_partnership covers the opp via scope_keywords", () => {
+    const ctx = {
+      ...baseCtx,
+      jv_partnerships: [{
+        partner_company: "Accenture Federal Services",
+        type: "sba_mentor_protege",
+        start_date: "2024-01-15",
+        scope_keywords: ["VA EHRM", "imaging"],
+        programs_in_scope: ["VA Imaging Portfolio"],
+      }],
+    };
+    const r = classifyRecommendationState(ctx, { keyword: "VA EHRM Restart", agency: "VA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.JV_TEAMING);
+    expect(r.detail).toMatch(/SBA mentor-protégé/);
+  });
+
+  it("WATCH_RFI: positive signal RFI detected", () => {
+    const ctx = { ...baseCtx };
+    const signals = [{ tag: "RFI", note: "RFI / sources-sought detected" }];
+    const r = classifyRecommendationState(ctx, { keyword: "Some unknown program", agency: "DHA", signals });
+    expect(r.state).toBe(RECOMMENDATION_STATES.WATCH_RFI);
+  });
+
+  it("WATCH_DRAFT_RFP: positive signal INDUSTRY_DAY detected", () => {
+    const ctx = { ...baseCtx };
+    const signals = [{ tag: "INDUSTRY_DAY", note: "Industry day" }];
+    const r = classifyRecommendationState(ctx, { keyword: "Some emerging program", agency: "VA", signals });
+    expect(r.state).toBe(RECOMMENDATION_STATES.WATCH_DRAFT_RFP);
+  });
+
+  it("PRIME_DIRECT: target agency aligned + certifications + vehicles", () => {
+    const ctx = {
+      ...baseCtx,
+      target_agencies: ["VA", "DHA"],
+      set_aside_certifications: ["SDVOSB"],
+      vehicle_holdings: [{ vehicle: "GSA MAS", contract: "GS-00F-243DA", role: "prime" }],
+      // a sparse v1 entry so we don't fall to INSUFFICIENT_DATA
+      active_pursuits: [{ name: "Other thing", role: "prime", stage: "capture" }],
+    };
+    const r = classifyRecommendationState(ctx, { keyword: "VA cloud modernization", agency: "VA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.PRIME_DIRECT);
+  });
+
+  it("INSUFFICIENT_DATA: ctx is null", () => {
+    const r = classifyRecommendationState(null, { keyword: "anything", agency: "VA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.INSUFFICIENT_DATA);
+  });
+
+  it("INSUFFICIENT_DATA: sparse profile with no v1 or v2 fields populated", () => {
+    const ctx = { ...baseCtx };
+    const r = classifyRecommendationState(ctx, { keyword: "VA cloud modernization", agency: "VA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.INSUFFICIENT_DATA);
+  });
+
+  it("NEW_ENTRY_LONGSHOT: populated v1 fields, no overlap with opp", () => {
+    const ctx = {
+      ...baseCtx,
+      active_pursuits: [{ name: "Some other thing entirely", role: "prime", stage: "capture" }],
+    };
+    const r = classifyRecommendationState(ctx, { keyword: "Brand new opportunity nobody knows", agency: "VA" });
+    expect(r.state).toBe(RECOMMENDATION_STATES.NEW_ENTRY_LONGSHOT);
+  });
+});
+
+describe("combineVerdictV2 — state floor/ceiling enforcement", () => {
+  it("SUB_TO_INCUMBENT floor of 60 protects against thin USASpending data", () => {
+    const v = combineVerdictV2(RECOMMENDATION_STATES.SUB_TO_INCUMBENT, 32);
+    expect(v.composite).toBeGreaterThanOrEqual(60);
+    expect(v.verdict).toBe("PURSUE");
+  });
+
+  it("OCI_BLOCKED ceiling of 20 caps high-signal opps", () => {
+    const v = combineVerdictV2(RECOMMENDATION_STATES.OCI_BLOCKED, 88);
+    expect(v.composite).toBeLessThanOrEqual(20);
+    expect(v.verdict).toBe("NO-BID");
+  });
+
+  it("EDITORIAL_TARGET returns EDITORIAL_TARGET verdict regardless of score", () => {
+    const v = combineVerdictV2(RECOMMENDATION_STATES.EDITORIAL_TARGET, 75);
+    expect(v.verdict).toBe("EDITORIAL_TARGET");
+    expect(v.composite).toBeLessThanOrEqual(STATE_FLOORS[RECOMMENDATION_STATES.EDITORIAL_TARGET].ceiling);
+  });
+
+  it("INSUFFICIENT_DATA passes through to INSUFFICIENT_DATA verdict", () => {
+    const v = combineVerdictV2(RECOMMENDATION_STATES.INSUFFICIENT_DATA, 30);
+    expect(v.verdict).toBe("INSUFFICIENT_DATA");
+  });
+
+  it("PRIME_DIRECT raw 50 → floored to 70 → PURSUE verdict", () => {
+    const v = combineVerdictV2(RECOMMENDATION_STATES.PRIME_DIRECT, 50);
+    expect(v.composite).toBe(70);
+    expect(v.verdict).toBe("PURSUE");
+  });
+
+  it("RECOMPETE_DEFENSE returns DEFEND verdict label", () => {
+    const v = combineVerdictV2(RECOMMENDATION_STATES.RECOMPETE_DEFENSE, 80);
+    expect(v.verdict).toBe("DEFEND");
+    expect(v.composite).toBeGreaterThanOrEqual(60);
+  });
+
+  it("WATCH_RFI ceiling caps at 70 even on strong upstream data", () => {
+    const v = combineVerdictV2(RECOMMENDATION_STATES.WATCH_RFI, 95);
+    expect(v.composite).toBeLessThanOrEqual(70);
+    expect(v.verdict).toBe("WATCH");
+  });
+});
+
+describe("RECOMMENDATION_STATES enum surface", () => {
+  it("exposes all 11 states", () => {
+    const expected = [
+      "PRIME_DIRECT",
+      "RECOMPETE_DEFENSE",
+      "SUB_TO_INCUMBENT",
+      "JV_TEAMING",
+      "WATCH_RFI",
+      "WATCH_DRAFT_RFP",
+      "OCI_BLOCKED",
+      "EDITORIAL_TARGET",
+      "NEW_ENTRY_LONGSHOT",
+      "NO_BID",
+      "INSUFFICIENT_DATA",
+    ];
+    for (const s of expected) {
+      expect(RECOMMENDATION_STATES[s]).toBe(s);
+    }
+    expect(Object.keys(RECOMMENDATION_STATES).length).toBe(11);
+  });
+});

--- a/tests/unit/pursuit-score-v1-regression.test.js
+++ b/tests/unit/pursuit-score-v1-regression.test.js
@@ -1,0 +1,124 @@
+// ============================================================
+// tests/unit/pursuit-score-v1-regression.test.js
+//
+// Sprint 9a Phase B regression guard — verifies the v1 verdict
+// ladder (combineVerdict + classifyCapturePosition) still ships
+// unchanged shape when PURSUIT_SCORE_V2=off. v1 subscribers
+// (pre-migration, no v2 fields) must not see any behavior change.
+// ============================================================
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyCapturePosition,
+  combineVerdict,
+  scoreCompanyFit,
+  detectPositiveSignals,
+  classifyRecommendationState,
+  RECOMMENDATION_STATES,
+} from "../../netlify/functions/lib/company-alignment.js";
+
+const v1Ctx = {
+  email: "test@example.com",
+  entity_name: "v1 Co",
+  target_agencies: ["VA"],
+  capabilities: ["healthcare it", "ehr", "cloud"],
+  naics_codes: ["541512"],
+  set_aside_certifications: ["WOSB"],
+  lanes: [{ name: "VA Scale Engine", priority: 1 }],
+  active_pursuits: [{
+    solicitation_number: "ABC-123",
+    name: "VA EHRM Restart",
+    role: "sub",
+    stage: "capture",
+  }],
+  incumbent_positions: [{ contract_number: "INCUMB-1", name: "VA HRO BPA" }],
+  no_go_list: [],
+  oci_exclusions: [],
+  vehicle_holdings: [],
+  teaming_preferred: [],
+  teaming_no_fly: [],
+  // v2 fields absent (pre-migration v1 row)
+};
+
+describe("v1 path unchanged when PURSUIT_SCORE_V2=off", () => {
+  it("classifyCapturePosition still returns IN_FLIGHT for active pursuits", () => {
+    const r = classifyCapturePosition(v1Ctx, { keyword: "VA EHRM Restart", agency: "VA" });
+    expect(r.tag).toBe("IN_FLIGHT");
+    expect(r.detail).toMatch(/EHRM Restart/);
+  });
+
+  it("classifyCapturePosition INCUMBENT_RECOMPETE on incumbent match", () => {
+    const r = classifyCapturePosition(v1Ctx, { keyword: "VA HRO BPA recompete", agency: "VA" });
+    expect(r.tag).toBe("INCUMBENT_RECOMPETE");
+  });
+
+  it("classifyCapturePosition NO_PROFILE when ctx is null", () => {
+    const r = classifyCapturePosition(null, { keyword: "anything", agency: "VA" });
+    expect(r.tag).toBe("NO_PROFILE");
+  });
+
+  it("combineVerdict returns PURSUE/QUALIFY/MONITOR/CAPTURE_VALIDATION/NO-BID at canonical thresholds", () => {
+    // Mock high market score + good fit
+    const high = combineVerdict({
+      marketScore: 80,
+      partial: false,
+      companyFit: { score: 80, band: "high", reasoning: [] },
+      capturePosition: { tag: "ON_LANE", detail: "x" },
+      signals: [],
+      opportunity: { keyword: "x", agency: "VA" },
+    });
+    expect(["PURSUE", "QUALIFY"]).toContain(high.verdict);
+    expect(high.composite).toBeGreaterThanOrEqual(60);
+
+    const low = combineVerdict({
+      marketScore: 5,
+      partial: false,
+      companyFit: { score: 10, band: "low", reasoning: [] },
+      capturePosition: { tag: "NEW", detail: "x" },
+      signals: [],
+      opportunity: { keyword: "x", agency: "VA" },
+    });
+    expect(["CAPTURE_VALIDATION", "NO-BID"]).toContain(low.verdict);
+  });
+
+  it("scoreCompanyFit produces a score and completeness for v1-only context", () => {
+    const fit = scoreCompanyFit(v1Ctx, { keyword: "VA EHR cloud", agency: "VA", naics: ["541512"] });
+    expect(fit.score).toBeGreaterThan(0);
+    expect(fit.score).toBeLessThanOrEqual(100);
+    expect(Array.isArray(fit.known)).toBe(true);
+    expect(Array.isArray(fit.reasoning)).toBe(true);
+  });
+
+  it("detectPositiveSignals still surfaces RFI from text", () => {
+    const sigs = detectPositiveSignals("Request for Information for the program");
+    expect(sigs.some((s) => s.tag === "RFI")).toBe(true);
+  });
+});
+
+describe("HELM acceptance — v2 empty seed lands on INSUFFICIENT_DATA", () => {
+  // Per the overnight runbook §"Sprint 9a Seed-File Gap": when Mary's
+  // AFS-on-HELM facts are not yet backfilled, position_history is
+  // empty and the HELM keyword should land on INSUFFICIENT_DATA, NOT
+  // SUB_TO_INCUMBENT. After Mary backfills the seed with an
+  // AFS-on-HELM sub record, this test will need to flip to expect
+  // SUB_TO_INCUMBENT (and that flip is the acceptance signal that
+  // the backfill landed correctly).
+  const stubbedSeed = {
+    email: "mary@missionmeetstech.com",
+    entity_name: "rockITdata LLC",
+    set_aside_certifications: ["WOSB", "SDVOSB"],
+    active_pursuits: [], incumbent_positions: [], no_go_list: [],
+    oci_exclusions: [], vehicle_holdings: [], lanes: [],
+    teaming_preferred: [], teaming_no_fly: [],
+    position_history: [], jv_partnerships: [],
+    agency_relationships: [], editorial_calendar: [],
+  };
+
+  it("HELM with empty v2 seed returns INSUFFICIENT_DATA (Mary's backfill TODO)", () => {
+    const r = classifyRecommendationState(stubbedSeed, {
+      keyword: "VA SCM DSO HELM",
+      agency: "VA",
+    });
+    expect(r.state).toBe(RECOMMENDATION_STATES.INSUFFICIENT_DATA);
+  });
+});


### PR DESCRIPTION
Sprint file: \`~/Downloads/sprint-9a-pursuit-score-phase-a-b.md\`
Status: code complete, awaiting Mary's review
Migration: NOT applied — SQL emitted, Mary runs in Supabase SQL Editor
Feature flag: \`PURSUIT_SCORE_V2=off\` (default) — v1 path stays live

## What this changes

### Phase A — Schema + seed (additive, idempotent)
- \`migrations/20260516000000_subscriber_context_v2.sql\` — 4 new JSONB columns: \`position_history\`, \`jv_partnerships\`, \`agency_relationships\`, \`editorial_calendar\`. All nullable with \`'[]'::jsonb\` defaults so v1 readers stay green. Column COMMENT blocks document expected shapes + enums.
- \`data/subscriber-context/mary-womack-seed.json\` — v2 fields added as empty arrays with \`__v2_todo\` flag (per runbook gap protocol — Mary's AFS-on-HELM facts not provided this session).
- \`netlify/functions/lib/subscriber-context.js\` — new \`normalizeContextV2\` helper. \`loadSubscriberContext\` returns a normalized record with v2 fields guaranteed present.
- \`scripts/validate-subscriber-context.js\` — new pre-deploy validator. Rejects bad role enum, malformed dates, missing required fields. \`node scripts/validate-subscriber-context.js\` passes on Mary's seed today.

### Phase B — Recommendation state engine (11 states)
- \`netlify/functions/lib/company-alignment.js\` — appended \`classifyRecommendationState\` (one of PRIME_DIRECT / RECOMPETE_DEFENSE / SUB_TO_INCUMBENT / JV_TEAMING / WATCH_RFI / WATCH_DRAFT_RFP / OCI_BLOCKED / EDITORIAL_TARGET / NEW_ENTRY_LONGSHOT / NO_BID / INSUFFICIENT_DATA) and \`combineVerdictV2\` (applies STATE_FLOORS — SUB_TO_INCUMBENT floors composite at 60, OCI_BLOCKED ceilings at 20).
- \`netlify/functions/lib/pursuit-score-engine.js\` — verdict combiner branches on \`PURSUIT_SCORE_V2\`. Flag off → original v1 ladder. Flag on → state engine + combineVerdictV2.
- \`netlify/functions/lib/feature-flags.js\` — \`PURSUIT_SCORE_V2: "off"\` added to FLAG_DEFAULTS.

### Tests (27 new, all passing)
- \`tests/unit/pursuit-score-states.test.js\` — 19 tests. Each of the 11 states reachable; STATE_FLOORS enforcement verified.
- \`tests/unit/pursuit-score-v1-regression.test.js\` — 8 tests. v1 \`classifyCapturePosition\` / \`combineVerdict\` / \`scoreCompanyFit\` unchanged. HELM-with-empty-seed → INSUFFICIENT_DATA (expected per runbook gap protocol).

\`npx vitest run\` → 239 pass / 1 pre-existing failure (\`pursuit-calendar.test.js\`, unrelated, also fails on \`main\`).

## Mary action checklist

1. **Apply migration** — copy the SQL from \`migrations/20260516000000_subscriber_context_v2.sql\` into the Supabase SQL Editor and run. Idempotent — safe to re-run.
2. **Backfill AFS facts** — replace the \`__v2_todo\` in \`mary-womack-seed.json\` with:
   - \`position_history\` entry for AFS-on-HELM (sub contract #, PoP, scope)
   - \`jv_partnerships\` entry for AFS partnership (type, dates, scope_keywords)
   - Optional: \`agency_relationships\`, \`editorial_calendar\`
3. **Re-validate** — \`node scripts/validate-subscriber-context.js\` must exit 0.
4. **Re-seed Supabase** — push the updated seed via existing admin import (POST /.netlify/functions/subscriber-context).
5. **Flip flag** — \`PURSUIT_SCORE_V2=on\` in Netlify env. v1 path stays as fallback if needed.
6. **Acceptance test** — score "VA SCM DSO HELM" — should return state=SUB_TO_INCUMBENT and composite ≥65 once seed is backfilled.

## Risk + rollback
- Phase A is additive only. Roll back via \`ALTER TABLE ... DROP COLUMN IF EXISTS\` (rollback block included as SQL comment).
- Phase B is fully flag-gated. Set \`PURSUIT_SCORE_V2=off\` to revert with zero deploy.
- All git-tracked changes revert via single PR revert.

## Out-of-scope (deferred to 9b/9c)
- Live SAM.gov acquisition-state lookup → 9b
- Monday Move generator → 9b
- Delta engine + run-history table → 9c (separate migration)
- UI changes to \`/premium/pursuit-score.html\` → 9c