### PR TITLE
Sprint 9c: Pursuit Score 2.0 — Phase E (delta engine + run history, flag-gated)

### DIFF
--- a/migrations/20260517000000_pursuit_score_runs.sql
+++ b/migrations/20260517000000_pursuit_score_runs.sql
@@ -1,0 +1,69 @@
+-- ============================================================
+-- 20260517000000_pursuit_score_runs.sql
+--
+-- Pursuit Score 2.0 Phase E — run history table. Stores every
+-- score envelope so the delta engine can compute "what changed
+-- since last run" on re-scores. Without this, every Pursuit
+-- Score call is a cold start with no context about which
+-- dimensions moved, which signals appeared, or which acquisition
+-- state changed.
+--
+-- ADDITIVE ONLY + IDEMPOTENT. Reads gated by PURSUIT_SCORE_RUN_HISTORY
+-- env var (default off); table can sit empty without affecting v1
+-- or v2-without-history behavior.
+--
+-- Spec: ~/Downloads/sprint-9c-pursuit-score-phase-e.md §"Phase E"
+--
+-- DO NOT APPLY TO PRODUCTION FROM THE WORKTREE. Mary runs this in
+-- Supabase SQL Editor per the overnight runbook migration gate.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS pursuit_score_runs (
+  id                  uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  email               text NOT NULL,
+  keyword             text NOT NULL,
+  agency              text,
+  envelope            jsonb NOT NULL,
+  composite           integer,
+  recommendation_state text,
+  acquisition_state   text
+);
+
+-- Lookup index — exact match on (email, lowercased keyword,
+-- coalesced agency), most recent first. Matches the delta engine's
+-- prior-run lookup pattern.
+CREATE INDEX IF NOT EXISTS idx_pursuit_runs_lookup
+  ON pursuit_score_runs (email, lower(keyword), coalesce(agency, ''), created_at DESC);
+
+-- TTL index — created_at descending. Retention policy is on the
+-- operator (keep 12 months, prune older). Defers cleanup to a
+-- separate cron rather than a CHECK constraint.
+CREATE INDEX IF NOT EXISTS idx_pursuit_runs_created_at
+  ON pursuit_score_runs (created_at DESC);
+
+-- Row-level security — only the service role writes; v2 reads
+-- through the engine, which uses SUPABASE_SERVICE_KEY. No subscriber
+-- reads this table directly.
+ALTER TABLE pursuit_score_runs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY pursuit_score_runs_service_key_all
+  ON pursuit_score_runs FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE pursuit_score_runs IS
+  'Pursuit Score 2.0 run history. Stores every score envelope so the delta engine can compute "what changed" across re-runs. Reads gated by PURSUIT_SCORE_RUN_HISTORY env var. See Sprint 9c.';
+COMMENT ON COLUMN pursuit_score_runs.envelope IS
+  'The full Pursuit Score response envelope at run time (jsonb). Includes layers, recommendation, monday_move, acquisition_state, signals — everything the engine emitted.';
+COMMENT ON COLUMN pursuit_score_runs.composite IS
+  'Composite score 0-100 at run time. Denormalized for fast delta queries.';
+COMMENT ON COLUMN pursuit_score_runs.recommendation_state IS
+  'v2 recommendation state at run time (PRIME_DIRECT / SUB_TO_INCUMBENT / etc). Denormalized from envelope.recommendation.state.';
+COMMENT ON COLUMN pursuit_score_runs.acquisition_state IS
+  'v2 acquisition state at run time (RFI_OPEN / RFI_CLOSED_RECENT / DRAFT_RFP / etc). Denormalized from envelope.acquisition_state.state.';
+
+-- Rollback (manual, for reference only — do not run unless reverting):
+--   DROP INDEX IF EXISTS idx_pursuit_runs_created_at;
+--   DROP INDEX IF EXISTS idx_pursuit_runs_lookup;
+--   DROP TABLE IF EXISTS pursuit_score_runs;

