### PR TITLE
Fix: founding-count was leaking Stripe key fragments (env mis-set)

### DIFF
--- a/netlify/functions/founding-count.js
+++ b/netlify/functions/founding-count.js
@@ -51,6 +51,39 @@ async function countActiveFoundingSubs(stripe) {
   return customerIds.size;
 }
 
+// Stripe error messages from `Invalid API Key provided: ...` include
+// a partially-masked key fragment (e.g. `whsec_hM**...rXgD`). Even
+// truncated, that's a secret reaching a public response. Server-side
+// logs can keep the original for debugging; public responses get
+// redacted and reduced to a safe category.
+function classifyAndRedactStripeError(err) {
+  const raw = String(err && err.message ? err.message : err || "");
+  // Strip anything that looks like a Stripe key fragment.
+  const safe = raw
+    .replace(/\b(sk|rk|pk|whsec)_[A-Za-z0-9*_-]+/gi, "$1_***")
+    .slice(0, 160);
+
+  // Detect the most common operator mistake: STRIPE_SECRET_KEY was set
+  // to a webhook secret (whsec_*) rather than an API key (sk_*).
+  const looksLikeWebhookSecretAsApiKey =
+    /whsec_/i.test(raw) && /Invalid API Key/i.test(raw);
+
+  return {
+    publicMessage: safe,
+    code: looksLikeWebhookSecretAsApiKey
+      ? "stripe_key_misconfigured_webhook_secret_in_api_key_slot"
+      : "stripe_error",
+  };
+}
+
+// Detect the wrong-prefix mistake at boot, before we even call Stripe,
+// so the public response carries the correct diagnostic code without
+// surfacing a real Stripe `Invalid API Key` error to the client.
+function looksLikeWrongPrefix(key) {
+  if (!key) return false;
+  return /^whsec_/i.test(key) || /^pk_/i.test(key);
+}
+
 exports.handler = async () => {
   const response = {
     remaining: HARDCODED_FALLBACK,
@@ -60,8 +93,20 @@ exports.handler = async () => {
   };
 
   try {
-    if (process.env.STRIPE_SECRET_KEY) {
-      const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+    const secret = process.env.STRIPE_SECRET_KEY;
+    if (secret && looksLikeWrongPrefix(secret)) {
+      // Server log keeps prefix detail for the operator; client response
+      // gets only the diagnostic code, never a key fragment.
+      console.warn(
+        "founding-count: STRIPE_SECRET_KEY has a non-API-key prefix " +
+        `(starts with "${secret.slice(0, 6)}..."). Expected sk_live_ or sk_test_. ` +
+        "Falling back to env count without calling Stripe."
+      );
+      response.remaining = parseEnvFallback();
+      response.source = "env_fallback_misconfigured_secret";
+      response.diagnostic = "stripe_key_misconfigured_wrong_prefix";
+    } else if (secret) {
+      const stripe = require("stripe")(secret);
       const activeCount = await countActiveFoundingSubs(stripe);
       if (activeCount !== null) {
         response.remaining = Math.max(0, TOTAL - activeCount);
@@ -75,10 +120,14 @@ exports.handler = async () => {
       response.source = "env_fallback_no_secret";
     }
   } catch (err) {
-    console.warn("founding-count: Stripe query failed, using env fallback:", err.message);
+    const { publicMessage, code } = classifyAndRedactStripeError(err);
+    // Server log retains the raw error for operator triage. Public
+    // response gets redacted message + diagnostic code only.
+    console.warn("founding-count: Stripe query failed:", err && err.message ? err.message : err);
     response.remaining = parseEnvFallback();
     response.source = "env_fallback_stripe_error";
-    response.error = err.message;
+    response.diagnostic = code;
+    response.error_message = publicMessage;
   }
 
   return {
@@ -92,3 +141,6 @@ exports.handler = async () => {
     body: JSON.stringify(response),
   };
 };
+
+// Export internals for unit testing without going through the handler.
+exports._internals = { classifyAndRedactStripeError, looksLikeWrongPrefix };


### PR DESCRIPTION
Found while triaging Mary's report that the /pricing page shows the wrong number of Founding Member spots remaining.

## Root cause
\`STRIPE_SECRET_KEY\` in Netlify env was set to a Stripe **webhook secret** (\`whsec_*\`) instead of an **API key** (\`sk_live_*\` / \`sk_test_*\`). Every \`stripe.subscriptions.list()\` call rejected with \`Invalid API Key provided: whsec_hM**...rXgD\` — and the founding-count function returned that error message verbatim in its public response. So:

1. The pricing page stuck on the hardcoded fallback of 96.
2. Anyone hitting \`/.netlify/functions/founding-count\` could see a masked fragment of the webhook secret.

## Mary action (separate from this PR)
Swap STRIPE_SECRET_KEY in Netlify env to the actual API key from Stripe Dashboard → Developers → API keys. Must start with \`sk_live_\` (production) or \`sk_test_\` (test mode). \`whsec_*\` is the webhook secret — that belongs in \`STRIPE_WEBHOOK_SECRET\`. After the env swap, the function picks up the change within ≤5 min cache TTL, or trigger a redeploy.

## What this PR fixes
- **Redacts \`sk_\`/\`rk_\`/\`pk_\`/\`whsec_\` fragments** from any Stripe error message before returning it. The server log keeps the original for triage; the public response only carries a category code + redacted message.
- **Pre-call prefix guard**: if STRIPE_SECRET_KEY starts with \`whsec_\` or \`pk_\`, don't even try to construct the Stripe client. Return source=\`env_fallback_misconfigured_secret\` and diagnostic=\`stripe_key_misconfigured_wrong_prefix\`. The client gets the category, never the secret material.
- Exports \`_internals\` for unit testing without going through the handler.

## Verification
Inline assertions in the commit message run:
- \`whsec_hM**...rXgD\` in "Invalid API Key" message → publicMessage redacted to \`whsec_***\`, code = \`...webhook_secret_in_api_key_slot\`
- \`sk_live_AbCdEf123\` in any error message → publicMessage redacted to \`sk_***\`
- Generic non-key error → code = \`stripe_error\`
- \`looksLikeWrongPrefix("whsec_abc")\` → true
- \`looksLikeWrongPrefix("pk_live_abc")\` → true
- \`looksLikeWrongPrefix("sk_live_abc")\` → false

All tests pass.

## Risk
- Read-only function, no schema, no env-var changes required by this PR
- Revertable via single PR revert