### PR TITLE
Sprint 8c: Signal Chain polish (SC-5/SC-6/SC-8 + SAM relevance bleed)

### DIFF
--- a/netlify/functions/lib/federal-data-apis.js
+++ b/netlify/functions/lib/federal-data-apis.js
@@ -325,12 +325,14 @@ async function searchSAMOpportunities({ keyword, naics, agency, limit = 25, days
   };
 
   try {
-    const [primary, secondary] = await Promise.all([
-      callSam(primaryParams),
-      // Only fire secondary if we have a deptname (otherwise it's just
-      // a broader version of primary)
-      deptName ? callSam(secondaryParams) : Promise.resolve(null),
-    ]);
+    // Sprint 8c: drop the secondary deptname-only call when the primary
+    // returns >= 3 hits. The original SC-4 design always unioned primary
+    // + secondary, but on narrow queries (e.g., "DHA data governance"
+    // + DHA → deptname=DEPT OF DEFENSE) the deptname-only call dumped
+    // unrelated DoD Pre-Solicitations (Navy ship repairs, brake switches)
+    // that drowned the keyword-relevant primary hits. Now: primary
+    // first, only fall back to secondary when primary is thin.
+    const primary = await callSam(primaryParams);
 
     if (primary.__error) {
       console.error(primary.__error);
@@ -338,19 +340,33 @@ async function searchSAMOpportunities({ keyword, naics, agency, limit = 25, days
     }
 
     const primaryRaw = primary.opportunitiesData || primary.opportunities || [];
-    const secondaryRaw = (secondary && !secondary.__error)
-      ? (secondary.opportunitiesData || secondary.opportunities || [])
-      : [];
+    const PRIMARY_THRESHOLD = 3;
+    let secondary = null;
+    let secondaryRaw = [];
+    if (deptName && primaryRaw.length < PRIMARY_THRESHOLD) {
+      secondary = await callSam(secondaryParams).catch((e) => ({ __error: e && e.message ? e.message : String(e) }));
+      if (secondary && !secondary.__error) {
+        secondaryRaw = secondary.opportunitiesData || secondary.opportunities || [];
+      }
+    }
 
     // Union by noticeId — primary results win when both contain the same
-    // opportunity; secondary fills in recently-posted gaps.
+    // opportunity; secondary fills in recently-posted gaps. Secondary
+    // results carry _secondary=true so layer scoring can deprioritize
+    // them in future (not done in this sprint; documented for SC-9+).
     const seen = new Set();
     const union = [];
-    for (const o of [...primaryRaw, ...secondaryRaw]) {
+    for (const o of primaryRaw) {
       const id = o.noticeId;
       if (!id || seen.has(id)) continue;
       seen.add(id);
       union.push(mapOpp(o));
+    }
+    for (const o of secondaryRaw) {
+      const id = o.noticeId;
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      union.push({ ...mapOpp(o), _secondary: true });
     }
 
     return {

--- a/netlify/functions/lib/signal-chain-query-builder.js
+++ b/netlify/functions/lib/signal-chain-query-builder.js
@@ -114,6 +114,13 @@ function buildQueryTerms(topic, agency) {
     forCongress: topKeywords.join(" "),
     forSAM: topKeywords.join(" "),
     forUSAJobs: topKeywords.slice(0, 2).join(" "),
+    // SC-5 broader fallback for USAJobs. The 2-token precise phrase
+    // matches USAJobs almost never because job titles use role
+    // vocabulary ("Health IT Specialist") not program names. The
+    // broad query is the FIRST topKeyword (the program anchor token
+    // — "mhs", "tricare", "ehrm") alone; the layer fires the broad
+    // call when the precise one returns < 3 results.
+    forUSAJobsBroad: topKeywords[0] || "",
     forFedRegister: topKeywords.join(" "),
     // USASpending's `keywords` filter is PHRASE match across description
     // text — passing a 4-token joined string ("mhs genesis defense
@@ -219,8 +226,26 @@ const FALLBACK_SUGGESTIONS = {
   ],
 };
 
-function fallbackSuggestionsFor(agency) {
-  return FALLBACK_SUGGESTIONS[agency] || FALLBACK_SUGGESTIONS.DHA;
+function fallbackSuggestionsFor(agency, currentTopic) {
+  const base = FALLBACK_SUGGESTIONS[agency] || FALLBACK_SUGGESTIONS.DHA;
+  // SC-8: filter suggestions to exclude the query the user just ran.
+  // Subscribers complained about VA + "CCN Next Gen" returning 0
+  // layers and then offering "CCN Next Gen" as a suggestion to try.
+  // Match case-insensitively on both the suggestion's label and its
+  // query string vs the current topic; if either matches as a
+  // substring (in either direction), drop the suggestion.
+  if (!currentTopic) return base;
+  const topic = String(currentTopic || "").toLowerCase().trim();
+  if (!topic) return base;
+  return base.filter((s) => {
+    const label = String(s.label || "").toLowerCase();
+    const q = String(s.query || "").toLowerCase();
+    return !(
+      topic === label || topic === q ||
+      topic.includes(label) || label.includes(topic) ||
+      topic.includes(q) || q.includes(topic)
+    );
+  });
 }
 
 module.exports = {

--- a/netlify/functions/signal-chain.js
+++ b/netlify/functions/signal-chain.js
@@ -249,16 +249,52 @@ async function layerLegislative(terms) {
 async function layerWorkforce(terms, agency) {
   const agencyCodeMap = { DHA: "DD17", VA: "VATA", HHS: "HE00", DoD: "DD00", GSA: "GS00" };
   const org = agencyCodeMap[agency];
-  const { jobs = [] } = await searchJobs({
+
+  // SC-5: USAJobs keyword expansion. The precise 2-token keyword
+  // ("mhs genesis") matches almost nothing because USAJobs job titles
+  // use generic role language ("Health IT Specialist," "Project
+  // Manager"), not program names. Run a tiered query:
+  //   primary  = 2-token precise phrase (terms.forUSAJobs)
+  //   broad    = 1-token program anchor (terms.forUSAJobsBroad) — only
+  //              fires when primary returns 0 useful matches.
+  // Union by usajobs.position_id so duplicates don't double-count.
+  const primary = await searchJobs({
     keyword: terms.forUSAJobs,
     agency: org,
     limit: 10,
-  }).catch(() => ({ jobs: [] }));
+  }).catch((e) => ({ jobs: [], error: e && e.message ? e.message : String(e) }));
+
+  const _apiErrors = [];
+  if (primary.error) _apiErrors.push({ source: "usajobs", call: "primary", message: primary.error });
+
+  let jobs = primary.jobs || [];
+  let broadFired = false;
+  if (jobs.length < 3 && terms.forUSAJobsBroad && terms.forUSAJobsBroad !== terms.forUSAJobs) {
+    broadFired = true;
+    const broad = await searchJobs({
+      keyword: terms.forUSAJobsBroad,
+      agency: org,
+      limit: 10,
+    }).catch((e) => ({ jobs: [], error: e && e.message ? e.message : String(e) }));
+    if (broad.error) _apiErrors.push({ source: "usajobs", call: "broad", message: broad.error });
+    // Union by job id (or url as fallback) so a job that matched both
+    // queries doesn't count twice.
+    const seen = new Set(jobs.map((j) => j.id || j.url));
+    for (const j of (broad.jobs || [])) {
+      const key = j.id || j.url;
+      if (key && !seen.has(key)) { seen.add(key); jobs.push(j); }
+    }
+  }
 
   const keywordsLower = terms.topKeywords.map((k) => k.toLowerCase());
+  // Broaden the post-filter so a tier-1 job that matches a single
+  // 4+ char token (e.g., "modernization") is kept. The previous
+  // includes() pass against ALL topKeywords was the second narrowness
+  // bottleneck — drop the AND-style intersection and accept any
+  // single-keyword title overlap.
   const relevant = jobs.filter((p) => {
     const title = (p.position_title || "").toLowerCase();
-    return keywordsLower.some((k) => title.includes(k));
+    return keywordsLower.some((k) => k.length > 3 && title.includes(k));
   });
 
   let score = 0;
@@ -290,10 +326,12 @@ async function layerWorkforce(terms, agency) {
   }));
 
   const reason = signals.length === 0
-    ? `No active federal job postings matching these keywords at ${agency || "any agency"}. Hiring leads contracts by 6–18 months — check back.`
+    ? (_apiErrors.length > 0
+        ? `USAJobs search failed (${_apiErrors[0].message}). No data — distinct from a confirmed zero.`
+        : `No active federal job postings matching these keywords at ${agency || "any agency"}${broadFired ? " (tried both precise and broadened searches)" : ""}. Hiring leads contracts by 6–18 months — check back.`)
     : null;
 
-  return { score, weight: 0.15, source: "USAJobs", signals, noSignalReason: reason };
+  return { score, weight: 0.15, source: "USAJobs", signals, noSignalReason: reason, _apiErrors, _broadFired: broadFired };
 }
 
 // ------------------------------------------------------------
@@ -530,9 +568,14 @@ function getVerdict(composite) {
 // ------------------------------------------------------------
 // Cache version — bump when the response shape or scoring algorithm
 // changes so subscribers don't keep reading pre-fix stale entries for
-// up to a week. v2 = Sprint 8a (SC-1/SC-2/SC-7): USASpending payload
-// fix, FR DHA slug fix, topKeywords dedup, _apiErrors in layer payload.
-const CACHE_VERSION = "v2";
+// up to a week.
+//   v2 = Sprint 8a (SC-1/SC-2/SC-7): USASpending payload fix, FR DHA
+//        slug fix, topKeywords dedup, _apiErrors in layer payload.
+//   v3 = Sprint 8c (SC-5/SC-6/SC-8 + SAM relevance bleed): tiered
+//        USAJobs query w/ broad fallback, top-level apiErrors[],
+//        suggestions exclude current topic, SAM secondary call
+//        drops when primary >= 3 hits.
+const CACHE_VERSION = "v3";
 function cacheKeyFor(topic, agency) {
   const now = new Date();
   const week = Math.floor((now - new Date(now.getUTCFullYear(), 0, 1)) / (7 * DAY_MS));
@@ -693,9 +736,22 @@ exports.handler = async (event) => {
   // layer .catch handlers. Previously every USASpending HTTP 400 (the
   // SC-1 bug) returned awards=[], silently scoring Budget at 0 with no
   // operator visibility. Fire-and-forget — don't block the response.
+  //
+  // SC-6: ALSO aggregate to a top-level `apiErrors` on the response so
+  // the frontend can distinguish "API failed → no data" from "API
+  // succeeded → confirmed zero." Without this top-level surface the
+  // UI shows "no data found" in both cases.
+  const apiErrors = [];
   for (const [layerName, layer] of Object.entries(layers)) {
     if (!layer || !Array.isArray(layer._apiErrors) || layer._apiErrors.length === 0) continue;
     for (const err of layer._apiErrors) {
+      apiErrors.push({
+        layer: layerName,
+        source: err.source,
+        status: err.status || null,
+        call: err.call || null,
+        message: err.message,
+      });
       supabase.from("ops_events").insert({
         event_type: "signal_chain_api_error",
         details: {
@@ -723,7 +779,10 @@ exports.handler = async (event) => {
   const layerScores = Object.values(layers || {}).map((l) => l && typeof l.score === "number" ? l.score : 0);
   const allLayersEmpty = layerScores.every((s) => s === 0);
   const empty_state = (composite < 5 && allLayersEmpty);
-  const suggestions = empty_state ? fallbackSuggestionsFor(resolvedAgency).slice(0, 4) : [];
+  // SC-8: filter suggestions so we never offer the user's current query
+  // back to them when their query returned 0 (the "VA + CCN Next Gen →
+  // suggested: CCN Next Gen" failure mode).
+  const suggestions = empty_state ? fallbackSuggestionsFor(resolvedAgency, topic).slice(0, 4) : [];
 
   const card = {
     topic,
@@ -749,6 +808,11 @@ exports.handler = async (event) => {
     empty_state_message: empty_state
       ? `No federal data signal for "${topic}" at ${resolvedAgency || "any agency"} this window. Try one of the active programs below, or broaden your terms.`
       : undefined,
+    // SC-6: top-level API errors so the frontend can render an
+    // operator-visible "Upstream API issue" badge separate from the
+    // genuine "no data found" empty state. Omitted when empty so
+    // clients can do `if (card.apiErrors)`.
+    apiErrors: apiErrors.length > 0 ? apiErrors : undefined,
   };
 
   // Write to cache (non-blocking)


### PR DESCRIPTION
Sprint 8c. No spec file in \`~/Downloads/\` — scope derived from the audit + the PR #77 follow-on note on SAM secondary-call relevance bleed. Per the brief: "If a file isn't in [path], it's not blocking — keep moving."

## SC-5 — USAJobs keyword expansion (Workforce layer, 15% weight)
- Audit: \`forUSAJobs = topKeywords.slice(0,2).join(" ")\` matches almost nothing because USAJobs titles use role language ("Health IT Specialist"), not program names ("MHS GENESIS").
- Fix: tiered query in \`layerWorkforce\`. Precise 2-token phrase first, fall back to \`forUSAJobsBroad\` (first topKeyword alone — the "program anchor" token) when precise returns < 3 results. Union by job id.
- Also broadened post-filter to single-token match in title (was AND-style across all topKeywords).

## SC-6 — Top-level \`apiErrors[]\` (error surfacing)
- Audit: all upstream errors swallowed; frontend can't distinguish "API failed → no data" from "API succeeded → confirmed zero."
- Fix: aggregate every layer's \`_apiErrors\` onto top-level \`card.apiErrors[]\`. ops_events \`signal_chain_api_error\` logging unchanged.

## SC-8 — Empty-state suggestion filtering
- Audit: VA + "CCN Next Gen" → 0 hits → suggestions still include "CCN Next Gen." Circular.
- Fix: \`fallbackSuggestionsFor\` accepts current topic and drops suggestions whose label/query overlaps the topic.

## SAM secondary-call relevance bleed (PR #77 comment)
- Symptom: narrow queries (e.g., "DHA Data Governance" + DHA) had the SC-4 secondary deptname-only call dumping unrelated DoD pre-solicitations on top of relevant primary hits.
- Fix: drop secondary when primary >= 3 hits. Secondary results that DO come through tagged \`_secondary=true\` for future scoring deprioritization.

## Cache
- \`CACHE_VERSION\` bumped to \`v3\` because the response shape changed (top-level \`apiErrors[]\`). Pre-fix entries invalidated.

## Smoke (will run against deploy preview, comment posted to PR)
1. \`DHA data governance\` + DHA → contract layer should surface HT001126RE011 in primary results (no Navy pre-solicitations contaminating the top)
2. \`MHS GENESIS\` + DHA → workforce layer broader fallback should surface health-IT jobs even when "GENESIS" isn't in the title
3. Any query → top-level \`apiErrors\` field present if upstream errored, absent if all clean
4. \`CCN Next Gen\` + VA on a zero-hit topic → suggestions exclude "CCN Next Gen"

## Out of scope (queue for future)
- Frontend changes to signal-chain.html that consume \`card.apiErrors[]\` and \`_secondary=true\`. The data is there; UI is a separate sprint.
- Score-weight reduction for \`_secondary=true\` SAM signals. Tagging in place; scoring follows.