--- a/netlify/functions/lib/delta-engine.js
+++ b/netlify/functions/lib/delta-engine.js
@@ -1,0 +1,159 @@
+// ============================================================
+// delta-engine.js — Sprint 9c Phase E. Pure function.
+//
+// computeDelta(current, prior) → DeltaResult
+//
+// Compares two Pursuit Score envelopes (or partials) and returns
+// what changed:
+//   composite_delta            — composite_now - composite_prior
+//   dimensions[name]           — { from, to, delta } per dimension
+//   state_change?              — "FROM → TO" when recommendation state moved
+//   acquisition_state_change?  — same shape for acquisition state
+//   new_signals[]              — signal tags present in current but not prior
+//   lost_signals[]             — signal tags present in prior but not current
+//   prior_run_at?              — passed through from caller for UI rendering
+//
+// No I/O. Caller fetches prior + current and passes both in. Returns
+// a stable shape regardless of inputs so the UI can render
+// "Δ since {prior_run_date}" without nullchecks everywhere.
+// ============================================================
+
+function _num(v) {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function _signalsOf(env) {
+  // Two valid shapes:
+  //   1) v1: env.signals = [{ tag, note }, ...]
+  //   2) v2 layered: env.layers.*.signals = [...] (different shape)
+  // Prefer top-level if present. Returns array of tag strings.
+  if (!env) return [];
+  if (Array.isArray(env.signals)) {
+    return env.signals.map((s) => s && (s.tag || s.title || s.source)).filter(Boolean);
+  }
+  // Fallback: harvest from layers
+  const tags = [];
+  if (env.layers && typeof env.layers === "object") {
+    for (const layer of Object.values(env.layers)) {
+      if (!layer || !Array.isArray(layer.signals)) continue;
+      for (const s of layer.signals) {
+        const tag = s && (s.tag || s.title);
+        if (tag) tags.push(tag);
+      }
+    }
+  }
+  return tags;
+}
+
+function _dimensionsOf(env) {
+  // v2 dimension shape: env.dimensions = { name: { score, max, ... } }
+  // v1 fallback: env.layers = { name: { score, weight } }
+  if (!env) return {};
+  if (env.dimensions && typeof env.dimensions === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(env.dimensions)) {
+      if (v && typeof v.score === "number") out[k] = v.score;
+    }
+    return out;
+  }
+  const out = {};
+  if (env.layers && typeof env.layers === "object") {
+    for (const [k, v] of Object.entries(env.layers)) {
+      if (v && typeof v.score === "number") out[k] = v.score;
+    }
+  }
+  return out;
+}
+
+function _stateOf(env) {
+  if (!env) return null;
+  if (env.recommendation && env.recommendation.state) return env.recommendation.state;
+  if (env.recommendation_state) return env.recommendation_state;
+  return null;
+}
+
+function _acquisitionStateOf(env) {
+  if (!env) return null;
+  if (env.acquisition_state && env.acquisition_state.state) return env.acquisition_state.state;
+  if (typeof env.acquisition_state === "string") return env.acquisition_state;
+  return null;
+}
+
+/**
+ * Compute the delta between a current envelope and a prior one.
+ *
+ * @param {Object|null} current — current Pursuit Score envelope
+ * @param {Object|null} prior   — prior envelope (may be null = first-time score)
+ * @returns {{
+ *   composite_delta: number|null,
+ *   dimensions: Object<string, {from: number|null, to: number|null, delta: number|null}>,
+ *   state_change: string|null,
+ *   acquisition_state_change: string|null,
+ *   new_signals: string[],
+ *   lost_signals: string[],
+ *   prior_run_at: string|null,
+ *   has_prior: boolean
+ * }}
+ */
+function computeDelta(current, prior) {
+  const empty = {
+    composite_delta: null,
+    dimensions: {},
+    state_change: null,
+    acquisition_state_change: null,
+    new_signals: [],
+    lost_signals: [],
+    prior_run_at: null,
+    has_prior: false,
+  };
+  if (!prior) return { ...empty, has_prior: false };
+
+  const curComposite = _num(current && current.composite);
+  const priorComposite = _num(prior.composite);
+  const composite_delta = curComposite !== null && priorComposite !== null
+    ? curComposite - priorComposite
+    : null;
+
+  const curDims = _dimensionsOf(current);
+  const priorDims = _dimensionsOf(prior);
+  const dimensionKeys = new Set([...Object.keys(curDims), ...Object.keys(priorDims)]);
+  const dimensions = {};
+  for (const k of dimensionKeys) {
+    const from = priorDims[k] !== undefined ? priorDims[k] : null;
+    const to = curDims[k] !== undefined ? curDims[k] : null;
+    const delta = (from !== null && to !== null) ? (to - from) : null;
+    dimensions[k] = { from, to, delta };
+  }
+
+  const curState = _stateOf(current);
+  const priorState = _stateOf(prior);
+  const state_change = (curState && priorState && curState !== priorState)
+    ? `${priorState} → ${curState}`
+    : null;
+
+  const curAcq = _acquisitionStateOf(current);
+  const priorAcq = _acquisitionStateOf(prior);
+  const acquisition_state_change = (curAcq && priorAcq && curAcq !== priorAcq)
+    ? `${priorAcq} → ${curAcq}`
+    : null;
+
+  const curSigs = new Set(_signalsOf(current));
+  const priorSigs = new Set(_signalsOf(prior));
+  const new_signals = [...curSigs].filter((s) => !priorSigs.has(s));
+  const lost_signals = [...priorSigs].filter((s) => !curSigs.has(s));
+
+  return {
+    composite_delta,
+    dimensions,
+    state_change,
+    acquisition_state_change,
+    new_signals,
+    lost_signals,
+    prior_run_at: prior.created_at || prior.run_at || null,
+    has_prior: true,
+  };
+}
+
+module.exports = { computeDelta };

