### PR TITLE
Fix: pursuit-calendar test flake at 2026-05-01+ (time-pinned)

### DIFF
--- a/netlify/functions/lib/pursuit-calendar-render.js
+++ b/netlify/functions/lib/pursuit-calendar-render.js
@@ -227,7 +227,13 @@ function renderRow(r, todayStr) {
  * @returns {string}    HTML
  */
 function renderPursuitCalendarHtml(rows, opts = {}) {
-  const todayStr = todayET();
+  // `opts.today` accepts a YYYY-MM-DD override so unit tests can pin
+  // time deterministically. Without this, the "groups rows by month
+  // and orders ascending by event_date" test was brittle — fixture
+  // rows used hard-coded 2026-05/06 dates that flipped from
+  // "upcoming" to "Recently closed" the moment real time passed
+  // 2026-05-01, reordering the rendered HTML and breaking the test.
+  const todayStr = opts.today || todayET();
 
   const sorted = [...(rows || [])].sort((a, b) => {
     const da = a.event_date || "";

--- a/tests/pursuit-calendar.test.js
+++ b/tests/pursuit-calendar.test.js
@@ -66,7 +66,12 @@ describe("pursuit-calendar-render / renderPursuitCalendarHtml", () => {
       { title: "A Item", event_date: "2026-05-01", category: "proposal_due", agency: "VA" },
       { title: "C Item", event_date: "2026-05-20", category: "industry_day", agency: "DHA" },
     ];
-    const html = render.renderPursuitCalendarHtml(rows);
+    // Pin "today" before the earliest row so all three are upcoming.
+    // Otherwise the test is brittle: once real time passes 2026-05-01,
+    // A flips to "Recently closed" (a section rendered AFTER "Next 90
+    // days"), so A appears after C in the HTML and the assertion
+    // fails for time-of-run reasons rather than a real regression.
+    const html = render.renderPursuitCalendarHtml(rows, { today: "2026-04-15" });
     expect(html).toContain("May 2026");
     expect(html).toContain("June 2026");
     // A should appear before C (both May), and both before B (June)


### PR DESCRIPTION
Side ticket from the overnight session. Not in any sprint PR.

## Symptom
\`tests/pursuit-calendar.test.js > "groups rows by month and orders ascending by event_date"\` has been red on \`main\` since 2026-05-01. Failure: \`AssertionError: expected 6758 to be less than 6086\` (row "A Item" was appearing AFTER row "C Item" in the rendered HTML).

## Root cause
The test uses hard-coded \`event_date\` values (2026-05-01, 2026-05-20, 2026-06-15) and assumes all three rows are still upcoming. The renderer calls \`todayET()\` internally and splits past pursuits into a "Recently closed" section that renders BELOW "Next 90 days". The moment real time passed 2026-05-01, row A flipped from upcoming → closed, so A landed in a later section than C — breaking the index-order assertion for time-of-run reasons rather than any real regression.

## Fix (two changes)
1. **\`renderPursuitCalendarHtml\` now accepts \`opts.today\`** — a YYYY-MM-DD override. Falls through to \`todayET()\` when omitted, so production behavior is unchanged. This is a test seam.
2. **The test pins \`today: "2026-04-15"\`** (before the earliest row) so all three fixtures remain "upcoming" regardless of when the test runs.

## Verification
\`npx vitest run tests/pursuit-calendar.test.js\` → 11/11 pass.

## Risk
- Read-only test fix + tiny optional opts parameter
- No schema, no env, no production behavior change
- Reverts cleanly via single PR revert

## Why this is a separate PR
Per the overnight session brief: this failure has been on \`main\` since long before any of the 8a/8b/9a work, so isolating it as its own PR keeps the sprint branches clean and the blame attribution clean.