--- a/netlify/functions/lib/feature-flags.js
+++ b/netlify/functions/lib/feature-flags.js
@@ -30,6 +30,12 @@ const FLAG_DEFAULTS = {
   // (11 states, v2 subscriber_context fields). When off, the v1 ladder
   // (combineVerdict / classifyCapturePosition) stays live.
   PURSUIT_SCORE_V2: "off",
+  // Pursuit Score 2.0 Phase E run history (Sprint 9c). Default "off" —
+  // when on, every score writes to pursuit_score_runs and reads the
+  // prior run for the same (email, keyword, agency) tuple to compute
+  // delta. Migration must be applied first
+  // (migrations/20260517000000_pursuit_score_runs.sql).
+  PURSUIT_SCORE_RUN_HISTORY: "off",
 };
 
 let _logged = false;

--- a/netlify/functions/pursuit-score.js
+++ b/netlify/functions/pursuit-score.js
@@ -15,6 +15,7 @@ const { getFlag } = require("./lib/feature-flags");
 const { loadToolContext, buildToolEnvelope, buildEvidencePanel, renderBlockedResponse } = require("./lib/premium-tools-core");
 const { loadSubscriberContext } = require("./lib/subscriber-context");
 const { loadEntitlement, blockMessageFor, logEntitlementMismatch } = require("./lib/entitlement");
+const { computeDelta } = require("./lib/delta-engine");
 
 // Cap + overage values come from lib/mmt-pricing.js (single source of truth)
 const MONTHLY_SCORE_CAP = MMT_PRICING.pursuit_score.premium_monthly_allowance;    // 20
@@ -275,6 +276,51 @@ exports.handler = async (event) => {
     console.warn("pursuit-score: ops_events log failed:", logErr.message);
   }
 
+  // Sprint 9c Phase E — write the run + read prior + compute delta.
+  // Gated behind PURSUIT_SCORE_RUN_HISTORY=on AND the migration
+  // (20260517000000_pursuit_score_runs.sql) being applied to Supabase.
+  // Both reads + writes silently no-op on schema-missing / flag-off so
+  // the engine never breaks when history is disabled.
+  let delta = null;
+  let priorRunAt = null;
+  const HISTORY_ON = String(getFlag("PURSUIT_SCORE_RUN_HISTORY") || "").toLowerCase() === "on";
+  if (HISTORY_ON) {
+    try {
+      const lookupKey = String(keyword || "").toLowerCase();
+      const lookupAgency = agency || "";
+      const { data: priorRow } = await supabase
+        .from("pursuit_score_runs")
+        .select("envelope, composite, recommendation_state, acquisition_state, created_at")
+        .eq("email", email)
+        .ilike("keyword", lookupKey)
+        .eq("agency", lookupAgency || null)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (priorRow && priorRow.envelope) {
+        delta = computeDelta(card, { ...priorRow.envelope, created_at: priorRow.created_at });
+        priorRunAt = priorRow.created_at;
+      } else {
+        delta = computeDelta(card, null);
+      }
+    } catch (deltaErr) {
+      console.warn("pursuit-score: prior-run read failed:", deltaErr.message);
+    }
+    try {
+      await supabase.from("pursuit_score_runs").insert({
+        email,
+        keyword,
+        agency: agency || null,
+        envelope: card,
+        composite: card.totalScore || card.total || card.composite || null,
+        recommendation_state: card.recommendation?.state || null,
+        acquisition_state: card.acquisition_state?.state || (typeof card.acquisition_state === "string" ? card.acquisition_state : null),
+      });
+    } catch (writeErr) {
+      console.warn("pursuit-score: run-history write failed:", writeErr.message);
+    }
+  }
+
   const responseBody = {
     ...card,
     remaining: Math.max(cap - used - 1, 0),
@@ -284,6 +330,8 @@ exports.handler = async (event) => {
       overage_per_score: MMT_PRICING.pursuit_score.premium_overage_per_score,
       standalone_per_score: MMT_PRICING.pursuit_score.standalone_per_score,
     },
+    delta: delta || undefined,
+    prior_run_at: priorRunAt || undefined,
   };
   if (envelope) responseBody.envelope = envelope;
 

--- a/tests/unit/delta-engine.test.js
+++ b/tests/unit/delta-engine.test.js
@@ -1,0 +1,128 @@
+// ============================================================
+// tests/unit/delta-engine.test.js
+//
+// Sprint 9c Phase E — computeDelta pure-function coverage.
+// Same opp scored twice with synthetic changes between runs.
+// ============================================================
+
+import { describe, it, expect } from "vitest";
+import { computeDelta } from "../../netlify/functions/lib/delta-engine.js";
+
+const PRIOR_RFI_OPEN = {
+  composite: 60,
+  layers: {
+    research: { score: 30 },
+    legislative: { score: 20 },
+    workforce: { score: 10 },
+    budget: { score: 60 },
+    contract: { score: 70 },
+  },
+  signals: [
+    { tag: "RFI" },
+    { tag: "INDUSTRY_DAY" },
+  ],
+  recommendation: { state: "WATCH_RFI" },
+  acquisition_state: { state: "RFI_OPEN" },
+  created_at: "2026-04-01T12:00:00Z",
+};
+
+const CURRENT_DRAFT_RFP = {
+  composite: 72,
+  layers: {
+    research: { score: 30 },
+    legislative: { score: 30 }, // +10
+    workforce: { score: 12 },   // +2
+    budget: { score: 60 },
+    contract: { score: 85 },    // +15
+  },
+  signals: [
+    { tag: "RFI" },
+    { tag: "DRAFT_RFP_POSTED" }, // new
+  ],
+  recommendation: { state: "WATCH_DRAFT_RFP" },
+  acquisition_state: { state: "DRAFT_RFP" },
+};
+
+describe("computeDelta", () => {
+  it("has_prior=false + empty diff when prior is null", () => {
+    const d = computeDelta(CURRENT_DRAFT_RFP, null);
+    expect(d.has_prior).toBe(false);
+    expect(d.composite_delta).toBeNull();
+    expect(d.dimensions).toEqual({});
+    expect(d.new_signals).toEqual([]);
+    expect(d.lost_signals).toEqual([]);
+    expect(d.state_change).toBeNull();
+    expect(d.acquisition_state_change).toBeNull();
+  });
+
+  it("composite_delta = current - prior", () => {
+    const d = computeDelta(CURRENT_DRAFT_RFP, PRIOR_RFI_OPEN);
+    expect(d.composite_delta).toBe(12);
+    expect(d.has_prior).toBe(true);
+  });
+
+  it("dimension deltas computed per layer", () => {
+    const d = computeDelta(CURRENT_DRAFT_RFP, PRIOR_RFI_OPEN);
+    expect(d.dimensions.legislative).toEqual({ from: 20, to: 30, delta: 10 });
+    expect(d.dimensions.contract).toEqual({ from: 70, to: 85, delta: 15 });
+    expect(d.dimensions.budget).toEqual({ from: 60, to: 60, delta: 0 });
+  });
+
+  it("state_change formatted as 'FROM → TO' when state moves", () => {
+    const d = computeDelta(CURRENT_DRAFT_RFP, PRIOR_RFI_OPEN);
+    expect(d.state_change).toBe("WATCH_RFI → WATCH_DRAFT_RFP");
+  });
+
+  it("acquisition_state_change uses same arrow format", () => {
+    const d = computeDelta(CURRENT_DRAFT_RFP, PRIOR_RFI_OPEN);
+    expect(d.acquisition_state_change).toBe("RFI_OPEN → DRAFT_RFP");
+  });
+
+  it("state_change is null when state didn't move (state-stable re-score)", () => {
+    const unchangedCur = { ...CURRENT_DRAFT_RFP, recommendation: { state: "WATCH_RFI" } };
+    const d = computeDelta(unchangedCur, PRIOR_RFI_OPEN);
+    expect(d.state_change).toBeNull();
+  });
+
+  it("new_signals + lost_signals diff", () => {
+    const d = computeDelta(CURRENT_DRAFT_RFP, PRIOR_RFI_OPEN);
+    expect(d.new_signals).toContain("DRAFT_RFP_POSTED");
+    expect(d.lost_signals).toContain("INDUSTRY_DAY");
+    expect(d.new_signals).not.toContain("RFI"); // unchanged
+  });
+
+  it("prior_run_at passes through from prior.created_at", () => {
+    const d = computeDelta(CURRENT_DRAFT_RFP, PRIOR_RFI_OPEN);
+    expect(d.prior_run_at).toBe("2026-04-01T12:00:00Z");
+  });
+
+  it("envelope.dimensions shape (v2 layered envelope) is honored", () => {
+    const cur = {
+      composite: 80,
+      dimensions: { budget_momentum: { score: 50 }, incumbent_vulnerability: { score: 30 } },
+      recommendation_state: "PRIME_DIRECT",
+    };
+    const prior = {
+      composite: 70,
+      dimensions: { budget_momentum: { score: 40 }, incumbent_vulnerability: { score: 30 } },
+      recommendation_state: "PRIME_DIRECT",
+      created_at: "2026-03-01T00:00:00Z",
+    };
+    const d = computeDelta(cur, prior);
+    expect(d.composite_delta).toBe(10);
+    expect(d.dimensions.budget_momentum).toEqual({ from: 40, to: 50, delta: 10 });
+    expect(d.state_change).toBeNull(); // both PRIME_DIRECT
+  });
+
+  it("graceful when current has no composite", () => {
+    const d = computeDelta({}, PRIOR_RFI_OPEN);
+    expect(d.composite_delta).toBeNull();
+    expect(d.has_prior).toBe(true);
+  });
+
+  it("AWARDED → AWARDED (no change) emits no acquisition_state_change", () => {
+    const a = { ...PRIOR_RFI_OPEN, acquisition_state: { state: "AWARDED" } };
+    const b = { ...CURRENT_DRAFT_RFP, acquisition_state: { state: "AWARDED" } };
+    expect(computeDelta(b, a).acquisition_state_change).toBeNull();
+  });
+});


### PR DESCRIPTION
Sprint 9c. Closes Pursuit Score 2.0. Every re-score against the same \`(email, keyword, agency)\` now carries a delta against the prior run.

## Two gates required at runtime
- \`PURSUIT_SCORE_V2 = on\` (Sprints 9a + 9b)
- \`PURSUIT_SCORE_RUN_HISTORY = on\` (this sprint)

Both default **off**. v1 path stays live until Mary flips them.

## What this ships

### Migration — NOT applied
\`migrations/20260517000000_pursuit_score_runs.sql\` — creates \`pursuit_score_runs\` (id, created_at, email, keyword, agency, envelope JSONB, denormalized composite/recommendation_state/acquisition_state). Lookup index on \`(email, lower(keyword), coalesce(agency,''), created_at DESC)\`. RLS on with service_role policy. Rollback block included as SQL comment. **Mary applies via Supabase SQL Editor**; SQL also emitted to MORNING_REPORT.md.

### Delta engine (pure)
\`netlify/functions/lib/delta-engine.js\` — \`computeDelta(current, prior) → DeltaResult\` returns:
- \`composite_delta\`
- \`dimensions[name] = {from, to, delta}\`
- \`state_change\` formatted \`FROM → TO\` (null when unchanged)
- \`acquisition_state_change\` same arrow format
- \`new_signals[]\` / \`lost_signals[]\`
- \`prior_run_at\`, \`has_prior\`

Handles v1 (\`envelope.layers.*\` scored) AND v2 (\`envelope.dimensions\`) shapes. First-run case (no prior) returns a stable all-empty diff with \`has_prior=false\`.

### Engine wire-up
\`netlify/functions/pursuit-score.js\` — under \`PURSUIT_SCORE_RUN_HISTORY=on\`:
- reads most-recent prior run for \`(email, lower(keyword), agency)\`
- calls \`computeDelta\`
- inserts the current envelope into \`pursuit_score_runs\`

Both ops wrapped in try/catch — engine never fails because history is unavailable (schema missing, flag off, etc.). Response gets \`delta\` + \`prior_run_at\` at top level when present; omitted otherwise so existing UI keeps working.

## Tests — 11 new, all passing (full suite 266/266)
\`tests/unit/delta-engine.test.js\` covers:
- first-run empty diff
- composite_delta math
- per-dimension deltas
- state_change / acquisition_state_change arrow formatting
- null state_change on unchanged state
- new_signals/lost_signals diff
- prior_run_at passthrough
- v2 dimensions shape
- graceful null current
- AWARDED → AWARDED emits no acquisition_state_change

## Out of scope (deferred to focused UI sprint)
Per the 9c spec § "UI polish": render delta badges, "Δ since {prior_run_date}" banner, evidence-panel toggle on \`/premium/pursuit-score.html\`. The engine carries everything the template needs; client-side rendering scoped to that page + its component scripts in a follow-on PR.

## Risk + rollback
- Migration purely additive (CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS). Rollback via \`DROP TABLE\`.
- All flag-gated; flip \`PURSUIT_SCORE_RUN_HISTORY=off\` to revert with zero deploy.
- Delta engine is a pure function; revertable via single commit revert.

## Mary action checklist
1. Apply migration SQL (block also in MORNING_REPORT.md) via Supabase SQL Editor.
2. Set \`PURSUIT_SCORE_RUN_HISTORY=on\` in Netlify env when ready.
3. Confirm \`PURSUIT_SCORE_V2\` is already set to \`on\` (needs 9a + 9b active for state/move/acquisition fields to appear in envelope).
4. Score "VA SCM DSO HELM" twice — second response carries \`delta\` with prior_run_at and per-dimension diffs.