### PR TITLE
HHS OMAS coverage + capture intel refresh + brief tile bug fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,115 @@ Before declaring work complete, verify:
 
 ---
 
+## Sprint 2026-05-18 — HHS OMAS realignment coverage (Phase 1 site update)
+
+Triggered by Mary's HHS update package delivered 2026-05-18:
+`paid-reader-changes.md` + `orgchart-hhs.json` + `site-update-spec.md`
++ `sources.md` + `email-send-spec.md` + `CLAUDE_CODE_HANDOFF.md`.
+Perplexity-assembled briefing on the May 2026 HHS Acquisition Solutions
+Day. Phase 2 (the email send) is gated on Mary's explicit approval per
+email-send-spec.md — not in this sprint.
+
+Translation note: the spec was written assuming Astro/Next.js. This
+repo is static HTML built by `node build.js` with `mmt_premium`
+localStorage gates, so the translation is: spec routes map to flat HTML
+files in `premium/{agencies,policy,updates,org-charts}/`, with clean
+URLs wired in `netlify.toml`. Every new clean URL is registered in
+`docs/member-features.json` so `validate-routes.js` enforces resolution.
+
+What shipped (single PR):
+
+- **4 data files**:
+  - `data/orgcharts/hhs.json` — verbatim from Mary's package. Canonical
+    HHS contracting org dataset (10 HCAs, OMAS leadership, ASFR
+    sub-offices, FY25 by-the-numbers).
+  - `data/orgcharts/index.json` — registry for future agency orgchart
+    datasets.
+  - `data/policy/eo-procurement.json` — EO 14210 (workforce), EO 14222
+    (cost), EO 14240 (procurement consolidation), OMB M-25-31 (impl).
+  - `data/changelog/2026-05-18-hhs-omas.json` — 8 TL;DR items with
+    source IDs into sources.md (S1, S9, S10, S13 slide refs, S14, S15).
+- **HHS profile JSON update** (`data/premium/agency-profiles/agencies.json`):
+  `description`, `mmtRead`, `role`, `key_offices` (now OMAS-led),
+  `key_vehicles` (OASIS+, NASA SEWP, GSA MAS IT, NITAAC CIO-SP),
+  `upcoming_signals` (OMAS Market Hour, RFO 8.4, FY26 consolidation),
+  `current_read`, `contractorRead`, `policyModule` (PACT + 3 EOs),
+  `opportunityMap` (3 SBCs), `watchNext` (5 entries), `sources` (6 IDs).
+  `lastUpdated` → 2026-05-18. Schema-stable: validate-agency-parity and
+  validate-agency-profiles both pass.
+- **build.js change**: `ORG_CHART_AGENCIES = new Set(['dha','va','hhs'])`
+  — the existing `generateAgencyProfilePage` auto-wires the
+  "View HHS Org Chart" CTA on `/agencies/hhs`. Plus a new auto-discovery
+  loop for `premium/{agencies,policy,updates}/` that mirrors the existing
+  `premium/org-charts/` pattern (siteScriptTag + tailwind inline +
+  noindex meta on copy to dist).
+- **7 new pages**:
+  - `premium/org-charts/hhs.html` (22KB) — visual orgchart: Office of
+    Secretary → ASA/ASFR → OA divisions → OMAS leadership → 3 SBCs →
+    10-HCAs grid. VACANT rows shown (per spec section E rule).
+    Sources footer cites HHS HCA roster + ASFR personnel + OSDBU +
+    Solutions Day deck.
+  - `premium/agencies/hhs-omas.html` (66KB) — OMAS standup, leadership,
+    3 SBCs scope detail, strategic goals (verbatim from deck), 3-year
+    outlook, Market Hour table (June 2026), staffing trajectory
+    (~40 → ~180).
+  - `premium/agencies/hhs-hcas.html` (65KB) — 10-row sortable +
+    filterable table. Filters: All / Permanent / Acting / New since
+    2025. Search box. Notable: 3 of 10 are Acting (ARPA-H, CDC, CMS —
+    the biggest spenders).
+  - `premium/policy/pact.html` (63KB) — PACT (now HHS Agency Priority
+    Goal), 4 doc cards (EO 14210/14222/14240/M-25-31) with plain-English
+    + vendor impact, Standardization Suitability Spectrum callout, FY26
+    consolidation outlook (28 OpDivs → 15).
+  - `premium/policy/rfo-8-4.html` (60KB) — 3 tier cards (MPT / SAT /
+    above SAT), each with rule + GSAR cite + vendor move callout. Plus
+    the 5 other RFO 8.4 changes + "RFIs from black hole to spotlight"
+    verbatim callout. PTAI on AcquisitionGateway.gov referenced.
+  - `premium/updates/2026-05-18-hhs-omas.html` (60KB) — the
+    subscriber-email landing. 8 numbered change-cards with item-level
+    deep links. Closer block ("if you only do one thing this week").
+    Otter mishearings audit (ASTR → ASFR, ARC → AHRQ, Bluedown →
+    Bredow).
+- **6 netlify.toml redirects** (status=200): `/agencies/hhs/orgchart`,
+  `/agencies/hhs/omas`, `/agencies/hhs/hcas`, `/policy/pact`,
+  `/policy/rfo-8-4`, `/updates/2026-05-18-hhs-omas`. validate-routes
+  duplicate-from check passes.
+- **6 docs/member-features.json registry entries** — required by
+  validate-routes.js (every marketed clean URL must register here).
+
+Hard rules added / re-asserted:
+- **Premium content grouped under `premium/{agencies,policy,updates}/`**
+  uses the same flat-file + inline-mmt_premium-gate pattern as
+  `premium/org-charts/`. The auto-discovery loop in build.js picks up
+  any new .html file. No per-feature subdirs beyond the grouping layer.
+- **The `policy/` tier is new** — first two pages are pact.html +
+  rfo-8-4.html. Future federal-procurement policy explainers (FAR Part
+  12 rewrites, FY27 consolidation rules) belong here.
+- **The `updates/` tier is the subscriber-email landing pattern.**
+  `/updates/<date>-<slug>` maps to `premium/updates/<date>-<slug>.html`.
+  Mary's email-send-spec links into this path; the landing surfaces the
+  8-item TL;DR with deep links into the full coverage.
+- **Otter.ai transcripts are a primary source for HHS event coverage**,
+  but mishearings happen (ASTR vs ASFR; ARC vs AHRQ; Bluedown vs
+  Bredow). Cross-check against the official ASFR Key Personnel and HCA
+  roster pages before publishing. Document the corrections in the
+  sources footer so future readers can verify.
+- **A Mary-delivered spec's path conventions are spec hypothesis, not
+  repo reality.** When a spec is authored against a generic stack (the
+  paid-reader-changes.md said "Astro/Next pages"), translate routes to
+  this repo's flat-HTML pattern and adapt the gate to the inline
+  `mmt_premium` localStorage check. Don't fabricate a framework.
+
+Verification (ran 2026-05-18):
+- `node build.js` — clean exit. 392 dist pages.
+- `node scripts/validate-dist.js` — OK, all sweeps pass.
+- `node scripts/validate-routes.js` — ✓ all 29 features resolve.
+- `node scripts/validate-agency-profiles.js` — OK, 11 agencies pass.
+- `node scripts/validate-agency-parity.js` — OK, 11 agencies pass.
+- Local preview against `dist/` — all 7 new URLs return HTTP 200 with
+  expected payload sizes.
+- Zero console errors on the org chart page.
+
 ## Sprint 2026-05-07 (late afternoon) — Digital Mary handoff: data laydown + halt for missing specs
 
 Mary directed: "do sprint 5 wave2 then do the handoff package digital mary".

--- a/build.js
+++ b/build.js
@@ -900,6 +900,32 @@ function escapeHtml(str) {
   return (str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+// Decode HTML entities so values pulled out of source HTML (titles,
+// descriptions) become plain text. Pair this with escapeHtml at the
+// render site — otherwise an `&amp;` in the source flows through to
+// the browser as `&amp;amp;` and renders literally as "&amp;". Surfaced
+// 2026-05-18 by the dashboard "Latest Friday Brief" tile showing
+// "DHA Budget &amp; Org Realignment" instead of "DHA Budget & Org
+// Realignment".
+function decodeHtmlEntities(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&middot;/g, '·')
+    .replace(/&mdash;/g, '—')
+    .replace(/&ndash;/g, '–')
+    .replace(/&rarr;/g, '→')
+    .replace(/&larr;/g, '←')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n, 10)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&amp;/g, '&');
+}
+
 function wrapText(text, maxCharsPerLine) {
   const words = text.split(/\s+/);
   const lines = [];
@@ -4439,8 +4465,12 @@ function getBriefFiles() {
       const descMatch = html.match(/<meta name="description" content="([^"]+)"/);
       const titleMatch = html.match(/<title>([^<]+)<\/title>/);
       const h1Match = html.match(/<h1[^>]*>([^<]+)<\/h1>/);
-      const desc = descMatch ? descMatch[1].split('. Weekly')[0] : '';
-      const rawTitle = (h1Match && h1Match[1]) || (titleMatch && titleMatch[1]) || '';
+      // Decode entities — source HTML uses `&amp;` etc., and the
+      // downstream renderer escapeHtml-s again. Without decoding here
+      // the dashboard tile renders "DHA Budget &amp; Org Realignment"
+      // literally. See decodeHtmlEntities note near top of file.
+      const desc = descMatch ? decodeHtmlEntities(descMatch[1].split('. Weekly')[0]) : '';
+      const rawTitle = decodeHtmlEntities((h1Match && h1Match[1]) || (titleMatch && titleMatch[1]) || '');
       const cleanedTitle = rawTitle.replace(/\s*\|\s*Mission Meets Tech.*$/, '').trim();
       out.set(dateStr, {
         file: f,
@@ -4503,9 +4533,11 @@ function getCaptureCornerFiles() {
     const titleMatch = html.match(/<title>([^<]+)<\/title>/);
     const descMatch = html.match(/<meta name="description" content="([^"]+)"/);
     const h1Match = html.match(/<h1[^>]*>([^<]+)<\/h1>/);
-    const rawTitle = (h1Match && h1Match[1]) || (titleMatch && titleMatch[1]) || `Capture Corner — ${formatted}`;
+    // Decode entities at extraction so escapeHtml() at the render
+    // site doesn't double-encode `&amp;` -> `&amp;amp;`.
+    const rawTitle = decodeHtmlEntities((h1Match && h1Match[1]) || (titleMatch && titleMatch[1]) || `Capture Corner — ${formatted}`);
     const title = rawTitle.replace(/\s*\|\s*Mission Meets Tech.*$/, '').replace(/\s*—\s*Capture Corner.*$/, '').trim();
-    const desc = descMatch ? descMatch[1].replace(/\s*\.?\s*Weekly.*$/, '').trim() : '';
+    const desc = descMatch ? decodeHtmlEntities(descMatch[1]).replace(/\s*\.?\s*Weekly.*$/, '').trim() : '';
     return {
       file: f,
       date: dateStr,

--- a/build.js
+++ b/build.js
@@ -3387,6 +3387,32 @@ ${innerHtml}
     console.log(`Copied ${ocFiles.length} premium org-chart page(s)`);
   }
 
+  // HHS sprint (2026-05-18) — auto-copy premium/agencies/, premium/policy/,
+  // premium/updates/ subdirs to dist. Same pattern as premium/org-charts/
+  // above. Each .html file in these subdirs is a self-contained paid page
+  // with its own inline dash-shell + mmt_premium gate. Drop a new file in
+  // and the build picks it up.
+  const premiumSubdirs = ['agencies', 'policy', 'updates'];
+  premiumSubdirs.forEach((sub) => {
+    const srcDir = path.join(__dirname, 'premium', sub);
+    if (!fs.existsSync(srcDir)) return;
+    const files = fs.readdirSync(srcDir).filter((f) => f.endsWith('.html'));
+    files.forEach((file) => {
+      const srcPath = path.join(srcDir, file);
+      const destPath = path.join(DIST_DIR, 'premium', sub, file);
+      ensureDir(path.dirname(destPath));
+      let html = fs.readFileSync(srcPath, 'utf8');
+      if (!html.includes('noindex')) {
+        html = html.replace('<head>', '<head>\n  <meta name="robots" content="noindex, nofollow">');
+      }
+      html = html.replace('</body>', siteScriptTag + '\n</body>');
+      html = inlineTailwindCss(html);
+      fs.writeFileSync(destPath, html);
+      console.log(`Copied premium/${sub}/${file}`);
+    });
+    if (files.length) console.log(`Copied ${files.length} premium/${sub} page(s)`);
+  });
+
   // Friday Brief pipeline — render content/friday-briefs/*.md to
   // premium/friday-briefs/<date>.html using the friday-brief-loader.
   // Added 2026-04-24 along with the scheduled_emails.stream='friday_brief'
@@ -4251,7 +4277,7 @@ function generateAgencyProfilePage(agency) {
 
   // Org chart availability — extend this Set when more chart pages land
   // in premium/org-charts/.
-  const ORG_CHART_AGENCIES = new Set(['dha', 'va']);
+  const ORG_CHART_AGENCIES = new Set(['dha', 'va', 'hhs']);
   const orgChartUrl = ORG_CHART_AGENCIES.has(agency.slug) ? `/premium/org-charts/${agency.slug}` : null;
   const orgChartCta = orgChartUrl ? `
     <a href="${orgChartUrl}" class="no-underline" style="display:inline-flex;align-items:center;gap:10px;padding:10px 16px;background:var(--mmt-navy);color:var(--mmt-white);font-weight:600;font-size:13px;border-radius:8px;margin-bottom:24px;">

--- a/data/changelog/2026-05-18-hhs-omas.json
+++ b/data/changelog/2026-05-18-hhs-omas.json
@@ -1,0 +1,90 @@
+{
+  "$schema_version": "1.0",
+  "id": "2026-05-18-hhs-omas",
+  "agency": "HHS",
+  "date": "2026-05-18",
+  "title": "HHS just made 8 changes that reshape FY26 BD plans",
+  "summary": "HHS Acquisition Solutions Day (May 2026) quietly rewrote how federal health agencies buy. OMAS is the new HCA, HHS dropped from 13 contracting activities to 10, and all common IT plus professional services consolidates through OMAS. Eight items every paid subscriber should know.",
+  "tier": "paid",
+  "data_as_of": "2026-05-18",
+  "primary_source_date": "2026-04-27",
+  "items": [
+    {
+      "id": "1",
+      "headline": "A new HHS contracting activity exists: OMAS.",
+      "summary": "The Office of Mission Acquisition Solutions (formerly OAMS) was realigned under ASFR / Office of Acquisitions in January 2026 and is now a designated HCA on the official HHS roster. Quentin McCoy is the HCA.",
+      "sources": ["S1", "S13", "S14"],
+      "links": [
+        { "label": "HHS HCA roster", "url": "https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html" },
+        { "label": "OMAS deep dive", "url": "/agencies/hhs/omas" }
+      ]
+    },
+    {
+      "id": "2",
+      "headline": "HHS contracting activities dropped from 13 to 10.",
+      "summary": "ACF and AHRQ independent contracting authority was eliminated. Both portfolios now flow through OMAS SBC-Mission.",
+      "sources": ["S13 slide 2", "S14"],
+      "links": [
+        { "label": "All 10 HCAs", "url": "/agencies/hhs/hcas" }
+      ]
+    },
+    {
+      "id": "3",
+      "headline": "Common IT and Professional Services centralize through OMAS.",
+      "summary": "Driven by EO 14240 (Procurement Consolidation, March 20, 2025) and OMB M-25-31 (July 18, 2025). Mission-specific procurement stays with the OpDiv.",
+      "sources": ["S9", "S10", "S13 slide 4"],
+      "links": [
+        { "label": "PACT explainer", "url": "/policy/pact" }
+      ]
+    },
+    {
+      "id": "4",
+      "headline": "HHS FY25 spend dropped to $28.2B.",
+      "summary": "A $16.3B reduction from final FY25 obligations driven by the HHS Cost Efficiency Initiative (HCEI). FY22-FY24 averaged ~$40B/yr.",
+      "sources": ["S13 slide 2"],
+      "links": []
+    },
+    {
+      "id": "5",
+      "headline": "OMAS Market Hour launches June 2026.",
+      "summary": "10-minute capability demo plus 5-minute Q&A virtual sessions. Customer-interest-driven selection from a Vendor Profile Form. Contact IndustryLiaison@hhs.gov.",
+      "sources": ["S13 slide 19", "S13 slide 28"],
+      "links": [
+        { "label": "OMAS deep dive", "url": "/agencies/hhs/omas" }
+      ]
+    },
+    {
+      "id": "6",
+      "headline": "GSAR 538.7103 (RFO 8.4) rewrote schedule-based buying.",
+      "summary": "Three tiers (at-or-below MPT / MPT-to-SAT / above-SAT) with different competition requirements. RFIs now drive whether your firm makes the RFQ list.",
+      "sources": ["S13 slides 24-25"],
+      "links": [
+        { "label": "RFO 8.4 tier playbook", "url": "/policy/rfo-8-4" }
+      ]
+    },
+    {
+      "id": "7",
+      "headline": "The HHS IDEAS Lab is central, not optional.",
+      "summary": "Kimberly Himes is the new HHS Acquisition Innovation Advocate (AIA) and Industry Liaison. Acquisition Innovation moved from optional practice to key driver under the FAR Overhaul.",
+      "sources": ["S13 slides 20-21", "S15"],
+      "links": []
+    },
+    {
+      "id": "8",
+      "headline": "HHS may consolidate further.",
+      "summary": "The FY2026 Budget in Brief signals consolidation of 28 operating divisions to 15 and closure of 5 regional offices. Today's 10-HCA org chart is a snapshot, not a steady state.",
+      "sources": ["S5"],
+      "links": [
+        { "label": "FY26 Budget in Brief", "url": "https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf" }
+      ]
+    }
+  ],
+  "related_pages": [
+    "/agencies/hhs",
+    "/agencies/hhs/omas",
+    "/agencies/hhs/hcas",
+    "/agencies/hhs/orgchart",
+    "/policy/pact",
+    "/policy/rfo-8-4"
+  ]
+}

--- a/data/orgcharts/hhs.json
+++ b/data/orgcharts/hhs.json
@@ -1,0 +1,203 @@
+{
+  "schema_version": "1.0",
+  "agency": "HHS",
+  "agency_full_name": "U.S. Department of Health and Human Services",
+  "data_as_of": "2026-05-18",
+  "primary_source_date": "2026-04-27",
+  "primary_sources": [
+    {
+      "label": "HHS Heads of Contracting Activity (HCA) — official roster",
+      "url": "https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html",
+      "as_of": "2026-04-27"
+    },
+    {
+      "label": "ASFR Key Personnel — official roster",
+      "url": "https://www.hhs.gov/about/agencies/asfr/key-personnel/index.html",
+      "as_of": "2026-04-27"
+    },
+    {
+      "label": "HHS OSDBU — Small Business Specialists by OpDiv",
+      "url": "https://www.hhs.gov/about/agencies/asfr/acquisition/osdbu/index.html",
+      "as_of": "2026-05-07"
+    },
+    {
+      "label": "HHS Organizational Charts (department-level)",
+      "url": "https://www.hhs.gov/about/organization/org-chart/index.html",
+      "as_of": "2025-08-21"
+    },
+    {
+      "label": "HHS Acquisition Solutions Day — Industry Day slide deck",
+      "url": "internal: HHS-Industry-Day-Slides.docx (Mary Womack workspace)",
+      "as_of": "2026-05-15 (event)"
+    },
+    {
+      "label": "HHS Acquisition Solutions Day — Otter.ai transcript",
+      "url": "internal: HHS-Acquisition-Solutions-Day_otter_ai_transcript.txt",
+      "as_of": "2026-05-15 (event)"
+    },
+    {
+      "label": "HHS FY2026 Budget in Brief",
+      "url": "https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf",
+      "as_of": "2025-06-02"
+    }
+  ],
+  "department_top": {
+    "secretary_office": "Office of the Secretary (OS)",
+    "asa": {
+      "name": "Office of the Assistant Secretary for Administration (ASA)",
+      "url": "https://www.hhs.gov/about/agencies/asa/about-asa/index.html"
+    },
+    "asfr": {
+      "name": "Office of the Assistant Secretary for Financial Resources (ASFR)",
+      "url": "https://www.hhs.gov/about/agencies/asfr/key-personnel/index.html",
+      "address": "Room 514-G, Hubert H. Humphrey Building, 200 Independence Ave SW, Washington DC 20201",
+      "phone": "202-690-6396",
+      "leadership_notes": "Principal Deputy ASFR — VACANT. Deputy Assistant Secretary for Operations and Management — VACANT.",
+      "sub_offices": [
+        { "name": "Office of Budget", "deputy_assistant_secretary": "Norris Cochran" },
+        { "name": "Office of Finance", "deputy_assistant_secretary": "Teresa Miranda", "title_note": "also HHS Deputy CFO" },
+        { "name": "Office of Grants", "deputy_assistant_secretary": "Dale Bell" },
+        {
+          "name": "Office of Acquisitions (OA)",
+          "deputy_assistant_secretary_for_acquisitions": {
+            "name": "Jennifer Johnson",
+            "title": "Deputy Assistant Secretary for Acquisitions (Senior Procurement Executive)",
+            "phone": "771-215-0133",
+            "responsibilities_per_slide_13": [
+              "Execute procurement-related statutory responsibilities of the Secretary, Deputy Secretary and Chief Acquisition Officer",
+              "Support ~$28B in annual HHS contract spending through policy, workforce, and oversight",
+              "Drive cost-efficiency via category management, workforce development, business systems",
+              "Build partnerships with Division Heads of Contracting and represent HHS in cross-government acquisition forums"
+            ],
+            "oa_managed_areas": [
+              "Procurement Business Systems",
+              "Acquisition Workforce Development",
+              "Industry Engagement",
+              "Procurement Policy",
+              "Oversight of Agency Acquisition Programs",
+              "Category Management",
+              "Procurement Innovation",
+              "Federal Acquisition Support Programs",
+              "Vendor Relations"
+            ]
+          },
+          "associate_deputy": { "name": "Anthony Kram", "phone": "202-578-0045" },
+          "divisions_under_oa": [
+            { "name": "Strategic Programs & Business Systems Division", "exec_director": "Sonya Carrion", "phone": "301-532-2220" },
+            { "name": "Office of Acquisition Policy, Legislation, Oversight & Workforce", "exec_director": "Mahua Muzamdar", "phone": "301-532-2216" },
+            { "name": "Office of Small & Disadvantaged Business Utilization (OSDBU)", "exec_director": "Shannon Jackson", "phone": "202-934-3804 (alt: 202-690-7300)", "email": "Shannon.Jackson@hhs.gov", "reporting_line_note": "Per OSDBU page: reports directly to the HHS Deputy Secretary; OA provides administrative support", "established": "1979 under P.L. 95-507" },
+            { "name": "Office of Recipient Integrity Coordination", "director": "Tiffani Redding", "phone": "202-768-0628" },
+            { "name": "Office of Mission Acquisition Solutions (OMAS)", "is_new_in_2025": true, "see_section": "omas" },
+            { "name": "HHS IDEAS Lab & Acquisition Program Support Division", "director": "Kimberly Himes", "additional_titles": ["HHS Acquisition Innovation Advocate (AIA)", "Industry Liaison"], "function": "HHS acquisition innovation lab (analog to DHS PIL, NASA M.A.I.L., VA SALE)" }
+          ]
+        }
+      ]
+    }
+  },
+  "omas": {
+    "full_name": "Office of Mission Acquisition Solutions",
+    "former_name": "OAMS (Office of Acquisition Management Services)",
+    "renamed_note": "OAMS → OMAS as part of PACT realignment under ASFR/Office of Acquisitions",
+    "joined_asfr": "January 2026 (per Quentin McCoy transcript remarks)",
+    "mission": "Enterprise shared service for common IT & Professional Services procurement across HHS; designated contracting activity for ACF, AHRQ, and Divisions without independent procurement authority",
+    "hca_email": "Quentin.McCoy@hhs.gov",
+    "hca_phone": "301-492-5456",
+    "industry_liaison_email": "IndustryLiaison@hhs.gov",
+    "staffing": {
+      "starting_strength": "~40+ at standup",
+      "current_strength": "~180 (as of May 2026)",
+      "trajectory": "Actively hiring; goal is fully staffed by end of Year 1 (Stand-Up & Stabilize)"
+    },
+    "leadership": [
+      { "name": "Quentin McCoy", "title": "Executive Director, Head of Contracting Activity (HCA)", "background": "Former HCA experience at U.S. Cyber Command and CAO/UMBC office (prior to OMAS)" },
+      { "name": "Colette Magwood", "title": "Chief of Staff" },
+      { "name": "VACANT", "title": "Deputy Head of Contracting Activity" },
+      { "name": "Lisa Portner", "title": "Director, Procurement Operations Support (POS)" }
+    ],
+    "strategic_buying_centers": [
+      {
+        "name": "Strategic Buying Center — Mission (SBC-Mission)",
+        "director": "Tatricia (Trish) James",
+        "scope": "Department-wide mission needs; Secretary initiatives; serves ACF, AHRQ, and Staff Divisions (Note: ACF and AHRQ independent contracting authority eliminated and absorbed by OMAS)"
+      },
+      {
+        "name": "Strategic Buying Center — Information Technology (SBC-IT)",
+        "director": "Adam Vance",
+        "scope": "Common enterprise IT, software, cyber, cloud, AI-related tools"
+      },
+      {
+        "name": "Strategic Buying Center — Professional Services (SBC-PS)",
+        "director": "Scott Bredow",
+        "scope": "Advisory, scientific, training & technical assistance, and programmatic services across HHS"
+      }
+    ],
+    "category_management_lead": {
+      "name": "Sonya Carrion",
+      "title": "Executive Director, Strategic Programs & Business Systems",
+      "note": "Featured on slide 22 alongside Trish James, Scott Bredow, Adam Vance for category management partnership"
+    },
+    "strategic_goals": [
+      "Stand up a fully staffed, trained, and equipped OMAS workforce",
+      "Build a high-impact customer engagement and experience model",
+      "Drive innovation and efficiency across the full acquisition lifecycle to deliver measurable savings",
+      "Establish OMAS as the Acquisition Office of Choice for Common IT and Professional Services across HHS"
+    ],
+    "three_year_outlook": [
+      { "year": "Year 1 — Stand-Up & Stabilize (current)", "milestones": ["OMAS Intake Activated", "Operating Model Established", "PACT Established as Agency Priority Goal", "Systems Modernization Kicked Off (NIH)"] },
+      { "year": "Year 2 — Optimize and Buy Better (enterprise buying)", "milestones": ["Establish Strategic Sourcing Vehicles", "Continue systems modernization/integration (NIH, CDC & CMS)", "Develop Demand Aggregation Initiatives", "Create Category-Based Solutions", "Demonstrate Reduced Duplication and Costs"] },
+      { "year": "Year 3 — Scale and Transform (departmental excellence)", "milestones": ["Enable Enterprise Insights & Analytics", "Leverage Data-Driven Strategies", "Establish a Scalable Acquisition Model", "Become a Strategic Mission Partner"] }
+    ]
+  },
+  "heads_of_contracting_activity_full_roster": [
+    { "opdiv": "ARPA-H", "opdiv_full_name": "Advanced Research Projects Agency for Health", "hca_name": "Benjamin Bryant", "hca_status": "Acting", "email": "benjamin.bryant@arpa-h.gov", "phone": null, "small_business_specialist": "Cindy Anderson (Cynthia.Anderson@hhs.gov, 202-578-1356)" },
+    { "opdiv": "CDC", "opdiv_full_name": "Centers for Disease Control and Prevention", "hca_name": "Christine Godfrey", "hca_status": "Acting", "email": "cnp9@cdc.gov", "phone": "770-488-2519", "small_business_specialists": ["Gwendolyn Miles (Gwendolyn.Miles@hhs.gov, 202-758-5124)", "LaTonya Dent (LaTonya.Dent@hhs.gov, 202-748-0571)"] },
+    { "opdiv": "CMS", "opdiv_full_name": "Centers for Medicare & Medicaid Services", "hca_name": "Doug Bergevin", "hca_status": "Acting", "email": "douglas.bergevin@cms.hhs.gov", "phone": "443-909-0131", "small_business_specialists": ["Anita Allen (Anita.Allen1@cms.hhs.gov, 202-640-0264)", "Christine Haber (Christine.Haber@hhs.gov, 202-853-1616)"] },
+    { "opdiv": "FDA", "opdiv_full_name": "Food and Drug Administration", "hca_name": "Leonard Grant", "hca_status": "Permanent", "email": "Leonard.Grant@fda.hhs.gov", "phone": "240-402-7584", "small_business_specialist": "Cindy Anderson (Cynthia.Anderson@hhs.gov, 202-578-1356)" },
+    { "opdiv": "HRSA", "opdiv_full_name": "Health Resources & Services Administration", "hca_name": "Brian Goodger", "hca_status": "Permanent", "email": "BGoodger@hrsa.gov", "phone": "301-945-9380", "small_business_specialist": "Wayne Berry (Wayne.Berry@hhs.gov, 202-390-5801)" },
+    { "opdiv": "IHS", "opdiv_full_name": "Indian Health Service", "hca_name": "Chantel Smith", "hca_status": "Permanent", "email": "Chantel.Smith@ihs.gov", "phone": "240-460-6876", "small_business_specialist": "Jonathan Ferguson (Jonathan.Ferguson@hhs.gov, 202-740-5509)" },
+    { "opdiv": "NIH", "opdiv_full_name": "National Institutes of Health", "hca_name": "Olga Acosta", "hca_status": "Permanent", "email": "olga.acosta@nih.gov", "phone": "301-435-4322", "small_business_specialists": ["Natasha Boyce", "Melanie Carter", "Jonathan Ferguson", "Anita Allen", "Amy Ulisse (amy.ulisse@hhs.gov, 771-216-7719)", "Martina Williams"] },
+    { "opdiv": "OMAS", "opdiv_full_name": "Office of the Secretary / ASFR / Office of Mission Acquisition Solutions", "hca_name": "Quentin McCoy", "hca_status": "Permanent (NEW HCA designation)", "email": "Quentin.McCoy@hhs.gov", "phone": "301-492-5456", "new_in_2025_2026": true, "note": "OMAS is the designated contracting activity for ACF, AHRQ, and HHS Divisions without independent procurement authority, plus all common IT and Professional Services procurements department-wide" },
+    { "opdiv": "ASPR", "opdiv_full_name": "Administration for Strategic Preparedness and Response", "hca_name": "Makoto P. Braxton", "hca_status": "Permanent", "email": "makoto.braxton@hhs.gov", "phone": "202-260-6794", "small_business_specialist": "LaTonya Dent (LaTonya.Dent@hhs.gov, 202-748-0571)" },
+    { "opdiv": "OIG", "opdiv_full_name": "Office of Inspector General", "hca_name": "John Marshall", "hca_status": "Permanent", "email": "john.marshall@oig.hhs.gov", "phone": "240-749-1499", "small_business_specialist": "Amy Ulisse (amy.ulisse@hhs.gov, 771-216-7719)" }
+  ],
+  "decentralized_opdivs_no_independent_contracting_authority": [
+    "ACF (Administration for Children and Families) — contracting absorbed into OMAS",
+    "AHRQ (Agency for Healthcare Research and Quality) — contracting absorbed into OMAS",
+    "SAMHSA (Substance Abuse and Mental Health Services Administration) — verify with HHS; small business specialist Gwendolyn Miles is OSDBU contact, but no HCA listed on HCA roster; coverage likely via OMAS or another HCA",
+    "ACL (Administration for Community Living) — verify; not listed on current HCA roster"
+  ],
+  "by_the_numbers_fy25": {
+    "fiscal_year": "FY2025",
+    "total_spend_usd": 28.2e9,
+    "yoy_pattern": {
+      "FY22": 41.0e9,
+      "FY23": 40.3e9,
+      "FY24": 39.1e9,
+      "FY25": 28.2e9,
+      "fy25_reduction_note": "HHS saw a $16.3B reduction from its final FY25 obligations due to the HHS Cost Efficiency Initiative (HCEI)"
+    },
+    "active_contracts": 4459,
+    "contract_actions": 56080,
+    "contracting_activities_count": 10,
+    "acquisition_workforce": {
+      "total_certified_count": 11024,
+      "as_of": "April 2026",
+      "fac_c_count": 1107,
+      "fac_p_pm_count": 952,
+      "fac_cor_count": 10688,
+      "note": "Workforce members may hold more than one certification; total is unique count of all acquisition individuals"
+    },
+    "acquisition_tools_count": "20+ acquisition-related systems including 6+ contract writing systems",
+    "fy26_sb_goal_overall": "25%",
+    "fy24_sb_scorecard_grade": "B (one of three federal agencies that did not achieve full SB prime contracting goals)",
+    "fy24_federal_sb_awards_total": "$69.6B (record, up from $66.6B in FY23)",
+    "osdbu_estab_year": 1979,
+    "osdbu_statute": "P.L. 95-507; 15 U.S.C. § 644(k)"
+  },
+  "future_consolidation_warning": {
+    "from": "HHS FY2026 Budget in Brief",
+    "url": "https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf",
+    "claim": "HHS plans to consolidate 28 operating divisions to 15 and close five of our most costly regional offices, returning FTE strength to roughly FY1990s levels",
+    "implication_for_subscribers": "Today's 10 HCAs may further consolidate; expect additional OpDiv mergers in FY26-FY27."
+  }
+}

--- a/data/orgcharts/index.json
+++ b/data/orgcharts/index.json
@@ -1,0 +1,14 @@
+{
+  "$schema_version": "1.0",
+  "comment": "Canonical index of agency org-chart datasets in data/orgcharts/*.json. Drives the /agencies/<slug>/orgchart pages and the AgencyOrgChart component. Add a new entry when a new agency dataset lands.",
+  "agencies": [
+    {
+      "slug": "hhs",
+      "name": "Department of Health and Human Services",
+      "tier": "paid",
+      "updated": "2026-05-18",
+      "data_path": "/data/orgcharts/hhs.json",
+      "page_url": "/agencies/hhs/orgchart"
+    }
+  ]
+}

--- a/data/policy/eo-procurement.json
+++ b/data/policy/eo-procurement.json
@@ -1,0 +1,56 @@
+{
+  "$schema_version": "1.0",
+  "comment": "Executive Orders and OMB memos that are driving the HHS procurement consolidation. Used by /policy/pact and surfaced on the /agencies/hhs profile. Sources: whitehouse.gov primary text + OMB memo PDF. Verified 2026-05-18.",
+  "data_as_of": "2026-05-18",
+  "records": [
+    {
+      "id": "eo-14210",
+      "type": "executive_order",
+      "number": "14210",
+      "title": "Implementing the President's Department of Government Efficiency Workforce Optimization Initiative",
+      "short_title": "DOGE Workforce Optimization Initiative",
+      "signed_date": "2025-02-11",
+      "url": "https://www.whitehouse.gov/presidential-actions/2025/02/implementing-the-presidents-department-of-government-efficiency-workforce-optimization-initiative/",
+      "plain_english": "Sets a 4-to-1 hiring ratio, directs RIF prep, and requires agency reorganization plans within 30 days.",
+      "vendor_impact": "Tightens the acquisition workforce on the buyer side. Expect fewer COs handling more files, longer cycle times, and more emphasis on consolidated buying.",
+      "affected_agencies": ["HHS", "VA", "DoD", "GSA", "all federal"]
+    },
+    {
+      "id": "eo-14222",
+      "type": "executive_order",
+      "number": "14222",
+      "title": "Implementing the President's Department of Government Efficiency Cost Efficiency Initiative",
+      "short_title": "DOGE Cost Efficiency Initiative",
+      "signed_date": "2025-02-26",
+      "url": "https://www.whitehouse.gov/presidential-actions/2025/02/implementing-the-presidents-department-of-government-efficiency-cost-efficiency-initiative/",
+      "plain_english": "Centralizes contract payment justification systems, requires a 30-day contract review, and freezes new CO warrants during the review window.",
+      "vendor_impact": "Existing contracts may be terminated for convenience or de-scoped. Modifications now require a written justification linked to the payment system. Cuts directly feed the FY25 $16.3B HHS spend reduction.",
+      "affected_agencies": ["HHS", "VA", "DoD", "GSA", "all federal"]
+    },
+    {
+      "id": "eo-14240",
+      "type": "executive_order",
+      "number": "14240",
+      "title": "Eliminating Waste and Saving Taxpayer Dollars by Consolidating Procurement",
+      "short_title": "Procurement Consolidation",
+      "signed_date": "2025-03-20",
+      "url": "https://www.whitehouse.gov/wp-content/uploads/2025/07/M-25-31-Consolidating-Federal-Procurement-Activities.pdf",
+      "url_note": "Primary EO text is referenced verbatim in OMB M-25-31; the full Federal Register text is the canonical record.",
+      "plain_english": "Mandates the transfer of common goods and services procurement to GSA. This is the root authority behind the HHS PACT initiative and the OMAS standup.",
+      "vendor_impact": "Common IT and Professional Services contracting consolidates through GSA Best-in-Class vehicles or, at HHS, through OMAS. If your firm sells laptops, cloud, cyber tools, or advisory services into HHS, your CO has moved.",
+      "affected_agencies": ["HHS", "VA", "DoD", "all federal"]
+    },
+    {
+      "id": "omb-m-25-31",
+      "type": "omb_memo",
+      "number": "M-25-31",
+      "title": "Consolidating Federal Procurement Activities",
+      "short_title": "OMB M-25-31",
+      "signed_date": "2025-07-18",
+      "url": "https://www.whitehouse.gov/wp-content/uploads/2025/07/M-25-31-Consolidating-Federal-Procurement-Activities.pdf",
+      "plain_english": "Implementation guidance for EO 14240. Two workstreams: (1) increased GSA use across agencies, (2) physical centralization of procurement function at GSA for specified categories.",
+      "vendor_impact": "Names the canonical buying paths: GSA MAS IT, NASA SEWP, NITAAC CIO-SP, and category-managed BICs. Be on these vehicles or be invisible to OMAS.",
+      "affected_agencies": ["HHS", "VA", "DoD", "GSA", "all federal"]
+    }
+  ]
+}

--- a/data/premium/agency-profiles/agencies.json
+++ b/data/premium/agency-profiles/agencies.json
@@ -647,7 +647,7 @@
           "why_it_matters": "Ohio + Indiana + Alaska + Cleveland brings the rollout across multiple VISNs in a single fiscal year. The demand surface expands for change management, clinician training, and interoperability integration."
         }
       ],
-      "caveat": "DigitalVA states 10 medical centers are currently live on the Federal EHR; the extracted deployment table identifies 6 prior sites. Preserve this discrepancy as an integrity signal \u2014 verify before publishing an external numeric live-site count.",
+      "caveat": "DigitalVA states 10 medical centers are currently live on the Federal EHR; the extracted deployment table identifies 6 prior sites. Preserve this discrepancy as an integrity signal — verify before publishing an external numeric live-site count.",
       "source_id": "va_ehr_sched"
     },
     "contractorRead": "VA's 2026 deployment posture moves the conversation from 'will the program continue?' to 'who supports the wave cadence?' Look at integrator vehicles, change-management staffing, clinician-trainer pipelines, telehealth and interoperability adapters, and EHRM-aligned cybersecurity. Michigan in April is the proof point downstream solicitations will cite.",
@@ -681,37 +681,33 @@
     "abbrev": "HHS",
     "name": "Department of Health and Human Services",
     "type": "Cabinet Department (parent of CMS, NIH, FDA, CDC, IHS, ONC, ARPA-H)",
-    "lastUpdated": "2026-05-13",
-    "description": "Department-level map. HHS itself sets policy and coordinates; the buying happens through its operating divisions. OS/OCIO (Office of the Secretary, CIO) is the enterprise IT, cybersecurity, AI governance, and data-operations consolidation point at the department level. Operating divisions: CMS (Medicare, Medicaid, claims), NIH (research IT, NITAAC), FDA (Sentinel, regulated-product data), CDC (data modernization, DCIPHER), IHS (PATH EHR), ASTP/ONC (interoperability, certification), ARPA-H (OTA-funded R&D).",
-    "mmtRead": "HHS IT spend is decentralized, but OS/OCIO is the department-level consolidation seat for AI, data, technology, cybersecurity, and data operations \u2014 that's where cross-OPDIV framing lives (the HHS AI strategy + the HIPAA security rule update + cross-cutting tech and cyber direction). Treat HHS as a navigation layer: route procurement questions to the operating division that owns the program (CMS for claims, NIH for research IT, FDA for surveillance, ASTP/ONC for standards). The departmental level is for policy, rulemaking, and OCIO-level enterprise coordination, not contract awards.",
+    "lastUpdated": "2026-05-18",
+    "description": "HHS just realigned. As of January 2026, OMAS (the Office of Mission Acquisition Solutions) is the new contracting activity for all common IT, professional services, and what used to flow through ACF and AHRQ. The department dropped from 13 contracting activities to 10. If you sell common IT or advisory services into HHS, your contracting officer moved. If you sell mission-unique work to NIH, CDC, CMS, FDA, HRSA, IHS, ASPR, ARPA-H, or OIG, you stay where you are.",
+    "mmtRead": "HHS is two stories now, not one. The mission-unique side (NIH for research IT, CMS for claims, FDA for surveillance, ARPA-H for OTA-funded R&D) still buys at the operating division. The common side (laptops, cloud, cybersecurity tools, advisory services, training) flows through OMAS strategic buying centers under EO 14240 and OMB M-25-31. Your BD calendar needs both maps: the operating-division map for mission, the OMAS SBC map for common. Expect the picture to keep moving — the FY26 Budget in Brief signals 28 operating divisions consolidating to 15 plus 5 regional offices closing.",
     "officialSources": [
       {
-        "label": "HHS About",
-        "url": "https://www.hhs.gov/about/index.html"
+        "label": "HHS HCA and Key Managers roster",
+        "url": "https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html"
       },
       {
-        "label": "CMS About",
-        "url": "https://www.cms.gov/about-cms"
+        "label": "HHS ASFR Key Personnel",
+        "url": "https://www.hhs.gov/about/agencies/asfr/key-personnel/index.html"
       },
       {
-        "label": "ONC About",
-        "url": "https://healthit.gov/about/"
+        "label": "HHS OSDBU",
+        "url": "https://www.hhs.gov/about/agencies/asfr/acquisition/osdbu/index.html"
       },
       {
-        "label": "ARPA-H Programs",
-        "url": "https://arpa-h.gov/explore-funding/programs/advocate"
+        "label": "HHS Organizational Charts",
+        "url": "https://www.hhs.gov/about/organization/org-chart/index.html"
       },
       {
-        "label": "IHS PATH EHR",
-        "url": "https://www.ihs.gov/hit/path-ehr/"
+        "label": "HHS FY2026 Budget in Brief",
+        "url": "https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf"
       },
       {
-        "label": "CDC Data Modernization",
-        "url": "https://www.cdc.gov/data-modernization/php/about/index.html"
-      },
-      {
-        "label": "FDA Sentinel",
-        "url": "https://www.fda.gov/safety/fdas-sentinel-initiative"
+        "label": "OMB M-25-31 (Procurement Consolidation)",
+        "url": "https://www.whitehouse.gov/wp-content/uploads/2025/07/M-25-31-Consolidating-Federal-Procurement-Activities.pdf"
       },
       {
         "label": "HHS AI Strategy & Implementation",
@@ -719,16 +715,18 @@
       }
     ],
     "keyPrograms": [
-      "Department-level coordination",
-      "Cross-OPDIV interoperability and AI governance",
-      "HIPAA modernization (policy)",
-      "OS/OCIO enterprise IT, cybersecurity, AI/data governance, data operations (department level)"
+      "OMAS standup and PACT (Procurement Alignment and Collaboration Task Force) — now an HHS Agency Priority Goal",
+      "Common IT and Professional Services centralization (driven by EO 14240 + OMB M-25-31)",
+      "HHS Cost Efficiency Initiative (HCEI) — drove the FY25 $16.3B spend reduction",
+      "Cross-OPDIV AI governance, data modernization, HIPAA modernization (policy)"
     ],
     "procurementSignals": [
-      "See operating division profiles for actual procurement"
+      "Common IT and PS through OMAS SBC-IT (Adam Vance) and SBC-PS (Scott Bredow)",
+      "ACF / AHRQ mission-unique work now in OMAS SBC-Mission (Trish James)",
+      "NIH, CDC, CMS, FDA, HRSA, IHS, ASPR, ARPA-H, OIG — each retains its own HCA and contracting authority"
     ],
     "openVehicles": [
-      "See CMS / NIH / NITAAC for operating-division vehicles"
+      "OASIS+, NASA SEWP V/VI, GSA MAS IT, NITAAC CIO-SP — the canonical buying paths OMAS leverages today"
     ],
     "premiumLocked": false,
     "budget": {
@@ -744,48 +742,93 @@
         "Public health preparedness funding (proposed cuts)"
       ]
     },
-    "current_read": "HHS at the department level coordinates policy. Buying flows through CMS, NIH, FDA, CDC, IHS, ONC, and ARPA-H. Use the operating-division profiles for actual procurement opportunities.",
-    "key_vehicles": [],
+    "current_read": "OMAS is the new front door for common IT and Professional Services at HHS, effective January 2026. ACF and AHRQ no longer have their own contracting authority — their work flows through OMAS SBC-Mission. The nine other HCAs (ARPA-H, CDC, CMS, FDA, HRSA, IHS, NIH, ASPR, OIG) keep mission-unique procurement. PACT is now an HHS Agency Priority Goal. The FY25 spend total dropped to $28.2B (down $16.3B from final FY25 obligations) on HCEI cuts. Three of the ten HCAs are still Acting (ARPA-H, CDC, CMS) — expect leadership churn at the biggest spenders.",
+    "key_vehicles": [
+      "OASIS+ (consolidated professional-services BIC)",
+      "NASA SEWP V / SEWP VI (IT hardware and software)",
+      "GSA MAS IT (multiple-award schedule)",
+      "NITAAC CIO-SP (NIH-issued, government-wide IT)",
+      "OMAS internal strategic-sourcing vehicles (under development, Year-2 outlook)"
+    ],
     "key_offices": [
-      "OS/OCIO (Office of the Secretary, CIO)",
-      "ASFR (Assistant Secretary for Financial Resources)",
-      "Operating Divisions (CMS, NIH, FDA, CDC, IHS, ONC, ARPA-H)"
+      "OMAS (Office of Mission Acquisition Solutions) — Quentin McCoy, HCA",
+      "OMAS SBC-IT — Adam Vance, Director (common enterprise IT, software, cyber, cloud, AI tools)",
+      "OMAS SBC-PS — Scott Bredow, Director (advisory, scientific, training, programmatic)",
+      "OMAS SBC-Mission — Tatricia (Trish) James, Director (ACF, AHRQ, Staff Divisions, Secretary initiatives)",
+      "ASFR / Office of Acquisitions — Jennifer Johnson, DAS for Acquisitions and Senior Procurement Executive",
+      "OSDBU — Shannon Jackson, Executive Director (reports to HHS Deputy Secretary)",
+      "HHS IDEAS Lab — Kimberly Himes, Acquisition Innovation Advocate and Industry Liaison"
     ],
     "recent_awards": [],
     "upcoming_signals": [
-      "HIPAA security rule update (proposed rulemaking)",
-      "Cross-OPDIV AI governance framework"
+      "OMAS Market Hour launches June 2026 — 10-minute capability demos + 5-minute Q&A. Contact IndustryLiaison@hhs.gov.",
+      "RFO 8.4 / GSAR 538.7103 rewrites schedule ordering. Three tiers (at-or-below MPT, MPT-to-SAT, above-SAT). RFIs now drive who makes the RFQ list.",
+      "FY26 Budget in Brief consolidation: 28 operating divisions to 15, plus 5 regional offices closing.",
+      "SBCX subcontracting opportunity feature in development at osdbu.hhs.gov.",
+      "HIPAA security rule update (proposed rulemaking)."
     ],
     "related_tags": [
+      "HHS",
+      "OMAS",
+      "PACT",
+      "Procurement Consolidation",
       "Healthcare Policy",
       "Interoperability"
     ],
-    "role": "Department-level navigation + AI governance",
+    "role": "Department-level navigation + OMAS shared service for common IT and Professional Services (since January 2026)",
     "premiumModules": [
-      "AI Governance Module",
-      "Confirmed-vs-Watch Split",
-      "Contractor Read"
+      "10 HCA Roster",
+      "OMAS Deep Dive",
+      "OMAS Org Chart",
+      "PACT + 3 EOs + OMB M-25-31",
+      "RFO 8.4 Tier Playbook",
+      "AI Governance"
     ],
     "policyModule": {
-      "title": "HHS Enterprise AI and Digital Governance",
+      "title": "EO 14240 + OMB M-25-31 + PACT",
       "confirmed_facts": [
-        "HHS frames its AI work as making AI available to the federal workforce and integrating AI across internal operations, research, and public health.",
-        "The official AI strategy themes are: driving AI innovation, improving AI governance, and fostering public trust in federal AI use.",
-        "The current public-facing AI artifact does not specify contract clauses, purchasing vehicles, or procurement requirements."
+        "EO 14240 (Procurement Consolidation, March 20, 2025) mandates transfer of common goods/services procurement to GSA — the root authority behind PACT.",
+        "OMB M-25-31 (Consolidating Federal Procurement Activities, July 18, 2025) is the implementation guidance: increased GSA use + procurement function centralization at GSA.",
+        "PACT (Procurement Alignment and Collaboration Task Force) is now an HHS Agency Priority Goal.",
+        "OMAS was realigned under ASFR/Office of Acquisitions in January 2026; staffing grew from ~40 at standup to ~180 by May 2026.",
+        "ACF and AHRQ independent contracting authority was eliminated and absorbed by OMAS SBC-Mission."
       ],
       "vendor_watch": [
-        "Governance artifacts: model documentation, evaluation frameworks, audit-ready logs, bias and fairness measurement.",
-        "Workforce enablement: AI literacy, role-specific training, secure model access for federal employees.",
-        "Responsible implementation: explainability, content provenance, safety/security review documentation.",
-        "Public-trust posture: transparency reports, plain-language disclosures, third-party assurance options.",
-        "Do not market HHS AI procurement requirements that the public page does not state. Treat as watch, not confirmed buy."
+        "Vehicle posture: be on GSA MAS IT, NASA SEWP, NITAAC CIO-SP, OASIS+. These are the canonical buying paths OMAS leverages.",
+        "OMAS Market Hour (June 2026): submit the Vendor Profile Form via IndustryLiaison@hhs.gov. Customer-interest-driven selection.",
+        "RFO 8.4 (GSAR 538.7103) tier rules: RFIs now drive who makes RFQ lists. Respond with facts, not brochures.",
+        "Small business: SBCX (osdbu.hhs.gov) is being expanded with a subcontracting opportunity feature — register and watch."
       ],
-      "source_id": "hhs_ai"
+      "source_id": "hhs_omas_solutions_day"
     },
-    "contractorRead": "HHS is a regulator-of-self for AI rollout across operating divisions, not a single buyer. Treat HHS-level AI direction as setting tone for CMS, CDC, FDA, IHS, NIH operating-division procurements. The right capture move is to map each governance theme to the operating division that actually buys, then position there.",
+    "contractorRead": "Two BD plans, not one. For common IT and Professional Services, build the OMAS SBC relationship and submit the Vendor Profile Form for Market Hour. For mission-unique work, your operating-division contracting officer is unchanged. Watch what comes off ACF and AHRQ recompetes — those move into OMAS SBC-Mission and reopen the field. Confirm presence on OASIS+, NASA SEWP, GSA MAS IT, and NITAAC CIO-SP, because OMAS leverages those vehicles today. Treat any quarterly OMAS Market Hour as a real foot in the door, not a vendor event.",
     "watchNext": [
       {
-        "signal": "HHS AI compliance plan publications and operating-division alignment activity",
+        "signal": "OMAS Market Hour first session (June 2026) — Vendor Profile Form submissions due now",
+        "buyer": "OMAS programs + acquisition staff",
+        "window": "June 2026",
+        "source_id": "hhs_omas_solutions_day"
+      },
+      {
+        "signal": "ACF / AHRQ recompete sweep absorbed into OMAS SBC-Mission",
+        "buyer": "OMAS SBC-Mission (Trish James)",
+        "window": "FY2026-FY2027",
+        "source_id": "hhs_hca_roster"
+      },
+      {
+        "signal": "OMAS strategic-sourcing vehicles announced in Year-2 outlook",
+        "buyer": "OMAS SBC-IT + SBC-PS",
+        "window": "FY2027",
+        "source_id": "hhs_omas_solutions_day"
+      },
+      {
+        "signal": "FY26 Budget consolidation milestones (28 OpDivs to 15; 5 regional offices closing)",
+        "buyer": "HHS department level",
+        "window": "FY2026-FY2027",
+        "source_id": "hhs_fy26_bib"
+      },
+      {
+        "signal": "HHS AI compliance plan publications and OpDiv alignment activity",
         "buyer": "HHS + operating divisions",
         "window": "FY2026-FY2027",
         "source_id": "hhs_ai"
@@ -793,14 +836,71 @@
     ],
     "sources": [
       {
+        "id": "hhs_hca_roster",
+        "label": "HHS HCA and Key Managers roster",
+        "url": "https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html",
+        "verified_at": "2026-04-27",
+        "confidence": "high"
+      },
+      {
+        "id": "hhs_asfr_personnel",
+        "label": "HHS ASFR Key Personnel page",
+        "url": "https://www.hhs.gov/about/agencies/asfr/key-personnel/index.html",
+        "verified_at": "2026-04-27",
+        "confidence": "high"
+      },
+      {
+        "id": "hhs_osdbu",
+        "label": "HHS OSDBU — Small Business Specialists by OpDiv",
+        "url": "https://www.hhs.gov/about/agencies/asfr/acquisition/osdbu/index.html",
+        "verified_at": "2026-05-07",
+        "confidence": "high"
+      },
+      {
+        "id": "hhs_omas_solutions_day",
+        "label": "HHS Acquisition Solutions Day (May 2026) — Industry Day deck + transcripts",
+        "url": "https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html",
+        "verified_at": "2026-05-15",
+        "confidence": "high",
+        "caveat": "Event materials sourced from the HHS-owned slide deck (28 slides) and Otter.ai transcripts. Otter mishearings (ASTR → ASFR, ARC → AHRQ) were corrected against the official ASFR and HCA roster pages."
+      },
+      {
+        "id": "hhs_fy26_bib",
+        "label": "HHS FY2026 Budget in Brief",
+        "url": "https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf",
+        "verified_at": "2025-06-02",
+        "confidence": "high"
+      },
+      {
+        "id": "hhs_ai",
         "label": "HHS AI Strategy & Implementation",
         "url": "https://www.hhs.gov/programs/topic-sites/ai/strategy-implementation/index.html",
         "verified_at": "2026-05-12",
         "confidence": "high",
-        "caveat": "Page does not state contract clauses, vehicles, or procurement requirements. Vendor implications are watch items, not confirmed buys.",
-        "id": "hhs_ai"
+        "caveat": "Page does not state contract clauses, vehicles, or procurement requirements. Vendor implications are watch items, not confirmed buys."
       }
-    ]
+    ],
+    "opportunityMap": {
+      "title": "OMAS Strategic Buying Centers",
+      "map": [
+        {
+          "sbc": "SBC-IT",
+          "director": "Adam Vance",
+          "what_lands": "Common enterprise IT, software, cyber, cloud, AI-related tools"
+        },
+        {
+          "sbc": "SBC-PS",
+          "director": "Scott Bredow",
+          "what_lands": "Advisory, scientific, training and technical assistance, programmatic services"
+        },
+        {
+          "sbc": "SBC-Mission",
+          "director": "Tatricia (Trish) James",
+          "what_lands": "Department-wide mission needs; Secretary initiatives; ACF, AHRQ, and Staff Divisions"
+        }
+      ],
+      "source_id": "hhs_omas_solutions_day"
+    }
   },
   {
     "slug": "onc",
@@ -901,7 +1001,7 @@
         "The HTI-2 final rule finalizes TEFCA-related provisions supporting electronic health information access, exchange, and use.",
         "The rule establishes 45 CFR Part 172 for TEFCA-related provisions.",
         "The rule amends information-blocking regulations by adding TEFCA Manner Exception definitions.",
-        "The rule makes no changes to the existing TEFCA Manner Exception at 45 CFR \u00a7 171.403."
+        "The rule makes no changes to the existing TEFCA Manner Exception at 45 CFR § 171.403."
       ],
       "vendor_watch": [
         "TEFCA transparency and reliability documentation as a deliverable compliance artifact set.",
@@ -956,7 +1056,7 @@
     "procurementSignals": [
       "ADVOCATE TA1/TA2/TA3 awards (June 2026)",
       "Sprint for Women's Health solicitation rolling",
-      "FY2027 budget zeroed in HHS proposal \u2014 executing on existing FY2026 funds"
+      "FY2027 budget zeroed in HHS proposal — executing on existing FY2026 funds"
     ],
     "openVehicles": [
       "OTA (program-specific, not a unified vehicle)"
@@ -1216,7 +1316,7 @@
     "type": "HHS Operating Division (federal-tribal health system)",
     "lastUpdated": "2026-05-12",
     "description": "Federal health system serving American Indian and Alaska Native populations. Currently executing PATH EHR Modernization on Oracle Cerner / Oracle Health to replace the legacy RPMS system. Vendor: GDIT.",
-    "mmtRead": "IHS PATH is the active EHR modernization arc \u2014 replacing RPMS with Oracle Health on the GDIT platform. Tribal health IT procurement intersects with both federal contracting and tribal sovereignty considerations, which constrains what vendors can compete and how.",
+    "mmtRead": "IHS PATH is the active EHR modernization arc — replacing RPMS with Oracle Health on the GDIT platform. Tribal health IT procurement intersects with both federal contracting and tribal sovereignty considerations, which constrains what vendors can compete and how.",
     "officialSources": [
       {
         "label": "IHS PATH EHR",
@@ -1576,7 +1676,7 @@
     "name": "National Institutes of Health / NIH IT Acquisition and Assessment Center",
     "type": "HHS Research Agency + Acquisition Channel",
     "lastUpdated": "2026-05-12",
-    "description": "NIH is the country's biomedical research agency. NITAAC is NIH's acquisition center and runs CIO-SP3 / CIO-SP4 (canceled) / CIO-CS \u2014 the NIH GWACs that anchor IT procurement across HHS. Treat NIH as both a research buyer and an acquisition channel for the rest of HHS.",
+    "description": "NIH is the country's biomedical research agency. NITAAC is NIH's acquisition center and runs CIO-SP3 / CIO-SP4 (canceled) / CIO-CS — the NIH GWACs that anchor IT procurement across HHS. Treat NIH as both a research buyer and an acquisition channel for the rest of HHS.",
     "mmtRead": "CIO-SP4 was canceled (SAM Amendment 0017 on RFP 75N98121R00001). CIO-SP3 is the active bridge through Apr 29 2027. CIO-CS is the IT commodities vehicle and a follow-on (`The Store`) is in pre-RFP at a reported $20B-$25B.",
     "officialSources": [
       {
@@ -1674,7 +1774,7 @@
         "source_id": "nitaac_cio_sp3"
       },
       {
-        "signal": "CIO-SP4 status \u2014 verify-before-publishing watch; treat any cancellation claim as unverified until primary-source-confirmed",
+        "signal": "CIO-SP4 status — verify-before-publishing watch; treat any cancellation claim as unverified until primary-source-confirmed",
         "buyer": "NITAAC",
         "window": "Verify before quoting",
         "source_id": "nitaac_cio_sp3"
@@ -1697,8 +1797,8 @@
     "name": "General Services Administration",
     "type": "Acquisition Channel (governmentwide IT vehicles)",
     "lastUpdated": "2026-05-13",
-    "description": "Acquisition channel + GSAR owner. Runs Alliant 3 (active, no ceiling), Polaris (small business), 8(a) STARS III ($50B), OASIS+ (professional services). GSAR \u2014 the GSA Acquisition Regulation, including the GSAR 552.239-7001 AI procurement clause \u2014 sets governmentwide AI and IT procurement governance language. Track GSA vehicles AND the GSAR rule-shaping lane.",
-    "mmtRead": "Alliant 3 went live with NTP March 10 2026 (42 Phase 1 contractors). Polaris small business GWAC is active. 8(a) STARS III ordering window runs through Jul 1 2026 with GSA option through 2029. OASIS+ continues on-ramping. The GSAR layer \u2014 particularly the GSAR 552.239-7001 AI procurement clause and the Refresh 32 acceptance work \u2014 is the rule-shaping signal vendors should track alongside vehicle access; AI procurement governance is moving faster than the vehicle on-ramps.",
+    "description": "Acquisition channel + GSAR owner. Runs Alliant 3 (active, no ceiling), Polaris (small business), 8(a) STARS III ($50B), OASIS+ (professional services). GSAR — the GSA Acquisition Regulation, including the GSAR 552.239-7001 AI procurement clause — sets governmentwide AI and IT procurement governance language. Track GSA vehicles AND the GSAR rule-shaping lane.",
+    "mmtRead": "Alliant 3 went live with NTP March 10 2026 (42 Phase 1 contractors). Polaris small business GWAC is active. 8(a) STARS III ordering window runs through Jul 1 2026 with GSA option through 2029. OASIS+ continues on-ramping. The GSAR layer — particularly the GSAR 552.239-7001 AI procurement clause and the Refresh 32 acceptance work — is the rule-shaping signal vendors should track alongside vehicle access; AI procurement governance is moving faster than the vehicle on-ramps.",
     "officialSources": [
       {
         "label": "GSA Alliant 3",
@@ -1722,7 +1822,7 @@
       "Polaris (small business GWAC)",
       "8(a) STARS III ($50B, Jul 2026 ordering end)",
       "OASIS+ (professional services, no ceiling)",
-      "GSAR (GSA Acquisition Regulation) \u2014 AI procurement governance, e.g., 552.239-7001"
+      "GSAR (GSA Acquisition Regulation) — AI procurement governance, e.g., 552.239-7001"
     ],
     "procurementSignals": [
       "Alliant 3 task orders ramping",

--- a/docs/member-features.json
+++ b/docs/member-features.json
@@ -336,6 +336,90 @@
       "freshness_sla_hours": null,
       "smoke_test_url": "/agencies/",
       "noindex": false
+    },
+    {
+      "feature_name": "HHS Org Chart",
+      "public_marketing_urls": [
+        "/agencies/hhs/orgchart"
+      ],
+      "member_url": "/premium/org-charts/hhs.html",
+      "backing_function": "static page (HHS sprint 2026-05-18) reading data/orgcharts/hhs.json",
+      "entitlement_required": "premium|founding|institutional|admin",
+      "public_locked_preview_behavior": "redirect to dashboard.html (sign-in gate)",
+      "expected_data_source": "data/orgcharts/hhs.json + HHS HCA roster + ASFR Key Personnel + Acquisition Solutions Day deck (May 2026)",
+      "freshness_sla_hours": null,
+      "smoke_test_url": "/agencies/hhs/orgchart",
+      "noindex": true
+    },
+    {
+      "feature_name": "HHS OMAS Deep Dive",
+      "public_marketing_urls": [
+        "/agencies/hhs/omas"
+      ],
+      "member_url": "/premium/agencies/hhs-omas.html",
+      "backing_function": "static page (HHS sprint 2026-05-18)",
+      "entitlement_required": "premium|founding|institutional|admin",
+      "public_locked_preview_behavior": "redirect to dashboard.html (sign-in gate)",
+      "expected_data_source": "HHS Acquisition Solutions Day deck + transcripts (May 2026)",
+      "freshness_sla_hours": null,
+      "smoke_test_url": "/agencies/hhs/omas",
+      "noindex": true
+    },
+    {
+      "feature_name": "HHS 10 HCAs Roster",
+      "public_marketing_urls": [
+        "/agencies/hhs/hcas"
+      ],
+      "member_url": "/premium/agencies/hhs-hcas.html",
+      "backing_function": "static page (HHS sprint 2026-05-18)",
+      "entitlement_required": "premium|founding|institutional|admin",
+      "public_locked_preview_behavior": "redirect to dashboard.html (sign-in gate)",
+      "expected_data_source": "HHS HCA and Key Managers roster + HHS OSDBU (Small Business Specialists by OpDiv)",
+      "freshness_sla_hours": 2160,
+      "smoke_test_url": "/agencies/hhs/hcas",
+      "noindex": true
+    },
+    {
+      "feature_name": "PACT and the 3 EOs",
+      "public_marketing_urls": [
+        "/policy/pact"
+      ],
+      "member_url": "/premium/policy/pact.html",
+      "backing_function": "static page (HHS sprint 2026-05-18) reading data/policy/eo-procurement.json",
+      "entitlement_required": "premium|founding|institutional|admin",
+      "public_locked_preview_behavior": "redirect to dashboard.html (sign-in gate)",
+      "expected_data_source": "EO 14210, EO 14222, EO 14240, OMB M-25-31, HHS FY2026 Budget in Brief",
+      "freshness_sla_hours": null,
+      "smoke_test_url": "/policy/pact",
+      "noindex": true
+    },
+    {
+      "feature_name": "RFO 8.4 Tier Playbook",
+      "public_marketing_urls": [
+        "/policy/rfo-8-4"
+      ],
+      "member_url": "/premium/policy/rfo-8-4.html",
+      "backing_function": "static page (HHS sprint 2026-05-18)",
+      "entitlement_required": "premium|founding|institutional|admin",
+      "public_locked_preview_behavior": "redirect to dashboard.html (sign-in gate)",
+      "expected_data_source": "GSAR 538.7103 + HHS Acquisition Solutions Day deck slides 23-25",
+      "freshness_sla_hours": null,
+      "smoke_test_url": "/policy/rfo-8-4",
+      "noindex": true
+    },
+    {
+      "feature_name": "HHS OMAS Update (2026-05-18)",
+      "public_marketing_urls": [
+        "/updates/2026-05-18-hhs-omas"
+      ],
+      "member_url": "/premium/updates/2026-05-18-hhs-omas.html",
+      "backing_function": "static page (HHS sprint 2026-05-18) \u2014 paid-subscriber email landing",
+      "entitlement_required": "premium|founding|institutional|admin",
+      "public_locked_preview_behavior": "redirect to dashboard.html (sign-in gate)",
+      "expected_data_source": "data/changelog/2026-05-18-hhs-omas.json",
+      "freshness_sla_hours": null,
+      "smoke_test_url": "/updates/2026-05-18-hhs-omas",
+      "noindex": true
     }
   ]
 }

--- a/intel-capture-intelligence.html
+++ b/intel-capture-intelligence.html
@@ -229,11 +229,11 @@
     <section class="ci-hero">
       <div class="wrap">
         <div class="ci-hero-meta">
-          <span data-capture-updated data-content-updated="2026-04-17">April 2026</span>
+          <span data-capture-updated data-content-updated="2026-05-18">Last reviewed May 18, 2026</span>
           <span class="dot">·</span>
           <span>FY2027 Federal Health Budget</span>
           <span class="dot">·</span>
-          <span data-capture-signal-count>25 Signals · 10 Agencies</span>
+          <span data-capture-signal-count>21 live signals · 12 agencies</span>
         </div>
         <h1 class="ci-page-title">Capture Intelligence:<br><span class="accent">FY2027 Federal Health Budget</span></h1>
         <p class="ci-page-subtitle">Two issues. Every row in the summary table is expanded below with sourced, decision-level intelligence: what the funding actually buys, what changed, who holds incumbent position, and what the action window requires. Every material claim carries a confidence label.</p>
@@ -273,7 +273,7 @@
     <section class="ci-table-section">
       <div class="wrap">
         <h2>Full Capture Sheet — FY2027</h2>
-        <p class="ci-table-count">25 signals · 10 agencies · Updated April 2026</p>
+        <p class="ci-table-count">21 live signals · 12 agencies · Last reviewed May 18, 2026 · Next review May 25, 2026</p>
         <div class="ci-table-wrap">
           <table class="ci-table">
             <thead>
@@ -291,21 +291,14 @@
                 <td class="program"><a href="#s1">CCN Next Gen (36C10G26R0003)</a></td>
                 <td>$56.2B community care (+17%); VBP models and utilization management enter new contract — neither exists in current CCN</td>
                 <td><span class="badge badge-verified">Verified</span></td>
-                <td class="window"><span class="urgent">Proposals due April 17</span></td>
-              </tr>
-              <tr>
-                <td class="agency">VA</td>
-                <td class="program"><a href="#s2">CCN Dental (36C10G26R0004)</a></td>
-                <td>~$47M companion dental network vehicle</td>
-                <td><span class="badge badge-verified">Verified</span></td>
-                <td class="window">Closed March 16 · Awards pending</td>
+                <td class="window">In evaluation · IDIQ award Aug 2026 · orals Oct · Regional TOPRs Jan 2027</td>
               </tr>
               <tr>
                 <td class="agency">VA</td>
                 <td class="program"><a href="#s3">EHRM: EHR Contract</a></td>
                 <td>$2.768B; Oracle Health sustainment of 19 live sites plus 26 new FY2027 go-lives</td>
                 <td><span class="badge badge-verified">Verified</span></td>
-                <td class="window"><span class="urgent">Michigan go-live April 11</span> · June 1 withhold gate</td>
+                <td class="window">Michigan live · <span class="urgent">June 6 Chillicothe go-live</span> · July 1 withhold gate</td>
               </tr>
               <tr>
                 <td class="agency">VA</td>
@@ -359,9 +352,9 @@
               <tr>
                 <td class="agency">HHS/ONC</td>
                 <td class="program"><a href="#s11">TEFCA Interoperability</a></td>
-                <td>~500M records; governance authority moved to HHS OCIO April 1, 2026; HTI-5 rule moving</td>
+                <td>~500M records; governance authority at HHS OCIO; <strong>HTI-5 Final Rule published</strong> (HealthIT.gov, April 29, 2026). TEFCA manner exception removed.</td>
                 <td><span class="badge badge-verified">Verified</span></td>
-                <td class="window">Update contact maps · Watch HTI-5 on next contract cycle</td>
+                <td class="window">QHIN participation now de-facto required · Jan 1, 2027 lock-date</td>
               </tr>
               <tr>
                 <td class="agency">ARPA-H</td>
@@ -413,21 +406,21 @@
                 <td class="program"><a href="#s18">Enterprise Data Catalog (HT001126RE011)</a></td>
                 <td>$34M; inventory of up to 80 DHA data systems, VAULTIS framework, automated ML metadata harvesting; WOSB</td>
                 <td><span class="badge badge-verified">Verified</span></td>
-                <td class="window">Active · Check SAM.gov for deadline</td>
+                <td class="window"><span class="status-closed" style="display:inline-block;padding:2px 8px;border-radius:10px;background:rgba(92,107,122,0.10);color:#5C6B7A;font-size:11px;font-weight:700;letter-spacing:0.04em;">Responses closed Jan 9, 2026 · pending award</span> · See EDC Phase 2 (#s27)</td>
               </tr>
               <tr>
                 <td class="agency">DHA / PEO DHMS</td>
                 <td class="program"><a href="#s19">EIDS PMO Consolidation</a></td>
-                <td>1+ petabyte AWS GovCloud, 10 active contracts, manpower assessment underway; SpinSys-Din&egrave; bridge expiring</td>
+                <td>SpinSys-Diné bridge (HT003824C0005, $54.1M) expired Jan 25, 2026. Koniag IT Systems awarded <strong>$94M DHA EIDS AWS IDIQ</strong> June 4, 2025. ESS Next Sources Sought posted March 26, 2026.</td>
                 <td><span class="badge badge-corroborated">Corroborated</span></td>
                 <td class="window">No RFP posted · Position now</td>
               </tr>
               <tr>
                 <td class="agency">CDMRP / USAMRAA</td>
                 <td class="program"><a href="#s20">PRMRP ($370M, 52 condition areas)</a></td>
-                <td>Platform Clinical Translation Award up to $15M/award; pre-application window closes before full FOA</td>
+                <td>All 7 FY26 PRMRP FOAs released May 8, 2026. Platform Clinical Translation Award up to $15M/award ($8M guaranteed FY26 funds).</td>
                 <td><span class="badge badge-verified">Verified</span></td>
-                <td class="window"><span class="urgent">Pre-application open now</span> · Full FOA pending</td>
+                <td class="window"><span class="urgent">Pre-app due July 16–23</span> · Full apps July 30–Sept 22</td>
               </tr>
               <tr>
                 <td class="agency">CDMRP / USAMRAA</td>
@@ -464,6 +457,60 @@
                 <td><span class="badge badge-verified">Verified</span></td>
                 <td class="window">Active · Track Enterprise Data Product Registry and catalog follow-ons</td>
               </tr>
+
+              <!-- REFRESH-B / REFRESH-C — 6 new rows added 2026-05-18 -->
+              <tr>
+                <td colspan="5" style="background:var(--ci-gold-bg);padding:12px 16px;font-size:12px;font-weight:700;color:var(--ci-gold);text-transform:uppercase;letter-spacing:0.1em;border-bottom:1px solid #E5D9A8;">2026-05-18 Refresh — replacement &amp; net-new signals</td>
+              </tr>
+
+              <tr>
+                <td class="agency">VA / VHA</td>
+                <td class="program"><a href="#s26">Ambient Scribe Enterprise IDIQ (36C10B26R0006)</a></td>
+                <td>$775.7M ceiling, 5-year multi-award IDIQ; up to 4.7M user-months; FedRAMP Moderate; one task order per VISN (18 VISNs); Full &amp; Open</td>
+                <td><span class="badge badge-verified">Verified</span></td>
+                <td class="window">Proposals submitted April 6 · IDIQ award expected Summer 2026 · 18 VISN TOs follow</td>
+              </tr>
+
+              <tr>
+                <td class="agency">DHA / CDAO</td>
+                <td class="program"><a href="#s27">EDC Phase 2 / FY26-30 Data Strategy</a></td>
+                <td>Directional $50M-$150M; multi-award likely; WOSB/SB continuation likely; LOE 5 Enterprise Data Catalog across full DHA data estate</td>
+                <td><span class="badge badge-directional">Directional</span></td>
+                <td class="window">Solicitation estimated Q3-Q4 FY26 · Position now</td>
+              </tr>
+
+              <tr>
+                <td class="agency">DHA / PEO DHMS</td>
+                <td class="program"><a href="#s28">HCDS EHR Follow-on (HT003826X0000)</a></td>
+                <td>~$5B+ IDIQ (value directional); industry input deadline Aug 30, 2026; draft RFP late FY26; competitive replacement of Oracle Health HCDS</td>
+                <td><span class="badge badge-verified">Verified</span></td>
+                <td class="window">Industry input due Aug 30, 2026 · Draft RFP late FY26</td>
+              </tr>
+
+              <tr>
+                <td class="agency">DHA / PEO DHMS</td>
+                <td class="program"><a href="#s29">Deployment Solutions IDIQ (HT003826RE001)</a></td>
+                <td>$300M ceiling; 1 base + 4 option years; multi-award (all technically acceptable offerors); price not an evaluation factor; OCI clause names 5 contractors</td>
+                <td><span class="badge badge-verified">Verified</span></td>
+                <td class="window"><span class="status-closed" style="display:inline-block;padding:2px 8px;border-radius:10px;background:rgba(92,107,122,0.10);color:#5C6B7A;font-size:11px;font-weight:700;letter-spacing:0.04em;">Proposals closed April 21, 2026</span> · Awards pending</td>
+              </tr>
+
+              <tr>
+                <td class="agency">ARPA-H / HHS</td>
+                <td class="program"><a href="#s30">ADVOCATE — Agentic AI Cardiovascular</a></td>
+                <td>$100M+ across multiple OTAs (total program budget undisclosed); first known LLM-assisted federal health R&amp;D review; FDA-authorized agentic AI clinical system</td>
+                <td><span class="badge badge-verified">Verified</span></td>
+                <td class="window">Full proposals submitted April 1, 2026 · Team selections June 2026</td>
+              </tr>
+
+              <tr>
+                <td class="agency">HHS / ASTP/ONC</td>
+                <td class="program"><a href="#s31">HTI-5 Final Rule Compliance Window</a></td>
+                <td>$50M-$200M/yr market (Directional); 7-month sprint to Jan 1, 2027 deadline; recertification + QHIN positioning + federal-agency vendor requirement updates</td>
+                <td><span class="badge badge-corroborated">Corroborated</span></td>
+                <td class="window">Most criteria changes effective now · Jan 1, 2027 lock-date for remaining</td>
+              </tr>
+
             </tbody>
           </table>
         </div>
@@ -473,7 +520,7 @@
     <!-- Deep Dive Accordions -->
     <section class="ci-deep-dive" id="deep-dive">
       <div class="wrap">
-        <h2>Deep Dive: All 25 Signals</h2>
+        <h2>Deep Dive: All 30 Signals</h2>
         <p class="ci-deep-dive-intro">Click any row to expand sourced intelligence. Every material claim carries a confidence label and primary source attribution.</p>
 
         <!-- 1. CCN Next Gen -->
@@ -512,40 +559,32 @@
             <p>Missing any single factor across all three references = Unacceptable rating. Binary. This structure forces teaming between traditional healthcare payers (Implementation strength) and systems integrators (IT Integration strength). Solo proposals from either category are exposed.</p>
             <p><strong>MOSA structure with No-Bid provision.</strong> A No-Bid is a compliant response to a task order. A specialized firm in network analytics, utilization review, rural telehealth, or clinical AI can win a bench position and wait for the matching task order without being penalized for passing on full-region awards.</p>
 
+            <h3>Timeline</h3>
+            <p>Response deadline was extended to <strong>April 3, 2026</strong> (from the original March 16). Proposals submitted. Industry tracker timeline: <strong>IDIQ award August 2026; oral presentations October 2026; Regional TOPR awards January 2027.</strong> <span class="badge badge-verified">Verified — <a href="https://www.highergov.com/contract-opportunity/q201-ccn-next-gen-medical-36c10g26r0003-k-79930/">HigherGov 36C10G26R0003, March 20, 2026</a>; <a href="https://www.paradigmseniors.com/va-rfp-resource-center">Paradigm Seniors VA RFP Resource Center</a></span></p>
+
             <div class="action-box">
               <div class="action-label">Action Window</div>
-              <p>Proposals due <strong>April 17, 2026.</strong> If you do not have a complete team and proposal in progress, this window is closed. Post-award: VBP model design task orders are where the long-game positioning happens. Watch for early task order releases — the organizations that propose the next payment models shape the contract's economics across the performance period.</p>
+              <p><strong>In evaluation.</strong> Proposals submitted April 3, 2026. IDIQ award targeted August 2026; orals October 2026; Regional TOPR awards January 2027. Post-award: VBP model design task orders are where the long-game positioning happens. Watch for early task order releases — the organizations that propose the next payment models shape the contract's economics across the performance period.</p>
             </div>
-            <div class="source-note">Sources: VA FY2027 Budget in Brief, April 3, 2026 (Verified); CFO Topping testimony, House VA Committee January 2026 (Verified); IDIQ ceiling: GovConWire solicitation analysis (Corroborated — statutory ceiling, not projected spend); Corporate experience structure: solicitation 36C10G26R0003 pre-proposal conference materials (Verified).</div>
+            <div class="source-note">Sources: VA FY2027 Budget in Brief, April 3, 2026 (Verified); CFO Topping testimony, House VA Committee January 2026 (Verified); IDIQ ceiling: GovConWire solicitation analysis (Corroborated — statutory ceiling, not projected spend); Corporate experience structure: solicitation 36C10G26R0003 pre-proposal conference materials (Verified); Timeline: <a href="https://www.paradigmseniors.com/va-rfp-resource-center">Paradigm Seniors VA RFP Resource Center</a> (Corroborated).</div>
           </div>
         </details>
 
-        <!-- 2. CCN Dental -->
-        <details class="ci-accordion" id="s2">
+        <!-- 2. CCN Dental — closed; collapsed to stub per 2026-05-18 cleanup spec -->
+        <details class="ci-accordion" id="s2" data-window="closed" style="opacity:0.7;">
           <summary>
             <span class="acc-number">02</span>
             <div class="acc-header">
-              <div class="acc-title">CCN Dental (36C10G26R0004)</div>
+              <div class="acc-title">CCN Dental (36C10G26R0004) <span class="status-closed" style="display:inline-block;margin-left:8px;padding:2px 8px;border-radius:10px;background:rgba(92,107,122,0.10);color:#5C6B7A;font-size:11px;font-weight:700;letter-spacing:0.04em;">Closed April 3, 2026 · awards pending</span></div>
               <div class="acc-meta">
                 <span class="acc-agency">VA</span>
                 <span class="badge badge-verified">Verified</span>
-                <span class="badge badge-corroborated">Awards Pending</span>
               </div>
             </div>
             <svg class="acc-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
           </summary>
           <div class="acc-body">
-            <h3>What it funds</h3>
-            <p>A companion dental network management vehicle to the medical IDIQ. Separate procurement, same structural logic: multiple-award IDIQ for nationwide dental network coordination for veterans using community care. Approximately <strong>$47 million.</strong> This vehicle is new — there was no standalone dental companion in prior CCN generations. <span class="badge badge-verified">Verified — SAM.gov</span></p>
-
-            <h3>Competitive landscape</h3>
-            <p>Proposals closed March 16. Awards are pending. Given that this solicitation has received considerably less scrutiny than the medical vehicle, it is more likely to contain evaluation inconsistencies that could support a protest.</p>
-
-            <div class="action-box">
-              <div class="action-label">Action Window</div>
-              <p>The actionable window is the <strong>protest period.</strong> Organizations that submitted and were not selected should assess whether the Corporate Experience matrix was applied consistently before the protest window closes. GAO protests must be filed within 10 calendar days of the date a debriefing is requested, or within 10 days of the debriefing if held.</p>
-            </div>
-            <div class="source-note">Sources: Solicitation number and dollar figure: SAM.gov (Verified). Vehicle structure: parallel to medical IDIQ (Analytical inference from solicitation documents).</div>
+            <p style="font-size:14px;color:var(--mmt-text-secondary);margin:0;">CCN Dental closed <strong>April 3, 2026</strong>. Awards pending. <a href="#" data-stub="true" style="color:var(--mmt-teal);text-decoration:none;border-bottom:1px solid rgba(69,123,157,0.3);">See archive</a> once available.</p>
           </div>
         </details>
 
@@ -558,7 +597,7 @@
               <div class="acc-meta">
                 <span class="acc-agency">VA · $2.768B</span>
                 <span class="badge badge-verified">Verified</span>
-                <span class="badge badge-urgent">Go-Live April 11 · June 1 Gate</span>
+                <span class="badge badge-urgent">Michigan live · June 6 Chillicothe · July 1 Gate</span>
               </div>
             </div>
             <svg class="acc-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
@@ -571,13 +610,18 @@
             <p>Four sites went live simultaneously on April 11, 2026: <strong>Ann Arbor, Battle Creek, Detroit, and Saginaw.</strong> All four completed go-live on schedule with no system-wide outages or OIG-reportable patient safety incidents identified in open sources through mid-May 2026, marking the first Federal EHR deployment since the 2023 operational pause. Ann Arbor and Detroit are Level 1A complex facilities — the highest classification in the VA system. No Oracle EHR deployment has previously attempted this complexity level. This was the first multi-site simultaneous deployment in the program's history. <span class="badge badge-verified">Verified — VA press releases; Healthcare IT News December 2025; Congress.gov hearing record; open-source monitoring through 2026-05-15</span></p>
             <p>On March 4, 2026 — three weeks before the Michigan window — the Oracle federal EHR went down from 8:37 AM to 2:05 PM Eastern (nearly six hours) across all six live VA sites, 26 community clinics, and installations serving DoD and the Coast Guard. Cause: database performance issue. <span class="badge badge-verified">Verified — Fierce Healthcare, March 2026</span></p>
 
-            <h3>The June 1 withhold</h3>
-            <p>Congress withheld 30% of EHRM's FY2026 appropriation — approximately <strong>$1.02 billion</strong> — pending three conditions by June 1, 2026:</p>
+            <h3>The 30% appropriation withhold</h3>
+            <p>Congress withheld 30% of EHRM's FY2026 appropriation — approximately <strong>$1.02 billion</strong> — pending statutory conditions by <strong>July 1, 2026</strong>:</p>
             <ul>
-              <li>An updated lifecycle cost estimate</li>
-              <li>A facility-by-facility deployment schedule through full deployment</li>
-              <li>The Secretary's certification of four or more consecutive successful go-lives without delays or patient harm</li>
+              <li>Updated lifecycle cost estimate</li>
+              <li>Facility-by-facility deployment schedule through full deployment</li>
+              <li>Staffing projections for the EHRM PMO through full deployment</li>
+              <li>Certification of 4 consecutive incident-free site deployments</li>
+              <li>Certification that existing sites met baseline performance metrics</li>
             </ul>
+            <p><strong>Status (as of May 18, 2026):</strong> The September 2025 VA lifecycle estimate ($37.2B) has been delivered to Congress but not yet reviewed by GAO. Secretary Collins testified April 30, 2026 that the Michigan rollout "has been phenomenal." Certification language remains undefined; certification has not been issued. <span class="badge badge-verified">Verified — MeriTalk, Nov 13 2025 and April 6 2026; FedScoop, April 30 2026</span></p>
+            <p><strong>FY27 budget context:</strong> VA FY27 budget requests <strong>$4.24 billion for EHRM</strong> — an $840M increase over FY26 enacted, with 26 new site deployments planned in FY27. <span class="badge badge-verified">Verified — MeriTalk, April 6 2026</span></p>
+            <p><strong>June 2026 wave:</strong> 4 Ohio/Kentucky sites (Chillicothe, Cincinnati ×2, Dayton). Chillicothe VAMC confirmed go-live <strong>June 6, 2026</strong>. <span class="badge badge-verified">Verified — DigitalVA deployment schedule, updated May 14, 2026</span></p>
             <p><strong>Structural problem with the cost estimate condition.</strong> Three lifecycle estimates exist: VA 2019 ($16.1B — GAO called it severely incomplete), IDA October 2022 ($49.8B: $32.7B implementation + $17.1B sustainment), and VA September 2025 ($37.2B, delivered by Deputy Secretary Paul Lawrence to Congress December 15, 2025). GAO's position as of December 2025: all three are outdated. GAO had not received the VA's September 2025 revision at the time of the hearing. GAO Director Carol Harris stated: <em>"We have not received that estimate, so I would ask the department to provide that to us so we can review it."</em> <span class="badge badge-verified">Verified — GAO-26-108812; House VA Subcommittee, December 15, 2025</span></p>
             <p><strong>Definitional problem with the go-live condition.</strong> The withhold language requires certification of deployments "without delays or patient harm." No quantitative threshold defines delay. No threshold defines patient harm. Certification rests on the Secretary's judgment. Context: VA OIG found 149 instances of patient harm at Spokane, 826 major performance incidents across the first five live sites, and a veteran's death linked to scheduling failures at Columbus. All of those sites were certified as go-lives. <span class="badge badge-verified">Verified — VA OIG reports July 2022, September 2024, March 2024</span></p>
 
@@ -587,7 +631,7 @@
 
             <div class="action-box">
               <div class="action-label">Action Window</div>
-              <p>The June 1 withhold release determines FY2027 deployment pace. If Congress does not release the $1.02B on schedule, the deployment timeline slows and support contract structures shift. Monitor committee correspondence in May — that is where the withhold condition evaluation happens. Oracle's subcontractor and support ecosystem is the primary addressable market for most organizations outside the Oracle prime.</p>
+              <p>The July 1, 2026 withhold release determines FY2027 deployment pace. If Congress does not release the $1.02B on schedule, the deployment timeline slows and support contract structures shift. Monitor committee correspondence in June — that is where the withhold condition evaluation happens. Oracle's subcontractor and support ecosystem is the primary addressable market for most organizations outside the Oracle prime.</p>
             </div>
             <div class="source-note">Sources: VA FY2027 Budget in Brief (Verified); GAO-26-108812 (Verified); GAO-25-108091 (Verified); VA OIG reports 2022, 2024 (Verified); Harris quote: Congress.gov hearing record December 15, 2025 (Verified); Outage: Fierce Healthcare March 2026 (Verified; 5h28m duration confirmed).</div>
           </div>
@@ -615,7 +659,7 @@
 
             <div class="action-box">
               <div class="action-label">Action Window</div>
-              <p>Verify that your existing VA vehicles (SEWP, existing BPAs) remain viable through FY2027. The facility-by-facility deployment schedule required as a condition of the June 1 withhold will show the FY2028 wave. Obtain that schedule when published. Infrastructure contractors embedded in current deployments carry site-specific configuration knowledge that transfers — and gives them a head start on follow-on waves.</p>
+              <p>Verify that your existing VA vehicles (SEWP, existing BPAs) remain viable through FY2027. The facility-by-facility deployment schedule required as a condition of the July 1 withhold will show the FY2028 wave. Obtain that schedule when published. Infrastructure contractors embedded in current deployments carry site-specific configuration knowledge that transfers — and gives them a head start on follow-on waves.</p>
             </div>
             <div class="source-note">Sources: VA FY2027 Budget in Brief (Verified). FY2028 site details: VA press releases 2025 (Verified for nine additional sites announced; full list pending schedule release).</div>
           </div>
@@ -640,7 +684,7 @@
             <p>The EHRM Integration Office (EHRM-IO) program management office — the entity responsible for overseeing 170 total VA medical centers, a $37–49 billion lifecycle cost range, and an active GAO high-risk designation. <span class="badge badge-verified">Verified — VA FY2027 Budget in Brief</span></p>
 
             <h3>The staffing gap</h3>
-            <p><strong>313 positions authorized. Approximately 250 filled.</strong> The program then lost 24 additional staff to probationary firings and deferred resignation offers in early 2026. The functional vacancy rate heading into the most intensive deployment phase in the program's history exceeds 20% — at the precise moment the PMO is simultaneously managing the June 1 Congressional deadline, a four-site simultaneous go-live at the highest complexity level ever attempted, and 16 open GAO recommendations. <span class="badge badge-verified">Verified — Congressional testimony, February 2025 and early 2026 (note: 250 filled and 24 losses are from separate testimony timepoints; current fill rate is lower than 250)</span></p>
+            <p><strong>313 positions authorized. Approximately 250 filled.</strong> The program then lost 24 additional staff to probationary firings and deferred resignation offers in early 2026. The functional vacancy rate heading into the most intensive deployment phase in the program's history exceeds 20% — at the precise moment the PMO is simultaneously managing the July 1 Congressional deadline, a four-site simultaneous go-live at the highest complexity level ever attempted, and 16 open GAO recommendations. <span class="badge badge-verified">Verified — Congressional testimony, February 2025 and early 2026 (note: 250 filled and 24 losses are from separate testimony timepoints; current fill rate is lower than 250)</span></p>
 
             <h3>What this means operationally</h3>
             <p>Program management functions the PMO cannot staff internally become contractor work. Michigan goes live this month and the PMO is demonstrably understaffed for it. Functions most likely to be contracted: acquisition support, data governance, quality assurance, deployment coordination, and Congressional reporting support.</p>
@@ -702,7 +746,8 @@
 
             <h3>What's happening inside this account</h3>
             <p>The 17% growth in community care creates a knock-on effect on Medical Services: VA facilities see increased clinical complexity among patients who remain in direct care (lower-acuity patients route to community care more readily), while the referral authorization and triage function — 39.6 million referrals since the June 2019 MISSION Act launch — requires clinical decision support infrastructure to manage at volume. <span class="badge badge-verified">Verified — VA BiB for referral count, attributed to MISSION Act community care program</span></p>
-            <p>The Ambient Scribe IDIQ (36C10B26R0006) funded through this account closed April 3. Awards pending. Mental health residential rehabilitation (MHRRTP) expansion — a figure flagged for verification — will be addressed in Part 2 of this budget series.</p>
+            <p>The Ambient Scribe IDIQ (36C10B26R0006) funded through this account closed April 6, 2026. Awards expected Summer 2026. See dedicated row #s26 below. Mental health residential rehabilitation (MHRRTP) expansion — a figure flagged for verification — will be addressed in Part 2 of this budget series.</p>
+            <p><strong>FY27 AI funding:</strong> The FY27 budget proposes <strong>$47.8M for Decision Intelligence and Automation</strong> (+10.9% over FY26 enacted), with AI Infrastructure solution as primary driver. <span class="badge badge-verified">Verified — <a href="https://www.nextgov.com/artificial-intelligence/2026/04/vas-fy27-budget-proposal-seeks-funding-additional-ai-adoption/412687/">Nextgov, April 7, 2026</a></span></p>
 
             <div class="action-box">
               <div class="action-label">Action Window</div>
@@ -732,6 +777,9 @@
             <h3>The strategic dynamic</h3>
             <p>The community care workforce-substitution model creates a counterintuitive facility investment pattern. Patients routed to community care are largely those where VA capacity was the constraint — meaning the remaining VA direct care volume skews toward higher complexity, specialty, and behavioral health cases that the community network cannot readily absorb. Facility investment will prioritize <strong>modernization, specialty capacity, and right-sizing</strong> over general expansion.</p>
             <p>The FY2028 advance appropriations request ($138.2 billion in medical programs + $53.8 billion in Toxic Exposures Fund advances) is what long-cycle contractors are planning against — not FY2027. <span class="badge badge-verified">Verified — VA FY2027 Budget in Brief</span></p>
+
+            <h3>FY26 NRM injection (operative now)</h3>
+            <p>VA announced <strong>$596M in Q2 FY26 NRM obligations</strong> out of a record <strong>$4.8B FY26 NRM total</strong> — $795M for infrastructure repairs, $255M specifically for EHRM prep, $13M for building systems. Active EHRM infrastructure construction RFP for Philadelphia VAMC (36C77626R0063_1) posted April 14–29, 2026, SDVOSB set-aside, $20–50M. <span class="badge badge-verified">Verified — <a href="https://news.va.gov/press-room/va-announces-nearly-600m-in-infrastructure-improvements-in-second-quarter-of-fy-2026/">VA News, May 11, 2026</a></span></p>
 
             <div class="action-box">
               <div class="action-label">Action Window</div>
@@ -829,7 +877,7 @@
             <p>Before April 1, the policy authority governing information blocking and the IT contract authority governing QHIN operations reported to different principals. They now report to the same principal — the HHS CIO. This matters for contracts: the authority writing QHIN technical requirements and the authority holding QHIN contracts are now unified.</p>
 
             <h3>The HTI-5 rule</h3>
-            <p>The proposed HTI-5 rule, published December 29, 2025, proposes removing <strong>34 of 60 health IT certification criteria</strong> and revising seven more. Comment period closed February 27, 2026. That rule is now moving under OCIO authority. Organizations holding QHIN certifications or operating as TEFCA Participants or Sub-Participants should assume their certification baseline may shift on the next contract cycle. <span class="badge badge-verified">Verified — Federal Register, December 29, 2025</span></p>
+            <p><strong>HTI-5 Final Rule published.</strong> The HealthIT.gov HTI Rules page classifies HTI-5 as Final Rule as of <strong>April 29, 2026</strong>. The rule removes <strong>34 of 60 ONC Health IT Certification criteria</strong>, eliminates AI "model card" transparency requirements, codifies AI/automated processes as "access" under the information blocking rules, and <strong>removes the TEFCA manner exception</strong> — making QHIN participation the de-facto information-blocking compliance baseline. Most removals are effective immediately; remaining criteria changes (including family health history and C-CDA transitions of care) are effective <strong>January 1, 2027</strong>. <span class="badge badge-verified">Verified — HealthIT.gov HTI Rules page, updated April 29, 2026</span></p>
             <p>HHS consolidated from more than 40 separate IT departments under this reorganization. The OCIO is now the single decision-making authority for health IT standards, QHIN contracts, and information blocking enforcement. <span class="badge badge-corroborated">Corroborated — Federal News Network</span></p>
 
             <div class="action-box">
@@ -895,6 +943,9 @@
 
             <h3>Congressional history</h3>
             <p>Senator Susan Collins (April 3, 2026): Congress had <em>"decisively rejected these particular cuts last year."</em> The record supports her. For FY2026, Congress enacted approximately FY2025 funding levels across most contested HHS lines. NIH remained whole. ARPA-H was funded. Defense received $10.6 billion above the Pentagon's own request. The same Congress is now voting on FY2027. <strong>Full consolidation as proposed is unlikely to pass.</strong> <span class="badge badge-verified">Verified — CRS R48891; Collins statement April 3, 2026</span></p>
+
+            <h3>What changed since Issue 1</h3>
+            <p>AHA (Administration for a Healthy America) <strong>appears in the HHS FY27 budget request as an existing entity</strong> but <strong>Congress has not appropriated AHA funding or authorized the merger.</strong> FY26 enacted appropriations (signed February 2026) kept SAMHSA at approximately FY25 discretionary level. Treat HRSA and SAMHSA legacy vehicles as viable until Congress acts; monitor whether new task orders route via legacy vehicles or AHA channels. <span class="badge badge-verified">Verified — <a href="https://filtermag.org/hhs-budget-administration-for-a-healthy-america/">Filter Magazine, April 13, 2026</a></span></p>
 
             <h3>Why act now regardless</h3>
             <p>Partial restructuring, administrative consolidation without full legislative action, and de facto priority shifts within agencies are possible without a statutory vote. HRSA and SAMHSA program funding and contracting authority can shift even if the organizational chart does not change. Organizations holding vehicles scoped to individual agencies need to model what happens to those vehicles if the reporting structure changes — that is a contract language question, not a legislative one.</p>
@@ -976,6 +1027,7 @@
           <p style="font-size:11px;font-weight:700;color:var(--ci-gold);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;">Issue 2 of 2</p>
           <h2 style="font-size:1.5rem;font-weight:700;color:var(--mmt-navy);margin-bottom:6px;">Combat &amp; Operational Medicine + MHS GENESIS</h2>
           <p style="font-size:14px;color:var(--mmt-text-secondary);line-height:1.65;">Published April 10, 2026. All figures in thousands unless noted. Confidence levels: Verified (primary source confirmed) / Corroborated (secondary sources, consistent with known pattern) / Single Source (flagged) / Analytical (reasoned beyond evidence, labeled).</p>
+          <p style="font-size:13px;color:var(--mmt-text-secondary);font-style:italic;margin-top:6px;">Issue 2 published April 10, 2026 &middot; still current as of last review.</p>
         </div>
 
         <!-- 15. HCDS EHR Follow-on -->
@@ -1064,11 +1116,11 @@
         </details>
 
         <!-- 18. Enterprise Data Catalog -->
-        <details class="ci-accordion" id="s18">
+        <details class="ci-accordion" id="s18" data-window="closed">
           <summary>
             <span class="acc-number">18</span>
             <div class="acc-header">
-              <div class="acc-title">Enterprise Data Catalog (HT001126RE011)</div>
+              <div class="acc-title">Enterprise Data Catalog (HT001126RE011) <span class="status-closed" style="display:inline-block;margin-left:8px;padding:2px 8px;border-radius:10px;background:rgba(92,107,122,0.10);color:#5C6B7A;font-size:11px;font-weight:700;letter-spacing:0.04em;">Responses closed Jan 9, 2026 · pending award</span></div>
               <div class="acc-meta">
                 <span class="acc-agency">DHA CDAO · $34M · WOSB</span>
                 <span class="badge badge-verified">Verified</span>
@@ -1080,11 +1132,15 @@
             <h3>What it funds</h3>
             <p>Inventory of up to <strong>80 DHA data systems.</strong> VAULTIS framework. Automated ML metadata harvesting. Part of DHA Data and Innovation Strategy launched March 2026. <strong>$34 million, WOSB set-aside.</strong> Posted December 22, 2025. <span class="badge badge-verified">Verified</span></p>
 
+            <h3>Status (May 2026)</h3>
+            <p>Responses closed <strong>January 9, 2026.</strong> The GAO protest filed by BDR Solutions, LLC (File B-424295.1) was <strong>dismissed March 30, 2026</strong>, suggesting award proceeded. Winner has not been publicly announced as of May 18, 2026. <span class="badge badge-verified">Verified — <a href="https://orangeslices.ai/protest-filed-dha-data-governance-transforming-the-data-landscape-a-strategic-imperative-for-modern-healthcare-in-support-of-military-readiness/">OrangeSlices / GAO docket, March 30, 2026</a></span></p>
+            <p><strong>Phase 2 is the live opportunity.</strong> See signal #s27 (DHA EDC Phase 2 / FY26-30 Data Strategy Implementation) for the multi-year follow-on.</p>
+
             <div class="action-box">
               <div class="action-label">Action Window</div>
-              <p>Active solicitation. Check SAM.gov for current status and response deadline. WOSB set-aside — positioning and teaming decisions should account for the small business requirement.</p>
+              <p>This solicitation is closed and pending award. Pivot to EDC Phase 2 — the FY26-30 Data Strategy LOE 5 mandates the EDC across the full DHA data estate. Solicitation estimated Q3-Q4 FY26 based on the 1-year HT001126RE011 performance period ending January 29, 2027.</p>
             </div>
-            <div class="source-note">Sources: Solicitation HT001126RE011, posted December 22, 2025 (Verified — SAM.gov). DHA Data and Innovation Strategy March 2026 (Verified).</div>
+            <div class="source-note">Sources: Solicitation HT001126RE011, posted December 22, 2025 (Verified — SAM.gov). DHA Data and Innovation Strategy March 2026 (Verified). GAO protest dismissal B-424295.1, March 30, 2026 (Verified — OrangeSlices / GAO docket).</div>
           </div>
         </details>
 
@@ -1103,7 +1159,9 @@
           </summary>
           <div class="acc-body">
             <h3>What it is</h3>
-            <p>MHS Information Platform currently runs on a <strong>1+ petabyte AWS GovCloud environment.</strong> EIDS PMO managing 10 active contracts; manpower assessment underway to consolidate. SpinSys-Din&egrave; bridge contract expiring. <strong>This is the highest-growth functional area in DHA IT.</strong> No RFP posted as of publication date. <span class="badge badge-corroborated">Corroborated</span></p>
+            <p>MHS Information Platform currently runs on a <strong>1+ petabyte AWS GovCloud environment.</strong> EIDS PMO managing 10 active contracts; manpower assessment underway to consolidate. <strong>This is the highest-growth functional area in DHA IT.</strong> <span class="badge badge-corroborated">Corroborated</span></p>
+            <p><strong>SpinSys-Diné bridge contract (HT003824C0005)</strong> expired January 25, 2026 at $54.1M total value. <strong>Koniag IT Systems was awarded a $94M DHA EIDS AWS IDIQ on June 4, 2025</strong> (firm fixed-price, 1 base + 3 option years) for cloud/compute/storage. <span class="badge badge-verified">Verified — <a href="https://www.highergov.com/contract/HT003824C0005/">HigherGov HT003824C0005</a>; <a href="https://orangeslices.ai/koniag-subsidiary-scores-94m-defense-health-agency-enterprise-intelligence-and-data-solutions-eids-pmo-amazon-web-services-idiq/">OrangeSlices, June 4 2025</a></span></p>
+            <p><strong>ESS Next Sources Sought (TBD-8675309)</strong> posted March 26, 2026; responses due April 9, 2026 — market research for the next enterprise software services vehicle supporting EIDS, DHMSM, JOMIS, and FEHRM. <span class="badge badge-verified">Verified — <a href="https://www.highergov.com/contract-opportunity/program-executive-office-defense-healthcare-manage-tbd-8675309-r-9656c/">HigherGov ESS Next, March 26 2026</a></span></p>
 
             <div class="action-box">
               <div class="action-label">Action Window</div>
@@ -1129,19 +1187,23 @@
           </summary>
           <div class="acc-body">
             <h3>What it funds</h3>
-            <p><strong>$370 million</strong> across <strong>52 condition areas.</strong> Pre-announcement March 5, 2026. Access through eBRAP, then Grants.gov CFDA 12.420. Platform Clinical Translation Award funds up to <strong>$15 million per award</strong> (with $8 million guaranteed from FY2026 funds). Requires preproposal followed by invitation-only full application. <span class="badge badge-verified">Verified</span></p>
+            <p><strong>$370 million</strong> across <strong>52 condition areas.</strong> <strong>All 7 PRMRP FY26 funding opportunity announcements were released May 8, 2026</strong> (CDMRP page updated May 14). Access through eBRAP, then Grants.gov CFDA 12.420. Platform Clinical Translation Award funds up to <strong>$15 million per award</strong> ($8M guaranteed FY26 funds). Pre-proposal is the invitation-only gating step. <span class="badge badge-verified">Verified — CDMRP PRMRP funding page, updated May 14, 2026</span></p>
 
-            <h3>The timing trap</h3>
-            <p><strong>The pre-application window closes before the full FOA publishes.</strong> For some mechanisms, the submission calendar has already begun. Do not wait for the FOA — the eBRAP pre-application is the mandatory gating step and some mechanisms close that window first.</p>
+            <h3>Active deadlines (FY26)</h3>
+            <ul>
+              <li><strong>Discovery &amp; Research Advancement Awards:</strong> pre-app (LOI) due <strong>July 16, 2026</strong> · full app July 30, 2026</li>
+              <li><strong>Platform Clinical Translation, Clinical Trial, Impact Awards:</strong> pre-proposal due <strong>July 23, 2026</strong> · full app September 22, 2026</li>
+              <li><strong>Technology / Therapeutic Development Award:</strong> pre-app July 23, 2026 · full app August 6, 2026</li>
+            </ul>
 
             <h3>FY2027 funding context</h3>
             <p>The FY2027 CDMRP total will be set by House appropriators in mid-April markup, not by this budget. The FY2026 award cycle is running now. <span class="badge badge-verified">Verified</span></p>
 
             <div class="action-box">
               <div class="action-label">Action Window</div>
-              <p>Pre-application <strong>open now.</strong> Full FOA pending. The eBRAP pre-application is the mandatory gating step — do not wait for the FOA to begin positioning.</p>
+              <p>The FOAs are <strong>live.</strong> Shift from watch to execute. Pre-proposals for the gating mechanisms (Platform Clinical Translation, Clinical Trial, Impact) are due July 23, 2026 — eBRAP pre-proposal is the mandatory step to be invited to submit a full application.</p>
             </div>
-            <div class="source-note">Sources: PRMRP pre-announcement March 5, 2026 (Verified — cdmrp.health.mil). Funding and condition area count (Verified). Platform Clinical Translation Award ceiling (Verified). eBRAP / Grants.gov CFDA 12.420 (Verified).</div>
+            <div class="source-note">Sources: <a href="https://cdmrp.health.mil/funding/prmrp">CDMRP PRMRP funding page (updated May 14, 2026)</a>. <a href="https://simpler.grants.gov/opportunity/14cd2db8-6b20-4e54-a090-e77e2cb17b1e">Grants.gov / Simpler.grants.gov FOA listing, May 8, 2026</a>.</div>
           </div>
         </details>
 
@@ -1160,7 +1222,8 @@
           </summary>
           <div class="acc-body">
             <h3>What it funds</h3>
-            <p><strong>$165 million</strong> across <strong>20 cancer types.</strong> Pre-announcement February 20, 2026. All 14 additional programs have live pre-announcements at cdmrp.health.mil. Each program has its own timeline and mechanism structure. Full FOAs have not yet posted to eBRAP. There is no single deadline to plan against. <span class="badge badge-verified">Verified</span></p>
+            <p><strong>$165 million</strong> across <strong>20 cancer types.</strong> Pre-announcement February 20, 2026. All 14 additional programs have live pre-announcements at cdmrp.health.mil. Each program has its own timeline and mechanism structure. <span class="badge badge-verified">Verified</span></p>
+            <p><strong>FY26 Prostate Cancer Research Program (PCRP) pre-announcement released April 24, 2026.</strong> Award mechanisms: Exploration-Hypothesis Award, Idea Development Award, Translational Research Partnership Award, Physician Research Training Award. FY26 PRCRP topic areas explicitly exclude breast, kidney, lung, melanoma, ovarian, pancreatic, prostate, and rare cancers (those route to separate programs). <span class="badge badge-verified">Verified — <a href="https://cdmrp.health.mil/pubs/press/2026/pcrppreann">CDMRP PCRP pre-announcement, April 24, 2026</a></span></p>
 
             <h3>Additional programs</h3>
             <ul>
@@ -1231,13 +1294,16 @@
           </summary>
           <div class="acc-body">
             <h3>What it is</h3>
-            <p>Infrastructure engineering support task order through NIWC Atlantic. <strong>$129.6 million.</strong> Six original bidders on current vehicle. Expiring FY2026. Recompete expected to draw significant interest given scope. No solicitation posted as of publication date. <span class="badge badge-corroborated">Corroborated</span></p>
+            <p>Infrastructure engineering support task order through NIWC Atlantic. <strong>$129.6 million.</strong> Six original bidders on current vehicle. Expiring FY2026. Recompete expected to draw significant interest given scope. <span class="badge badge-corroborated">Corroborated</span></p>
+
+            <h3>Incumbent + follow-on</h3>
+            <p>Incumbent Core4ce TO <strong>N6523621F3030</strong> has potential end date <strong>September 2, 2026</strong> (83% complete, $42.2M funded backlog). NIWC Atlantic forecast shows follow-on <strong>DHIA II</strong> (LSUBP00010-0134, ≥$100M, SeaPort-NxG) with RFP targeted <strong>December 2026</strong> — bridge gap risk is real. <span class="badge badge-verified">Verified — <a href="https://www.highergov.com/contract/N0017819D8560-N6523621F3030/">HigherGov N6523621F3030, June 17, 2025</a>; <a href="https://www.niwcatlantic.navy.mil/Portals/94/Page-Content/Industry/71st-SBIOI/20250716%20Cannady_SBIOI_Contracts%20FINAL%20508%20compliant_.pdf">NIWC Atlantic SBIOI Forecast, July 16, 2025</a></span></p>
 
             <div class="action-box">
               <div class="action-label">Action Window</div>
-              <p>Watch NIWC Atlantic on SAM.gov. Begin teaming and capability alignment now. Six original bidders sets the competitive benchmark — organizations without prior DHA infrastructure engineering work should identify teaming partners with that past performance.</p>
+              <p>Watch NIWC Atlantic on SAM.gov. Begin teaming and capability alignment now. Six original bidders sets the competitive benchmark — organizations without prior DHA infrastructure engineering work should identify teaming partners with that past performance. DHIA II RFP targeted December 2026 — pipeline both simultaneously to bridge the gap.</p>
             </div>
-            <div class="source-note">Sources: Contract value and expiration timeline (Corroborated — secondary sources consistent with known NIWC Atlantic task order portfolio). Bidder count (Corroborated).</div>
+            <div class="source-note">Sources: Contract value and expiration timeline (Corroborated). Bidder count (Corroborated). DHIA II follow-on (Verified — NIWC Atlantic SBIOI forecast).</div>
           </div>
         </details>
 
@@ -1292,7 +1358,7 @@
           </summary>
           <div class="acc-body">
             <h3>What it is</h3>
-            <p>On April 16, 2026, DHA's Chief Data and Analytics Office published <em>Enabling Decision Advantage With Health Data</em> — the strategy, governance, and request-process playbook for how DHA will consolidate data operations across more than 100 source systems. This is the structural document every DHA data solicitation through at least FY2028 will operate inside. Every capture team working DHA data, GenAI, or MHS analytics needs to read it against their pipeline. <span class="badge badge-verified">Verified — DHA CDAO, April 16, 2026</span></p>
+            <p>The <strong>FY26-30 DHA Data Strategy</strong> was signed and released <strong>March 11, 2026</strong> with five Lines of Effort: (1) Strengthen Data Roles; (2) Maximize Authoritative Data Sources; (3) Operationalize Data-as-a-Product; (4) Build Trust Through Data Quality; (5) Maintain Enterprise Data Catalog. On April 16, 2026, DHA CDAO published the operating companion <em>Enabling Decision Advantage With Health Data</em> — the strategy, governance, and request-process playbook for how DHA will consolidate data operations across more than 100 source systems. The EDC LOE is the direct successor authority for HT001126RE011 Phase 2 work. <span class="badge badge-verified">Verified — <a href="https://dha.mil/News/2026/03/11/17/05/Data-and-Innovation-Strategy-launched-to-improve-warfighter-readiness">DHA.mil, March 11, 2026</a>; DHA CDAO, April 16, 2026</span></p>
 
             <h3>The three things this document tells you</h3>
 
@@ -1345,6 +1411,211 @@
               <p>For teams with clinical content: audit your AI stack against the approved GenAI list <em>before</em> submitting on DHA solicitations that may involve PHI. A compliant stack is a proposal-defensibility issue, not a post-award one.</p>
             </div>
             <div class="source-note">Sources: DHA CDAO, <em>Enabling Decision Advantage With Health Data: DHA Data Strategy, Governance, and Request Process</em>, April 16, 2026 (Verified — primary publication). Solicitation HT001126RE011 (Verified — SAM.gov). Approved GenAI platforms list (Verified — DHA CDAO publication). Six-role governance model and seven-step Enterprise Measure Request Process (Verified — DHA CDAO publication). 51-systems / 12-month / Space Force API Portal reference (Corroborated — annotated source copy, single-source directional).</div>
+          </div>
+        </details>
+
+        <!-- 2026-05-18 Refresh divider -->
+        <div style="margin:40px 0 28px;padding:20px 0;border-top:2px solid var(--ci-gold);border-bottom:1px solid var(--mmt-border-light);">
+          <p style="font-size:11px;font-weight:700;color:var(--ci-gold);text-transform:uppercase;letter-spacing:0.1em;margin-bottom:6px;">2026-05-18 Refresh</p>
+          <h2 style="font-size:1.5rem;font-weight:700;color:var(--mmt-navy);margin-bottom:6px;">Replacement &amp; net-new signals</h2>
+          <p style="font-size:14px;color:var(--mmt-text-secondary);line-height:1.65;">Six signals added on this refresh. Two replace closed items (CCN Dental; EDC HT001126RE011). Four are net-new: HCDS EHR Follow-on, DHA Deployment Solutions IDIQ, ARPA-H ADVOCATE, and the HTI-5 Final Rule compliance window.</p>
+        </div>
+
+        <!-- 26. VA Ambient Scribe Enterprise IDIQ -->
+        <details class="ci-accordion" id="s26">
+          <summary>
+            <span class="acc-number">26</span>
+            <div class="acc-header">
+              <div class="acc-title">VA / VHA — Ambient Scribe Enterprise IDIQ (36C10B26R0006)</div>
+              <div class="acc-meta">
+                <span class="acc-agency">VA · $775.7M ceiling · 5-year</span>
+                <span class="badge badge-verified">Verified</span>
+                <span class="badge badge-urgent">Awards expected Summer 2026</span>
+              </div>
+            </div>
+            <svg class="acc-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+          </summary>
+          <div class="acc-body">
+            <h3>What it funds</h3>
+            <p>VA's Technology Acquisition Center (TAC New Jersey) issued solicitation 36C10B26R0006 March 20, 2026 with proposals due April 6, 2026. The IDIQ establishes a <strong>multi-vendor, multi-VISN ambient AI scribe capability</strong> with a <strong>$775.7M ceiling and 5-year ordering period</strong>, with up to <strong>4,700,000 user-months of utilization.</strong> <span class="badge badge-verified">Verified — <a href="https://www.highergov.com/contract-opportunity/da10-ambient-scribe-enterprise-idiq-va-26-000129-36c10b26r0006-k-3749d/">HigherGov 36C10B26R0006, April 2, 2026</a></span></p>
+
+            <h3>Why the IDIQ doesn't end the competition</h3>
+            <p>The contract structure envisions <strong>one task order per VISN</strong> (18 VISNs + possible additional TOs) — competition does not end at IDIQ award. Each VISN-level task order is a separate competitive event. Technical requirements: FedRAMP Moderate authorization, integration with VistA/CPRS and Oracle Health EHR, real-time note generation, and specialty-specific documentation.</p>
+
+            <h3>Strategic context</h3>
+            <p>VA's AI strategy commits to scaling ambient scribe across all 170 VAMCs. The FY27 budget allocates $47.8M for Decision Intelligence and Automation (+10.9%). Existing pilots at VA Providence (March 24, 2026), Kansas City (April 2026), and at least 12 other sites under Knowtex's $15M contract create technical past performance. Kansas City pilot: 18 providers, all want to continue; 1–2 hours/day saved per provider. <span class="badge badge-verified">Verified — <a href="https://news.va.gov/kansas-city-embrace-ambient-scribe-technology/">VA News Kansas City, April 18, 2026</a></span></p>
+
+            <h3>Competitive landscape</h3>
+            <p>FedRAMP-authorized ambient AI vendors — <strong>Knowtex, Nuance/Microsoft, Ambience, Suki, DeepScribe</strong> — are the likely prime competitors.</p>
+
+            <div class="action-box">
+              <div class="action-label">Action Window</div>
+              <p>Highest-probability near-term VA health-IT award: proposals already submitted, award likely by <strong>Summer 2026</strong>, with 18 follow-on VISN task orders immediately actionable post-award. If you're not on the IDIQ, position now for sub-on partnerships with primes.</p>
+            </div>
+            <div class="source-note">Sources: <a href="https://www.highergov.com/contract-opportunity/da10-ambient-scribe-enterprise-idiq-va-26-000129-36c10b26r0006-k-3749d/">HigherGov 36C10B26R0006</a> (Verified). <a href="https://news.va.gov/kansas-city-embrace-ambient-scribe-technology/">VA News Kansas City pilot, April 18, 2026</a> (Verified). <a href="https://www.nextgov.com/artificial-intelligence/2026/04/vas-fy27-budget-proposal-seeks-funding-additional-ai-adoption/412687/">Nextgov VA AI funding, April 7, 2026</a> (Verified).</div>
+          </div>
+        </details>
+
+        <!-- 27. DHA EDC Phase 2 -->
+        <details class="ci-accordion" id="s27">
+          <summary>
+            <span class="acc-number">27</span>
+            <div class="acc-header">
+              <div class="acc-title">DHA CDAO / PEO DHMS — EDC Phase 2 / FY26-30 Data Strategy Implementation</div>
+              <div class="acc-meta">
+                <span class="acc-agency">DHA CDAO · $50M-$150M directional</span>
+                <span class="badge badge-directional">Directional</span>
+              </div>
+            </div>
+            <svg class="acc-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+          </summary>
+          <div class="acc-body">
+            <h3>What it funds</h3>
+            <p>The <strong>DHA FY26-30 Data Strategy</strong> (signed and released March 11, 2026) mandates an Enterprise Data Catalog as standing <strong>LOE 5</strong>: integration with all key data systems for continuous metadata refresh; metadata-first governance; metadata quality indicators; and connection of EDC metadata to operational and analytical systems. HT001126RE011 was a 1-year, $34M scoping/prototype contract covering only 80 systems. <strong>Phase 2 must implement the EDC across the full DHA data estate (hundreds of systems).</strong> <span class="badge badge-verified">Verified — <a href="https://dha.mil/News/2026/03/11/17/05/Data-and-Innovation-Strategy-launched-to-improve-warfighter-readiness">DHA.mil, March 11, 2026</a>; <a href="https://dha.mil/Reference-Library/d/e/f/Defense-Health-Agency-Data-Strategy">DHA FY26-30 Data Strategy PDF</a></span></p>
+
+            <h3>The near-term driver</h3>
+            <p>CDAO Jesus Caban's Orchestration Layer mandate (~51 systems orchestrated to the Space Force API Portal reference within 12 months) is the implementation forcing function. The GAO protest dismissal (BDR Solutions, B-424295.1, March 30, 2026) means HT001126RE011 award likely proceeded, establishing a Phase 1 incumbent. <span class="badge badge-verified">Verified — <a href="https://orangeslices.ai/protest-filed-dha-data-governance-transforming-the-data-landscape-a-strategic-imperative-for-modern-healthcare-in-support-of-military-readiness/">OrangeSlices / GAO docket, March 30, 2026</a></span></p>
+
+            <h3>Competitive landscape</h3>
+            <p>WOSB/SB set-aside likely to continue. Firms with DHA data pedigree (EIDS PMO support teams, VAULTIS framework implementers) and Enterprise Data Catalog COTS deployment partners (<strong>Collibra, Alation, Microsoft Purview</strong>) are natural competitors. Solicitation estimated Q3-Q4 FY26 based on HT001126RE011 performance period ending January 29, 2027.</p>
+
+            <div class="action-box">
+              <div class="action-label">Action Window</div>
+              <p>Phase 2 is the multi-year EDC implementation vehicle. If you sit on HT001126RE011 as the prime or a sub, the Phase 2 incumbency advantage is real. If you don't, position with a teaming partner that does — and confirm your COTS catalog tooling is approved on the GenAI/data list.</p>
+            </div>
+            <div class="source-note">Sources: <a href="https://dha.mil/News/2026/03/11/17/05/Data-and-Innovation-Strategy-launched-to-improve-warfighter-readiness">DHA.mil, March 11, 2026</a> (Verified). <a href="https://dha.mil/Reference-Library/d/e/f/Defense-Health-Agency-Data-Strategy">DHA FY26-30 Data Strategy PDF</a> (Verified). <a href="https://orangeslices.ai/protest-filed-dha-data-governance-transforming-the-data-landscape-a-strategic-imperative-for-modern-healthcare-in-support-of-military-readiness/">OrangeSlices GAO B-424295.1 dismissal, March 30, 2026</a> (Verified).</div>
+          </div>
+        </details>
+
+        <!-- 28. HCDS EHR Follow-on -->
+        <details class="ci-accordion" id="s28">
+          <summary>
+            <span class="acc-number">28</span>
+            <div class="acc-header">
+              <div class="acc-title">DHA / PEO DHMS — HCDS EHR Follow-on (HT003826X0000)</div>
+              <div class="acc-meta">
+                <span class="acc-agency">DHA / PEO DHMS · ~$5B+ IDIQ</span>
+                <span class="badge badge-verified">Verified</span>
+              </div>
+            </div>
+            <svg class="acc-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+          </summary>
+          <div class="acc-body">
+            <h3>What it funds</h3>
+            <p>DHA posted <strong>Special Notice HT003826X0000 on March 18, 2026</strong> — the first public signal of the formal procurement process for the MHS GENESIS HCDS recompete — with an <strong>August 30, 2026 industry input deadline</strong>. This is the follow-on to the current HCDS contract supporting MHS GENESIS, the DoD's Federal EHR deployed at 10 Army, Navy, Air Force, and Coast Guard MTFs with expansion underway. <span class="badge badge-verified">Verified — <a href="https://www.federalcompass.com/rfp-opportunity-detail/HT003826X0000">FederalCompass HT003826X0000, April 13, 2026</a></span></p>
+
+            <h3>Draft contract strategy</h3>
+            <p>From Industry Days (November 2025 and March 2026), the draft strategy emphasizes: (1) leveraging the commercial ecosystem to maintain technology relevance, (2) tighter VA/DoD interoperability, (3) <strong>value-based EHR contractor compensation</strong> (outcomes, not consumption), and (4) preserving best-in-class deployment methodologies from the current Oracle Health contract. The Deployment Solutions IDIQ (HT003826RE001, $300M — see #s29) separates deployment services from the EHR platform itself, creating two distinct competitive streams.</p>
+
+            <h3>Competitive landscape</h3>
+            <p>Oracle Health holds the current HCDS platform contract but the government has <strong>explicitly designed for competitive replacement.</strong> Epic, Cerner (Oracle), and potentially AWS/Microsoft healthcare cloud platforms are potential offerors. For capture teams, the 2026 opportunity is the Deployment Solutions IDIQ; the HCDS platform recompete is a 12-18 month pipeline investment. <span class="badge badge-verified">Verified — <a href="https://www.washingtontechnology.com/contracts/2026/04/dha-starts-bidding-300-tech-deployment-support-contract/412707/">Washington Technology, April 8, 2026</a></span></p>
+
+            <div class="action-box">
+              <div class="action-label">Action Window</div>
+              <p>Industry input due <strong>August 30, 2026.</strong> Draft RFP late FY26. Use the input window to shape evaluation criteria around your differentiators. If you're not Oracle, the government is asking for your perspective on what the platform should look like in a commercial-leverage model — answer the question they asked.</p>
+            </div>
+            <div class="source-note">Sources: <a href="https://www.federalcompass.com/rfp-opportunity-detail/HT003826X0000">FederalCompass HT003826X0000, April 13, 2026</a> (Verified). <a href="https://www.washingtontechnology.com/contracts/2026/04/dha-starts-bidding-300-tech-deployment-support-contract/412707/">Washington Technology, April 8, 2026</a> (Verified).</div>
+          </div>
+        </details>
+
+        <!-- 29. DHA Deployment Solutions IDIQ -->
+        <details class="ci-accordion" id="s29">
+          <summary>
+            <span class="acc-number">29</span>
+            <div class="acc-header">
+              <div class="acc-title">DHA / PEO DHMS — Deployment Solutions IDIQ (HT003826RE001)</div>
+              <div class="acc-meta">
+                <span class="acc-agency">DHA · $300M ceiling · multi-award</span>
+                <span class="badge badge-verified">Verified</span>
+                <span class="status-closed" style="display:inline-block;padding:2px 8px;border-radius:10px;background:rgba(92,107,122,0.10);color:#5C6B7A;font-size:11px;font-weight:700;letter-spacing:0.04em;">Closed April 21, 2026</span>
+              </div>
+            </div>
+            <svg class="acc-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+          </summary>
+          <div class="acc-body">
+            <h3>What it funds</h3>
+            <p>DHA posted HT003826RE001 April 6, 2026 (final amendment April 13, 2026 extended close to April 21). <strong>$300M IDIQ for site preparation, deployment, training, change management, and post-installation support</strong> across all DHMS products — MHS GENESIS, operational medicine systems, JOMIS. 1 base + 4 option years. <span class="badge badge-verified">Verified — <a href="https://www.washingtontechnology.com/contracts/2026/04/dha-starts-bidding-300-tech-deployment-support-contract/412707/">Washington Technology, April 8, 2026</a></span></p>
+
+            <h3>The unusual evaluation structure</h3>
+            <p>DHA will award to <strong>every technically acceptable offeror</strong> — effectively an open IDIQ vehicle for qualified firms — with <strong>price not an evaluation factor.</strong> Evaluation focuses on a <strong>two-scenario EHR deployment challenge:</strong> OCONUS accredited medical center + operational medicine scenario for EUCOM/INDOPACOM. <span class="badge badge-verified">Verified</span></p>
+
+            <h3>The named OCI contractors</h3>
+            <p>Five named government support contractors appear in the OCI clause — proposers must state whether access is granted: <strong>Andrew Morgan Consulting, Boston Consulting Group, Greenlight Analytic, Monterey Consultants, Swing Tide.</strong> <span class="badge badge-verified">Verified — <a href="https://www.highergov.com/contract-opportunity/program-executive-office-peo-defense-healthcare-ht003826re001-k-feb02/">HigherGov HT003826RE001, April 17, 2026</a></span></p>
+
+            <div class="action-box">
+              <div class="action-label">Action Window</div>
+              <p>Proposals closed April 21, 2026. Primary vehicle for the FY26 13-site go-live acceleration and the FY27 26-site wave. This is an access-to-market vehicle — getting on the IDIQ now, then competing for task orders as each site wave begins. Watch for award notice.</p>
+            </div>
+            <div class="source-note">Sources: <a href="https://www.washingtontechnology.com/contracts/2026/04/dha-starts-bidding-300-tech-deployment-support-contract/412707/">Washington Technology, April 8, 2026</a> (Verified). <a href="https://www.highergov.com/contract-opportunity/program-executive-office-peo-defense-healthcare-ht003826re001-k-feb02/">HigherGov HT003826RE001, April 17, 2026</a> (Verified).</div>
+          </div>
+        </details>
+
+        <!-- 30. ARPA-H ADVOCATE Net-New -->
+        <details class="ci-accordion" id="s30">
+          <summary>
+            <span class="acc-number">30</span>
+            <div class="acc-header">
+              <div class="acc-title">ARPA-H ADVOCATE — Agentic AI Cardiovascular Care</div>
+              <div class="acc-meta">
+                <span class="acc-agency">ARPA-H · $100M+ OTAs</span>
+                <span class="badge badge-verified">Verified</span>
+                <span class="badge badge-urgent">Team selections June 2026</span>
+              </div>
+            </div>
+            <svg class="acc-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+          </summary>
+          <div class="acc-body">
+            <h3>What it funds</h3>
+            <p>ARPA-H-SOL-26-142 issued <strong>January 13, 2026;</strong> solution summaries due February 27; <strong>full proposals due April 1, 2026.</strong> Targets the <strong>first FDA-authorized, agentic AI clinical system</strong> — an autonomous AI agent capable of adjusting medications, scheduling, diet, and prescriptions for heart failure and MI patients 24/7. Three technical areas: (TA1) patient-facing clinical AI agent; (TA2) supervisory safety agent; (TA3) health system integration and deployment. <span class="badge badge-verified">Verified — <a href="https://arpa-h.gov/explore-funding/programs/advocate">ARPA-H ADVOCATE program page</a>; <a href="https://arpa-h.gov/news-and-events/arpa-h-revolutionize-cardiovascular-disease-management-clinical-agentic-ai">ARPA-H news release, January 13, 2026</a></span></p>
+
+            <h3>The OT structure</h3>
+            <p>Awards via <strong>Other Transaction Agreements</strong>, not traditional contracts or grants. Due to "exceptional interest," ARPA-H is piloting <strong>LLM-assisted review of solution summaries</strong> — the first known use of AI in federal health R&amp;D proposal review at this scale. <span class="badge badge-verified">Verified</span></p>
+
+            <h3>Teaming reality</h3>
+            <p>Teaming between tech sector (clinical AI vendors), academic health systems, and medical device/pharma regulatory experts is <strong>virtually required</strong> per ARPA-H's own guidance. While the total program budget is undisclosed, GovCon intelligence estimates <strong>$100M+ over 4-5 years across multiple awardees.</strong></p>
+
+            <div class="action-box">
+              <div class="action-label">Action Window</div>
+              <p>Team selections anticipated <strong>June 2026.</strong> Active watch item for capture teams in clinical AI, health system integration, and FDA regulatory strategy. Position for down-select and follow-on rounds — the program runs 4-5 years and ARPA-H typically funds multiple teams.</p>
+            </div>
+            <div class="source-note">Sources: <a href="https://arpa-h.gov/explore-funding/programs/advocate">ARPA-H ADVOCATE program page</a> (Verified). <a href="https://arpa-h.gov/news-and-events/arpa-h-revolutionize-cardiovascular-disease-management-clinical-agentic-ai">ARPA-H news release, January 13, 2026</a> (Verified).</div>
+          </div>
+        </details>
+
+        <!-- 31. HTI-5 Final Rule Compliance Window -->
+        <details class="ci-accordion" id="s31">
+          <summary>
+            <span class="acc-number">31</span>
+            <div class="acc-header">
+              <div class="acc-title">HHS / ASTP/ONC — HTI-5 Final Rule Compliance Services Window</div>
+              <div class="acc-meta">
+                <span class="acc-agency">HHS · $50M-$200M/yr market</span>
+                <span class="badge badge-corroborated">Corroborated</span>
+                <span class="badge badge-urgent">Jan 1, 2027 lock-date</span>
+              </div>
+            </div>
+            <svg class="acc-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>
+          </summary>
+          <div class="acc-body">
+            <h3>What it is</h3>
+            <p>HTI-5 Final Rule confirmed published (HealthIT.gov page classifies HTI-5 as <strong>Final Rule</strong> as of <strong>April 29, 2026</strong>). The rule removes <strong>34 of 60 ONC Health IT Certification criteria</strong>, eliminates AI "model card" transparency requirements, defines AI/automated processes as "access" under information blocking, and <strong>removes the TEFCA manner exception</strong> — making QHIN participation de-facto mandatory for IB compliance. <span class="badge badge-verified">Verified — <a href="https://healthit.gov/regulations/hti-rules/">HealthIT.gov HTI Rules, updated April 29, 2026</a></span></p>
+
+            <h3>Effective dates</h3>
+            <p>Most removals are effective <strong>immediately</strong> upon publication. Remaining criteria changes (including family health history and C-CDA transitions of care) are effective <strong>January 1, 2027</strong>. The Jan 1, 2027 deadline for remaining criteria changes creates a 7-month sprint for large health systems.</p>
+
+            <h3>The compliance services window (the opportunity)</h3>
+            <ol>
+              <li><strong>EHR vendors</strong> must decertify removed criteria and re-certify revised criteria — creating developer services demand.</li>
+              <li><strong>Health systems</strong> must re-assess information blocking compliance posture now that the TEFCA manner exception is eliminated.</li>
+              <li><strong>QHIN participants</strong> see increased value as TEFCA becomes the compliance backstop.</li>
+              <li><strong>Federal agencies</strong> deploying certified health IT (VA, DHA, IHS, CMS) must align vendor requirements with the new certification landscape — recertification services opportunity for federal capture teams.</li>
+            </ol>
+
+            <div class="action-box">
+              <div class="action-label">Action Window</div>
+              <p>Flag this to agency clients as a <strong>configuration / recertification services opportunity.</strong> If you support federal EHR deployments (VA, DHA, IHS, CMS), the Jan 1, 2027 lock-date is your forcing function. The compliance services market is estimated at $50M-$200M/yr through 2027.</p>
+            </div>
+            <div class="source-note">Sources: <a href="https://healthit.gov/regulations/hti-rules/">HealthIT.gov HTI Rules page, updated April 29, 2026</a> (Verified). <a href="https://www.aha.org/lettercomment/2026-02-27-aha-comments-astponc-health-care-technology-interoperability-proposed-rule">AHA comments, February 27, 2026</a> (Corroborated).</div>
           </div>
         </details>
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -419,6 +419,36 @@
   to = "/agencies/"
   status = 301
 
+# HHS sprint (2026-05-18) — clean URLs for the OMAS realignment coverage.
+# Sub-pages under /agencies/hhs/ each map to a flat file in premium/agencies/
+# or premium/org-charts/. Policy section is new — /policy/pact and
+# /policy/rfo-8-4 map to premium/policy/. /updates/<date>-<slug> is the
+# subscriber-email landing pattern.
+[[redirects]]
+  from = "/agencies/hhs/orgchart"
+  to = "/premium/org-charts/hhs.html"
+  status = 200
+[[redirects]]
+  from = "/agencies/hhs/omas"
+  to = "/premium/agencies/hhs-omas.html"
+  status = 200
+[[redirects]]
+  from = "/agencies/hhs/hcas"
+  to = "/premium/agencies/hhs-hcas.html"
+  status = 200
+[[redirects]]
+  from = "/policy/pact"
+  to = "/premium/policy/pact.html"
+  status = 200
+[[redirects]]
+  from = "/policy/rfo-8-4"
+  to = "/premium/policy/rfo-8-4.html"
+  status = 200
+[[redirects]]
+  from = "/updates/2026-05-18-hhs-omas"
+  to = "/premium/updates/2026-05-18-hhs-omas.html"
+  status = 200
+
 # Canonical clean URLs for /pricing and /dashboard.
 # Internal links should use the bare path; .html variants 301 to clean.
 # (The /pricing -> /pricing.html and /tools -> /tools.html 200-rewrites

--- a/netlify/functions/data/mmt-content-corpus-public.json
+++ b/netlify/functions/data/mmt-content-corpus-public.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-18T18:42:56.896Z",
+  "generated_at": "2026-05-18T20:14:45.786Z",
   "total": 179,
   "note": "Public subset of mmt-content-corpus.json (premium=false items only). For unauthenticated endpoints. Per Sprint C 2026-05-14.",
   "counts": {

--- a/netlify/functions/data/mmt-content-corpus-public.json
+++ b/netlify/functions/data/mmt-content-corpus-public.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-18T13:17:11.216Z",
+  "generated_at": "2026-05-18T18:42:56.896Z",
   "total": 179,
   "note": "Public subset of mmt-content-corpus.json (premium=false items only). For unauthenticated endpoints. Per Sprint C 2026-05-14.",
   "counts": {

--- a/netlify/functions/data/mmt-content-corpus.json
+++ b/netlify/functions/data/mmt-content-corpus.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-18T18:42:56.896Z",
+  "generated_at": "2026-05-18T20:14:45.786Z",
   "total": 213,
   "counts": {
     "articles": 111,

--- a/netlify/functions/data/mmt-content-corpus.json
+++ b/netlify/functions/data/mmt-content-corpus.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-18T13:17:11.216Z",
+  "generated_at": "2026-05-18T18:42:56.896Z",
   "total": 213,
   "counts": {
     "articles": 111,

--- a/premium/agencies/hhs-hcas.html
+++ b/premium/agencies/hhs-hcas.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The 10 HHS Heads of Contracting Activity &middot; MMT Premium</title>
+  <meta name="robots" content="noindex">
+  <meta name="description" content="The 10 HHS Heads of Contracting Activity. Names, emails, phones, status (Acting vs Permanent), small business specialists. Sortable and filterable. Sourced from the official HHS HCA roster as of April 27, 2026.">
+  <link rel="stylesheet" href="/styles/tailwind.css">
+  <link rel="icon" href="/favicon-v3.png" type="image/png">
+  <style>
+    :root { --mmt-navy:#0A192F; --mmt-teal:#457B9D; --mmt-white:#FFFFFF; --mmt-surface:#F3F4F6; --mmt-text-secondary:#6B7280; --mmt-border:#E5E7EB; --ci-gold:#92710A; --status-acting:#457B9D; --dash-sidebar:220px; }
+    body { font-family:Inter,system-ui,sans-serif; color:var(--mmt-navy); background:var(--mmt-surface); margin:0; line-height:1.55; }
+    .dash-shell { display:grid; grid-template-columns:var(--dash-sidebar) 1fr; min-height:100vh; }
+    .dash-nav { background:var(--mmt-navy); padding:24px 0; display:flex; flex-direction:column; position:sticky; top:0; height:100vh; overflow-y:auto; }
+    .dash-nav-brand { padding:0 20px 24px; border-bottom:1px solid rgba(255,255,255,0.1); margin-bottom:16px; }
+    .dash-nav-brand a { color:#fff; text-decoration:none; font-weight:800; font-size:14px; }
+    .dash-nav-brand small { display:block; font-size:11px; color:rgba(255,255,255,0.5); font-weight:400; margin-top:2px; }
+    .dash-nav-link { display:flex; align-items:center; gap:10px; padding:10px 20px; color:rgba(255,255,255,0.6); text-decoration:none; font-size:13px; font-weight:500; transition:all 0.15s; }
+    .dash-nav-link:hover { color:#fff; background:rgba(255,255,255,0.05); }
+    .dash-nav-link.active { color:#fff; background:rgba(69,123,157,0.3); border-left:3px solid var(--mmt-teal); }
+    .dash-nav-section { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.12em; color:rgba(255,255,255,0.3); padding:16px 20px 6px; }
+    .dash-header { background:var(--mmt-white); padding:16px 32px; border-bottom:1px solid var(--mmt-border); display:flex; align-items:center; justify-content:space-between; }
+    .dash-main { padding:32px; max-width:1100px; }
+    .eyebrow { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.10em; color:var(--mmt-text-secondary); margin-bottom:8px; }
+    h1 { font-size:26px; font-weight:800; margin:0 0 8px; letter-spacing:-0.02em; }
+    .lede { font-size:15.5px; color:var(--mmt-text-secondary); margin:0 0 14px; line-height:1.6; }
+    .meta-row { font-size:12px; color:var(--mmt-text-secondary); margin-bottom:24px; }
+    .meta-row a { color:var(--mmt-teal); text-decoration:none; }
+    .filters { display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin-bottom:14px; }
+    .filters input[type=text] { flex:1; min-width:220px; padding:9px 12px; border:1px solid var(--mmt-border); border-radius:6px; font-size:14px; font-family:Inter,sans-serif; }
+    .filters .toggle-group { display:flex; gap:0; background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:6px; overflow:hidden; }
+    .filters .toggle-btn { background:transparent; border:none; padding:8px 14px; font-size:12.5px; font-weight:600; color:var(--mmt-text-secondary); cursor:pointer; font-family:Inter,sans-serif; }
+    .filters .toggle-btn.active { background:var(--mmt-navy); color:#fff; }
+    .count-line { font-size:12.5px; color:var(--mmt-text-secondary); margin-bottom:12px; }
+    table.hca { width:100%; border-collapse:collapse; background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:10px; overflow:hidden; font-size:13.5px; }
+    table.hca th { text-align:left; padding:12px; background:var(--mmt-surface); font-weight:700; border-bottom:2px solid var(--mmt-border); color:var(--mmt-navy); position:sticky; top:0; }
+    table.hca th button { background:none; border:none; font:inherit; font-weight:700; color:inherit; cursor:pointer; padding:0; display:inline-flex; align-items:center; gap:4px; }
+    table.hca th button:hover { color:var(--mmt-teal); }
+    table.hca td { padding:12px; border-bottom:1px solid var(--mmt-border); color:var(--mmt-navy); vertical-align:top; }
+    table.hca tr:hover td { background:rgba(69,123,157,0.04); }
+    table.hca tr.is-new td { background:rgba(69,123,157,0.10); }
+    .opdiv-chip { display:inline-block; padding:3px 10px; border-radius:12px; background:rgba(69,123,157,0.10); color:var(--mmt-teal); font-weight:700; font-size:11.5px; letter-spacing:0.04em; }
+    .status-pill { display:inline-block; padding:2px 8px; border-radius:10px; font-size:11px; font-weight:700; letter-spacing:0.04em; }
+    .status-pill.acting { background:rgba(69,123,157,0.15); color:var(--mmt-teal); }
+    .status-pill.permanent { background:rgba(10,25,47,0.06); color:var(--mmt-navy); }
+    .status-pill.new { background:rgba(146,113,10,0.10); color:var(--ci-gold); margin-left:6px; }
+    a.contact { color:var(--mmt-teal); text-decoration:none; word-break:break-all; }
+    a.contact:hover { text-decoration:underline; }
+    .source-block { background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:10px; padding:18px 22px; margin-top:24px; font-size:12.5px; color:var(--mmt-text-secondary); line-height:1.6; }
+    .source-block strong { color:var(--mmt-navy); }
+    .source-block a { color:var(--mmt-teal); text-decoration:none; }
+    .empty-state { text-align:center; padding:40px 20px; color:var(--mmt-text-secondary); font-size:14px; }
+    @media (max-width:768px) {
+      .dash-shell { grid-template-columns:1fr; } .dash-nav { display:none; } .dash-main { padding:16px; padding-bottom:80px; }
+      table.hca { font-size:12px; }
+      table.hca th, table.hca td { padding:8px; }
+    }
+  </style>
+  <script>
+    (function() {
+      var isPremium = localStorage.getItem('mmt_premium') === 'true';
+      var ts = localStorage.getItem('mmt_premium_ts');
+      var withinWindow = ts && (Date.now() - parseInt(ts)) < 30 * 24 * 60 * 60 * 1000;
+      if (!isPremium || !withinWindow) { window.location.href = '/dashboard.html'; }
+    })();
+  </script>
+</head>
+<body>
+  <div class="dash-shell">
+    <nav class="dash-nav">
+      <div class="dash-nav-brand"><a href="/premium/dashboard.html">&#9733; MMT Premium<small>Intelligence Dashboard</small></a></div>
+      <div class="dash-nav-section">Intelligence</div>
+      <a href="/premium/dashboard.html" class="dash-nav-link">Dashboard</a>
+      <a href="/agencies/" class="dash-nav-link active">Agencies</a>
+      <a href="/premium/briefings.html" class="dash-nav-link">Friday Brief</a>
+      <a href="/premium/monthly-briefs.html" class="dash-nav-link">Monthly Brief</a>
+      <a href="/premium/key-people.html" class="dash-nav-link">Key People</a>
+      <a href="/premium/gao-sustain.html" class="dash-nav-link">GAO Sustains</a>
+      <div class="dash-nav-section">Tools</div>
+      <a href="/premium/pursuit-score.html" class="dash-nav-link">Pursuit Score</a>
+      <a href="/premium/compliance-check.html" class="dash-nav-link">Compliance Check</a>
+      <a href="/premium/signal-chain.html" class="dash-nav-link">Signal Chain</a>
+      <div class="dash-nav-section">Resources</div>
+      <a href="/premium/calendar.html" class="dash-nav-link">Pursuit Calendar</a>
+      <a href="/contract-tracker.html" class="dash-nav-link">Contract Tracker</a>
+      <a href="/idiq-tracker.html" class="dash-nav-link">IDIQ Tracker</a>
+      <a href="/premium/single-bidder.html" class="dash-nav-link">Sole-Source Watch</a>
+      <a href="/premium/forecast-delta.html" class="dash-nav-link">Forecast Delta</a>
+      <a href="/premium/cr-exposure.html" class="dash-nav-link">CR Exposure</a>
+      <a href="/premium/fpds-migration.html" class="dash-nav-link">FPDS Sunset</a>
+      <a href="/premium/ask-mmt.html" class="dash-nav-link">Ask MMT</a>
+      <div class="dash-nav-section">Account</div>
+      <a href="/premium/settings.html" class="dash-nav-link">Settings</a>
+      <a href="/" class="dash-nav-link" style="margin-top:auto; border-top:1px solid rgba(255,255,255,0.1); padding-top:16px;">&larr; Back to site</a>
+    </nav>
+    <div>
+      <div class="dash-header">
+        <span style="font-size:14px; font-weight:700;">&#9733; Premium Dashboard</span>
+        <div style="display:flex; align-items:center; gap:16px;">
+          <span style="font-size:13px; color:var(--mmt-text-secondary);" id="dash-email"></span>
+          <a href="/" style="font-size:12px; color:var(--mmt-teal); text-decoration:none;">Back to site</a>
+          <a href="#" onclick="localStorage.removeItem('mmt_premium');localStorage.removeItem('mmt_premium_ts');localStorage.removeItem('mmt_email');document.cookie='mmt_premium=;path=/;max-age=0';window.location.href='/';return false;" style="font-size:12px; color:var(--mmt-text-secondary); text-decoration:none;">Sign out</a>
+        </div>
+      </div>
+      <div class="dash-main">
+
+        <div class="eyebrow">HHS &middot; Heads of Contracting Activity</div>
+        <h1>The 10 HHS HCAs — every name, every email, current as of April 2026</h1>
+        <p class="lede">HHS went from 13 contracting activities to 10. OMAS is new. ACF and AHRQ are gone (their work flows through OMAS SBC-Mission). Three of the remaining HCAs are Acting — and they happen to be the three biggest spenders.</p>
+        <div class="meta-row">
+          Data current as of April 27, 2026 from the HHS HCA roster. Page updated May 18, 2026.
+          &middot; <a href="/agencies/hhs">HHS profile</a>
+          &middot; <a href="/agencies/hhs/orgchart">Visual org chart</a>
+          &middot; <a href="/agencies/hhs/omas">OMAS deep dive</a>
+        </div>
+
+        <div class="filters">
+          <input type="text" id="search" placeholder="Filter by name, agency, or email...">
+          <div class="toggle-group" role="tablist">
+            <button class="toggle-btn active" data-filter="all">All</button>
+            <button class="toggle-btn" data-filter="permanent">Permanent</button>
+            <button class="toggle-btn" data-filter="acting">Acting only</button>
+            <button class="toggle-btn" data-filter="new">New since 2025</button>
+          </div>
+        </div>
+        <div class="count-line" id="countLine">Showing 10 of 10 HCAs.</div>
+
+        <table class="hca" id="hcaTable">
+          <thead>
+            <tr>
+              <th><button type="button" data-sort="opdiv">OpDiv &uarr;&darr;</button></th>
+              <th><button type="button" data-sort="name">HCA name &uarr;&darr;</button></th>
+              <th><button type="button" data-sort="status">Status &uarr;&darr;</button></th>
+              <th>Email</th>
+              <th>Phone</th>
+              <th>Small business specialist</th>
+            </tr>
+          </thead>
+          <tbody id="hcaBody">
+            <tr data-status="acting" data-new="false">
+              <td><span class="opdiv-chip">ARPA-H</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Advanced Research Projects Agency for Health</span></td>
+              <td><strong>Benjamin Bryant</strong></td>
+              <td><span class="status-pill acting">Acting</span></td>
+              <td><a class="contact" href="mailto:benjamin.bryant@arpa-h.gov">benjamin.bryant@arpa-h.gov</a></td>
+              <td>&mdash;</td>
+              <td>Cindy Anderson<br><a class="contact" href="mailto:Cynthia.Anderson@hhs.gov">Cynthia.Anderson@hhs.gov</a> &middot; 202-578-1356</td>
+            </tr>
+
+            <tr data-status="acting" data-new="false">
+              <td><span class="opdiv-chip">CDC</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Centers for Disease Control and Prevention</span></td>
+              <td><strong>Christine Godfrey</strong></td>
+              <td><span class="status-pill acting">Acting</span></td>
+              <td><a class="contact" href="mailto:cnp9@cdc.gov">cnp9@cdc.gov</a></td>
+              <td>770-488-2519</td>
+              <td>Gwendolyn Miles &middot; LaTonya Dent</td>
+            </tr>
+
+            <tr data-status="acting" data-new="false">
+              <td><span class="opdiv-chip">CMS</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Centers for Medicare &amp; Medicaid Services</span></td>
+              <td><strong>Doug Bergevin</strong></td>
+              <td><span class="status-pill acting">Acting</span></td>
+              <td><a class="contact" href="mailto:douglas.bergevin@cms.hhs.gov">douglas.bergevin@cms.hhs.gov</a></td>
+              <td>443-909-0131</td>
+              <td>Anita Allen &middot; Christine Haber</td>
+            </tr>
+
+            <tr data-status="permanent" data-new="false">
+              <td><span class="opdiv-chip">FDA</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Food and Drug Administration</span></td>
+              <td><strong>Leonard Grant</strong></td>
+              <td><span class="status-pill permanent">Permanent</span></td>
+              <td><a class="contact" href="mailto:Leonard.Grant@fda.hhs.gov">Leonard.Grant@fda.hhs.gov</a></td>
+              <td>240-402-7584</td>
+              <td>Cindy Anderson</td>
+            </tr>
+
+            <tr data-status="permanent" data-new="false">
+              <td><span class="opdiv-chip">HRSA</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Health Resources &amp; Services Administration</span></td>
+              <td><strong>Brian Goodger</strong></td>
+              <td><span class="status-pill permanent">Permanent</span></td>
+              <td><a class="contact" href="mailto:BGoodger@hrsa.gov">BGoodger@hrsa.gov</a></td>
+              <td>301-945-9380</td>
+              <td>Wayne Berry</td>
+            </tr>
+
+            <tr data-status="permanent" data-new="false">
+              <td><span class="opdiv-chip">IHS</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Indian Health Service</span></td>
+              <td><strong>Chantel Smith</strong></td>
+              <td><span class="status-pill permanent">Permanent</span></td>
+              <td><a class="contact" href="mailto:Chantel.Smith@ihs.gov">Chantel.Smith@ihs.gov</a></td>
+              <td>240-460-6876</td>
+              <td>Jonathan Ferguson</td>
+            </tr>
+
+            <tr data-status="permanent" data-new="false">
+              <td><span class="opdiv-chip">NIH</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">National Institutes of Health</span></td>
+              <td><strong>Olga Acosta</strong></td>
+              <td><span class="status-pill permanent">Permanent</span></td>
+              <td><a class="contact" href="mailto:olga.acosta@nih.gov">olga.acosta@nih.gov</a></td>
+              <td>301-435-4322</td>
+              <td>Natasha Boyce &middot; Melanie Carter &middot; Jonathan Ferguson &middot; Amy Ulisse</td>
+            </tr>
+
+            <tr data-status="permanent" data-new="true" class="is-new">
+              <td><span class="opdiv-chip">OMAS</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Office of the Secretary / ASFR / Mission Acquisition Solutions</span></td>
+              <td><strong>Quentin McCoy</strong></td>
+              <td><span class="status-pill permanent">Permanent</span><span class="status-pill new">NEW HCA</span></td>
+              <td><a class="contact" href="mailto:Quentin.McCoy@hhs.gov">Quentin.McCoy@hhs.gov</a></td>
+              <td>301-492-5456</td>
+              <td>Industry Liaison: <a class="contact" href="mailto:IndustryLiaison@hhs.gov">IndustryLiaison@hhs.gov</a></td>
+            </tr>
+
+            <tr data-status="permanent" data-new="false">
+              <td><span class="opdiv-chip">ASPR</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Admin. for Strategic Preparedness and Response</span></td>
+              <td><strong>Makoto P. Braxton</strong></td>
+              <td><span class="status-pill permanent">Permanent</span></td>
+              <td><a class="contact" href="mailto:makoto.braxton@hhs.gov">makoto.braxton@hhs.gov</a></td>
+              <td>202-260-6794</td>
+              <td>LaTonya Dent</td>
+            </tr>
+
+            <tr data-status="permanent" data-new="false">
+              <td><span class="opdiv-chip">OIG</span><br><span style="font-size:11px;color:var(--mmt-text-secondary);">Office of Inspector General</span></td>
+              <td><strong>John Marshall</strong></td>
+              <td><span class="status-pill permanent">Permanent</span></td>
+              <td><a class="contact" href="mailto:john.marshall@oig.hhs.gov">john.marshall@oig.hhs.gov</a></td>
+              <td>240-749-1499</td>
+              <td>Amy Ulisse</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="source-block">
+          <strong>Sources.</strong>
+          <a href="https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html" rel="noopener">HHS HCA and Key Managers roster</a> (verified 2026-04-27).
+          <a href="https://www.hhs.gov/about/agencies/asfr/acquisition/osdbu/index.html" rel="noopener">HHS OSDBU Small Business Specialists by OpDiv</a> (verified 2026-05-07).<br><br>
+          <strong>What's not on this page.</strong> SAMHSA and ACL no longer appear on the HCA roster. SAMHSA's contracting authority is verifying — coverage is likely via OMAS or a parent HCA. ACL is similar. Treat both as "verify before targeting" until HHS publishes a clarification.<br><br>
+          <strong>Refresh cadence.</strong> Quarterly, against the official roster page. Vacancies fill; Acting designations turn Permanent. If you see a name change between refreshes, email <a href="mailto:mary@missionmeetstech.com">mary@missionmeetstech.com</a> and we'll re-verify the source.
+        </div>
+
+      </div>
+    </div>
+  </div>
+  <script>
+    var email=localStorage.getItem('mmt_email');var __de=document.getElementById('dash-email');if(__de&&email)__de.textContent=email;
+
+    (function() {
+      var tbody = document.getElementById('hcaBody');
+      var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
+      var search = document.getElementById('search');
+      var countLine = document.getElementById('countLine');
+      var toggles = document.querySelectorAll('.toggle-btn');
+      var currentFilter = 'all';
+      var sortKey = null;
+      var sortDir = 1;
+
+      function applyFilters() {
+        var q = (search.value || '').trim().toLowerCase();
+        var visible = 0;
+        rows.forEach(function(r) {
+          var text = r.textContent.toLowerCase();
+          var matchQ = !q || text.indexOf(q) !== -1;
+          var status = r.getAttribute('data-status');
+          var isNew = r.getAttribute('data-new') === 'true';
+          var matchF = currentFilter === 'all' ||
+            (currentFilter === 'permanent' && status === 'permanent') ||
+            (currentFilter === 'acting' && status === 'acting') ||
+            (currentFilter === 'new' && isNew);
+          if (matchQ && matchF) { r.style.display = ''; visible++; }
+          else { r.style.display = 'none'; }
+        });
+        countLine.textContent = 'Showing ' + visible + ' of ' + rows.length + ' HCAs.';
+      }
+
+      search.addEventListener('input', applyFilters);
+      toggles.forEach(function(t) {
+        t.addEventListener('click', function() {
+          toggles.forEach(function(x) { x.classList.remove('active'); });
+          t.classList.add('active');
+          currentFilter = t.getAttribute('data-filter');
+          applyFilters();
+        });
+      });
+
+      function sortBy(key) {
+        if (sortKey === key) sortDir = -sortDir; else { sortKey = key; sortDir = 1; }
+        var keyIdx = key === 'opdiv' ? 0 : key === 'name' ? 1 : 2;
+        rows.sort(function(a, b) {
+          var av = a.cells[keyIdx].textContent.trim().toLowerCase();
+          var bv = b.cells[keyIdx].textContent.trim().toLowerCase();
+          return av < bv ? -sortDir : av > bv ? sortDir : 0;
+        });
+        rows.forEach(function(r) { tbody.appendChild(r); });
+      }
+      document.querySelectorAll('th button[data-sort]').forEach(function(b) {
+        b.addEventListener('click', function() { sortBy(b.getAttribute('data-sort')); });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/premium/agencies/hhs-omas.html
+++ b/premium/agencies/hhs-omas.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OMAS Deep Dive &middot; HHS &middot; MMT Premium</title>
+  <meta name="robots" content="noindex">
+  <meta name="description" content="OMAS (Office of Mission Acquisition Solutions) standup history, leadership, the three Strategic Buying Centers, the 3-year outlook, and Market Hour. Sourced from HHS Acquisition Solutions Day (May 2026) and the HHS HCA roster.">
+  <link rel="stylesheet" href="/styles/tailwind.css">
+  <link rel="icon" href="/favicon-v3.png" type="image/png">
+  <style>
+    :root { --mmt-navy:#0A192F; --mmt-teal:#457B9D; --mmt-white:#FFFFFF; --mmt-surface:#F3F4F6; --mmt-text-secondary:#6B7280; --mmt-border:#E5E7EB; --ci-gold:#92710A; --dash-sidebar:220px; }
+    body { font-family:Inter,system-ui,sans-serif; color:var(--mmt-navy); background:var(--mmt-surface); margin:0; line-height:1.55; }
+    .dash-shell { display:grid; grid-template-columns:var(--dash-sidebar) 1fr; min-height:100vh; }
+    .dash-nav { background:var(--mmt-navy); padding:24px 0; display:flex; flex-direction:column; position:sticky; top:0; height:100vh; overflow-y:auto; }
+    .dash-nav-brand { padding:0 20px 24px; border-bottom:1px solid rgba(255,255,255,0.1); margin-bottom:16px; }
+    .dash-nav-brand a { color:#fff; text-decoration:none; font-weight:800; font-size:14px; }
+    .dash-nav-brand small { display:block; font-size:11px; color:rgba(255,255,255,0.5); font-weight:400; margin-top:2px; }
+    .dash-nav-link { display:flex; align-items:center; gap:10px; padding:10px 20px; color:rgba(255,255,255,0.6); text-decoration:none; font-size:13px; font-weight:500; transition:all 0.15s; }
+    .dash-nav-link:hover { color:#fff; background:rgba(255,255,255,0.05); }
+    .dash-nav-link.active { color:#fff; background:rgba(69,123,157,0.3); border-left:3px solid var(--mmt-teal); }
+    .dash-nav-section { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.12em; color:rgba(255,255,255,0.3); padding:16px 20px 6px; }
+    .dash-header { background:var(--mmt-white); padding:16px 32px; border-bottom:1px solid var(--mmt-border); display:flex; align-items:center; justify-content:space-between; }
+    .dash-main { padding:32px; max-width:920px; }
+    .dash-card { background:var(--mmt-white); border-radius:12px; padding:28px; margin-bottom:20px; border:1px solid var(--mmt-border); }
+    .eyebrow { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.10em; color:var(--mmt-text-secondary); margin-bottom:8px; }
+    h1 { font-size:28px; font-weight:800; margin:0 0 8px; letter-spacing:-0.02em; }
+    h2 { font-size:20px; font-weight:800; margin:0 0 14px; letter-spacing:-0.01em; color:var(--mmt-navy); }
+    h3 { font-size:15px; font-weight:700; margin:0 0 8px; color:var(--mmt-navy); }
+    .lede { font-size:16px; color:var(--mmt-text-secondary); margin:0 0 16px; line-height:1.6; }
+    .meta-row { font-size:12px; color:var(--mmt-text-secondary); margin-bottom:24px; }
+    .meta-row a { color:var(--mmt-teal); text-decoration:none; }
+    p { font-size:14.5px; color:var(--mmt-navy); margin:0 0 14px; }
+    ul { font-size:14.5px; padding-left:20px; margin:0 0 14px; }
+    ul li { margin-bottom:6px; }
+    .leader-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; }
+    .leader-card { background:var(--mmt-surface); border:1px solid var(--mmt-border); border-radius:8px; padding:14px 16px; }
+    .leader-card.is-vacant { background:rgba(92,107,122,0.08); border-color:rgba(92,107,122,0.30); opacity:0.95; }
+    .leader-card.is-primary { border-left:3px solid var(--mmt-teal); background:var(--mmt-white); }
+    .leader-role { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.06em; color:var(--mmt-teal); margin-bottom:4px; }
+    .leader-name { font-size:15px; font-weight:700; color:var(--mmt-navy); margin-bottom:2px; }
+    .leader-title { font-size:12.5px; color:var(--mmt-text-secondary); line-height:1.4; }
+    .leader-contact { font-size:12px; color:var(--mmt-teal); margin-top:6px; word-break:break-all; }
+    .sbc-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:14px; }
+    .sbc-card { background:var(--mmt-white); border:1px solid var(--mmt-border); border-left:3px solid var(--mmt-teal); border-radius:8px; padding:16px 18px; }
+    .sbc-name { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.08em; color:var(--mmt-teal); margin-bottom:4px; }
+    .sbc-director { font-size:16px; font-weight:700; color:var(--mmt-navy); margin-bottom:6px; }
+    .sbc-scope { font-size:13px; color:var(--mmt-text-secondary); line-height:1.5; }
+    .timeline-card { background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:10px; padding:16px 20px; margin-bottom:10px; }
+    .timeline-year { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.08em; color:var(--mmt-teal); margin-bottom:6px; }
+    .timeline-label { font-size:15px; font-weight:700; color:var(--mmt-navy); margin-bottom:8px; }
+    .callout { background:var(--mmt-surface); border:1px solid var(--mmt-border); border-left:3px solid var(--mmt-teal); border-radius:6px; padding:14px 18px; margin:14px 0; font-size:14px; line-height:1.55; }
+    .callout strong { color:var(--mmt-navy); }
+    table.kv { width:100%; border-collapse:collapse; font-size:14px; margin:0 0 16px; }
+    table.kv th, table.kv td { padding:10px 12px; border-bottom:1px solid var(--mmt-border); text-align:left; vertical-align:top; }
+    table.kv th { font-weight:700; color:var(--mmt-navy); background:var(--mmt-surface); width:32%; }
+    .source-block { font-size:12.5px; color:var(--mmt-text-secondary); line-height:1.6; }
+    .source-block a { color:var(--mmt-teal); text-decoration:none; }
+    .source-block a:hover { text-decoration:underline; }
+    .pill-row { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+    .pill-row a { font-size:12px; font-weight:600; color:var(--mmt-navy); background:var(--mmt-white); border:1px solid var(--mmt-border); padding:6px 12px; border-radius:6px; text-decoration:none; }
+    .pill-row a:hover { border-color:var(--mmt-navy); }
+    @media (max-width:768px) { .dash-shell { grid-template-columns:1fr; } .dash-nav { display:none; } .dash-main { padding:16px; padding-bottom:80px; } }
+  </style>
+  <script>
+    (function() {
+      var isPremium = localStorage.getItem('mmt_premium') === 'true';
+      var ts = localStorage.getItem('mmt_premium_ts');
+      var withinWindow = ts && (Date.now() - parseInt(ts)) < 30 * 24 * 60 * 60 * 1000;
+      if (!isPremium || !withinWindow) { window.location.href = '/dashboard.html'; }
+    })();
+  </script>
+</head>
+<body>
+  <div class="dash-shell">
+    <nav class="dash-nav">
+      <div class="dash-nav-brand"><a href="/premium/dashboard.html">&#9733; MMT Premium<small>Intelligence Dashboard</small></a></div>
+      <div class="dash-nav-section">Intelligence</div>
+      <a href="/premium/dashboard.html" class="dash-nav-link">Dashboard</a>
+      <a href="/agencies/" class="dash-nav-link active">Agencies</a>
+      <a href="/premium/briefings.html" class="dash-nav-link">Friday Brief</a>
+      <a href="/premium/monthly-briefs.html" class="dash-nav-link">Monthly Brief</a>
+      <a href="/premium/key-people.html" class="dash-nav-link">Key People</a>
+      <a href="/premium/gao-sustain.html" class="dash-nav-link">GAO Sustains</a>
+      <div class="dash-nav-section">Tools</div>
+      <a href="/premium/pursuit-score.html" class="dash-nav-link">Pursuit Score</a>
+      <a href="/premium/compliance-check.html" class="dash-nav-link">Compliance Check</a>
+      <a href="/premium/signal-chain.html" class="dash-nav-link">Signal Chain</a>
+      <div class="dash-nav-section">Resources</div>
+      <a href="/premium/calendar.html" class="dash-nav-link">Pursuit Calendar</a>
+      <a href="/contract-tracker.html" class="dash-nav-link">Contract Tracker</a>
+      <a href="/idiq-tracker.html" class="dash-nav-link">IDIQ Tracker</a>
+      <a href="/premium/single-bidder.html" class="dash-nav-link">Sole-Source Watch</a>
+      <a href="/premium/forecast-delta.html" class="dash-nav-link">Forecast Delta</a>
+      <a href="/premium/cr-exposure.html" class="dash-nav-link">CR Exposure</a>
+      <a href="/premium/fpds-migration.html" class="dash-nav-link">FPDS Sunset</a>
+      <a href="/premium/ask-mmt.html" class="dash-nav-link">Ask MMT</a>
+      <div class="dash-nav-section">Account</div>
+      <a href="/premium/settings.html" class="dash-nav-link">Settings</a>
+      <a href="/" class="dash-nav-link" style="margin-top:auto; border-top:1px solid rgba(255,255,255,0.1); padding-top:16px;">&larr; Back to site</a>
+    </nav>
+    <div>
+      <div class="dash-header">
+        <span style="font-size:14px; font-weight:700;">&#9733; Premium Dashboard</span>
+        <div style="display:flex; align-items:center; gap:16px;">
+          <span style="font-size:13px; color:var(--mmt-text-secondary);" id="dash-email"></span>
+          <a href="/" style="font-size:12px; color:var(--mmt-teal); text-decoration:none;">Back to site</a>
+          <a href="#" onclick="localStorage.removeItem('mmt_premium');localStorage.removeItem('mmt_premium_ts');localStorage.removeItem('mmt_email');document.cookie='mmt_premium=;path=/;max-age=0';window.location.href='/';return false;" style="font-size:12px; color:var(--mmt-text-secondary); text-decoration:none;">Sign out</a>
+        </div>
+      </div>
+      <div class="dash-main">
+
+        <div class="eyebrow">HHS &middot; Office of Mission Acquisition Solutions</div>
+        <h1>OMAS deep dive: who they are, what they buy, when to engage</h1>
+        <p class="lede">OMAS is the new HHS contracting activity for common IT and Professional Services. It absorbed ACF and AHRQ's independent contracting authority. This is the leadership, the three Strategic Buying Centers, the 3-year roadmap, and the first vendor engagement program.</p>
+        <div class="meta-row">
+          Data current as of April 27, 2026 (HHS HCA roster) and May 15, 2026 (Acquisition Solutions Day). Page updated May 18, 2026.
+          &middot; <a href="/agencies/hhs">HHS profile</a>
+          &middot; <a href="/agencies/hhs/orgchart">Visual org chart</a>
+          &middot; <a href="/agencies/hhs/hcas">All 10 HCAs</a>
+        </div>
+
+        <div class="dash-card">
+          <h2>Why OMAS exists</h2>
+          <p>OMAS (Office of Mission Acquisition Solutions) is the rename of OAMS. It realigned under ASFR / Office of Acquisitions in January 2026 as part of the PACT initiative (Procurement Alignment and Collaboration Task Force). PACT is now a formal HHS Agency Priority Goal. The mandate has three goals:</p>
+          <ol style="font-size:14.5px; padding-left:22px; margin:0 0 14px;">
+            <li style="margin-bottom:6px;">Centralize common IT and common professional services through OMAS.</li>
+            <li style="margin-bottom:6px;">Modernize the acquisition system stack (HCAS and related tools, financial-system integration, data standardization).</li>
+            <li>Preserve mission-specialized procurement at operating divisions with mission-critical authority.</li>
+          </ol>
+          <p>Driving authority: EO 14240 (Procurement Consolidation, March 20, 2025) and OMB M-25-31 (Consolidating Federal Procurement Activities, July 18, 2025). Plus the Secretary's "Make America Healthy Again" framing for realignment of mission support functions.</p>
+        </div>
+
+        <div class="dash-card">
+          <h2>OMAS leadership</h2>
+          <p>Quentin McCoy is the HCA. He's a permanent designation on the official HHS roster, and the HCA designation is new (OMAS itself is the new contracting activity). His prior HCA experience includes U.S. Cyber Command and a CAO/UMBC office before OMAS.</p>
+          <div class="leader-grid" style="margin-top:16px;">
+            <div class="leader-card is-primary">
+              <div class="leader-role">HCA &middot; Permanent</div>
+              <div class="leader-name">Quentin McCoy</div>
+              <div class="leader-title">Executive Director and Head of Contracting Activity</div>
+              <div class="leader-contact">Quentin.McCoy@hhs.gov &middot; 301-492-5456</div>
+            </div>
+            <div class="leader-card">
+              <div class="leader-role">Chief of Staff</div>
+              <div class="leader-name">Colette Magwood</div>
+              <div class="leader-title">Chief of Staff, OMAS</div>
+            </div>
+            <div class="leader-card is-vacant">
+              <div class="leader-role">Deputy HCA</div>
+              <div class="leader-name">VACANT</div>
+              <div class="leader-title">Deputy Head of Contracting Activity &middot; Open role</div>
+            </div>
+            <div class="leader-card">
+              <div class="leader-role">Operations Support</div>
+              <div class="leader-name">Lisa Portner</div>
+              <div class="leader-title">Director, Procurement Operations Support (POS)</div>
+            </div>
+          </div>
+          <p style="margin-top:14px;">Category-management partnership at the Office-of-Acquisitions level: Sonya Carrion (Executive Director, Strategic Programs &amp; Business Systems). She was featured alongside the three SBC directors on the Acquisition Solutions Day deck, slide 22.</p>
+        </div>
+
+        <div class="dash-card">
+          <h2>The three Strategic Buying Centers</h2>
+          <p>This is the part that changes your BD plan. If your firm sells common IT or professional services into HHS, your contracting officer is now in one of these three. If you sell mission-unique work to ACF or AHRQ, you're now in SBC-Mission.</p>
+          <div class="sbc-grid">
+            <div class="sbc-card">
+              <div class="sbc-name">SBC-Mission</div>
+              <div class="sbc-director">Tatricia (Trish) James</div>
+              <div class="sbc-scope">Director. Department-wide mission needs, Secretary initiatives, ACF, AHRQ, and Staff Divisions. ACF and AHRQ independent contracting authority was eliminated and absorbed here.</div>
+            </div>
+            <div class="sbc-card">
+              <div class="sbc-name">SBC-IT</div>
+              <div class="sbc-director">Adam Vance</div>
+              <div class="sbc-scope">Director. Common enterprise IT, software, cybersecurity, cloud, AI-related tools. Leverages GSA MAS IT, NASA SEWP V/SEWP VI, NITAAC CIO-SP, OASIS+.</div>
+            </div>
+            <div class="sbc-card">
+              <div class="sbc-name">SBC-PS</div>
+              <div class="sbc-director">Scott Bredow</div>
+              <div class="sbc-scope">Director. Advisory, scientific, training and technical assistance, and programmatic services across HHS. OASIS+ is the canonical vehicle referenced in the May 2026 transcripts.</div>
+            </div>
+          </div>
+          <div class="callout">
+            <strong>What's "common" vs. "mission"?</strong> OMAS uses a Standardization Suitability Spectrum (Acquisition Solutions Day, slide 10). At one end: complex, mission-unique, high program enablement (Divisions handle). At the other end: simple, mission-agnostic, easy to standardize (OMAS handles). Examples on the "OMAS-handles" side: laptops, HHS-wide LMS, license renewals.
+          </div>
+        </div>
+
+        <div class="dash-card">
+          <h2>Strategic goals (verbatim from the May 2026 deck)</h2>
+          <ol style="font-size:14.5px; padding-left:22px; margin:0;">
+            <li style="margin-bottom:8px;">Stand up a fully staffed, trained, and equipped OMAS workforce.</li>
+            <li style="margin-bottom:8px;">Build a high-impact customer engagement and experience model.</li>
+            <li style="margin-bottom:8px;">Drive innovation and efficiency across the full acquisition lifecycle to deliver measurable savings.</li>
+            <li>Establish OMAS as the Acquisition Office of Choice for Common IT and Professional Services across HHS.</li>
+          </ol>
+        </div>
+
+        <div class="dash-card">
+          <h2>Three-year outlook</h2>
+          <div class="timeline-card">
+            <div class="timeline-year">Year 1 (current) &middot; Stand-Up &amp; Stabilize</div>
+            <div class="timeline-label">Get the function running.</div>
+            <ul>
+              <li>OMAS Intake Activated.</li>
+              <li>Operating Model Established.</li>
+              <li>PACT Established as Agency Priority Goal.</li>
+              <li>Systems Modernization Kicked Off (NIH).</li>
+            </ul>
+          </div>
+          <div class="timeline-card">
+            <div class="timeline-year">Year 2 &middot; Optimize and Buy Better</div>
+            <div class="timeline-label">Move from intake to enterprise buying.</div>
+            <ul>
+              <li>Establish strategic-sourcing vehicles.</li>
+              <li>Continue systems modernization (NIH, CDC &amp; CMS integration).</li>
+              <li>Develop demand-aggregation initiatives.</li>
+              <li>Create category-based solutions.</li>
+              <li>Demonstrate reduced duplication and costs.</li>
+            </ul>
+          </div>
+          <div class="timeline-card">
+            <div class="timeline-year">Year 3 &middot; Scale and Transform</div>
+            <div class="timeline-label">Departmental excellence.</div>
+            <ul>
+              <li>Enable enterprise insights and analytics.</li>
+              <li>Leverage data-driven strategies.</li>
+              <li>Establish a scalable acquisition model.</li>
+              <li>Become a strategic mission partner.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="dash-card">
+          <h2>OMAS Market Hour (launches June 2026)</h2>
+          <p>The new vendor engagement program. Virtual sessions, customer-interest-driven selection. If your firm wants in, the Vendor Profile Form is the only path.</p>
+          <table class="kv">
+            <tr><th>Launch</th><td>June 2026</td></tr>
+            <tr><th>Format</th><td>10-minute capability demonstration + 5-minute Q&amp;A with OMAS customers</td></tr>
+            <tr><th>Audience</th><td>OMAS programs, acquisition staff, technical teams</td></tr>
+            <tr><th>Selection</th><td>Customer-interest-driven from a submitted Vendor Profile Form. Only completed profiles are considered.</td></tr>
+            <tr><th>Contact</th><td><a href="mailto:IndustryLiaison@hhs.gov" style="color:var(--mmt-teal);">IndustryLiaison@hhs.gov</a></td></tr>
+            <tr><th>Action this week</th><td>Submit the Vendor Profile Form via the OMAS QR code (slide 19 and slide 28 of the Solutions Day deck). Submit early — June slots will fill on customer interest, not first-come-first-served.</td></tr>
+          </table>
+          <p>Reverse Industry Days, targeted solution sessions, and ongoing RFI / market research are also planned. No dates yet.</p>
+        </div>
+
+        <div class="dash-card">
+          <h2>OMAS staffing trajectory</h2>
+          <p>Quentin McCoy on the May 2026 transcript: "We started with about a little over 40 people. Today, we've got about 180." The goal is fully staffed by end of Year 1. If you're a federal acquisition professional, OMAS is hiring.</p>
+        </div>
+
+        <div class="dash-card">
+          <h2>How this connects</h2>
+          <div class="pill-row">
+            <a href="/agencies/hhs">HHS profile</a>
+            <a href="/agencies/hhs/orgchart">Visual org chart</a>
+            <a href="/agencies/hhs/hcas">All 10 HCAs</a>
+            <a href="/policy/pact">PACT + EO 14240 + OMB M-25-31</a>
+            <a href="/policy/rfo-8-4">RFO 8.4 tier playbook</a>
+            <a href="/updates/2026-05-18-hhs-omas">May 18 changelog</a>
+          </div>
+        </div>
+
+        <div class="dash-card source-block">
+          <strong>Sources.</strong>
+          <a href="https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html" rel="noopener">HHS HCA and Key Managers roster</a> (verified 2026-04-27).
+          <a href="https://www.hhs.gov/about/agencies/asfr/key-personnel/index.html" rel="noopener">HHS ASFR Key Personnel</a> (verified 2026-04-27).
+          <a href="https://www.hhs.gov/about/agencies/asfr/acquisition/osdbu/index.html" rel="noopener">HHS OSDBU</a> (verified 2026-05-07).
+          HHS Acquisition Solutions Day (May 2026) Industry Day deck + Otter.ai transcripts. Some Otter mishearings (ASTR &rarr; ASFR, ARC &rarr; AHRQ, Bluedown &rarr; Bredow) were corrected against the official ASFR and HCA roster pages.<br><br>
+          <strong>What changes after this date?</strong> The Deputy HCA role fills. Year-2 strategic-sourcing vehicles get named. The Market Hour cadence shifts after June 2026. We re-verify quarterly — email <a href="mailto:mary@missionmeetstech.com">mary@missionmeetstech.com</a> if you spot something stale.
+        </div>
+
+      </div>
+    </div>
+  </div>
+  <script>
+    var email=localStorage.getItem('mmt_email');var __de=document.getElementById('dash-email');if(__de&&email)__de.textContent=email;
+  </script>
+</body>
+</html>

--- a/premium/org-charts/hhs.html
+++ b/premium/org-charts/hhs.html
@@ -1,0 +1,385 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex">
+<title>HHS Organizational Structure &middot; MMT Premium</title>
+<meta name="description" content="HHS contracting organization as of May 18, 2026 — OMAS, the 10 HCAs, ASFR/Office of Acquisitions, and OSDBU. Sourced from the HHS HCA roster, ASFR Key Personnel page, and the May 2026 Acquisition Solutions Day deck.">
+<link rel="stylesheet" href="/styles/tokens.css">
+<style>
+:root{
+  --mmt-navy:#0A192F;
+  --mmt-teal:#457B9D;
+  --mmt-soft:#F3F4F6;
+  --mmt-white:#FFFFFF;
+  --mmt-border:#D8E0E8;
+  --mmt-text:#102033;
+  --mmt-text-secondary:#5C6B7A;
+  --mmt-text-faint:#8898aa;
+  --mmt-red:#E63946;
+  --status-acting:#457B9D;
+  --status-acting-bg:rgba(69,123,157,0.08);
+  --status-acting-border:rgba(69,123,157,0.35);
+  --status-vacant:#5C6B7A;
+  --status-vacant-bg:rgba(92,107,122,0.08);
+  --status-vacant-border:rgba(92,107,122,0.30);
+  --status-new:#457B9D;
+  --status-new-bg:rgba(69,123,157,0.10);
+  --status-new-border:rgba(69,123,157,0.40);
+  --bg:var(--mmt-white);
+  --surface:var(--mmt-white);
+  --surface-2:var(--mmt-soft);
+  --surface-offset:#E8EDF3;
+  --border:var(--mmt-border);
+  --text:var(--mmt-text);
+  --text-muted:var(--mmt-text-secondary);
+  --text-faint:var(--mmt-text-faint);
+  --primary:var(--mmt-navy);
+  --primary-hover:#06122A;
+  --primary-light:rgba(10,25,47,0.06);
+  --accent:var(--mmt-teal);
+  --accent-light:rgba(69,123,157,0.10);
+  --shadow-sm:0 1px 3px rgba(10,25,47,0.06);
+  --shadow-md:0 4px 16px rgba(10,25,47,0.08);
+  --radius:8px;--radius-lg:12px;
+  --font-body:'Inter',-apple-system,BlinkMacSystemFont,sans-serif;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{-webkit-font-smoothing:antialiased;font-size:16px}
+body{font-family:var(--font-body);background:var(--bg);color:var(--text);min-height:100vh;line-height:1.5}
+.page-hero{background:var(--primary);color:#fff;padding:32px 24px 40px;border-bottom:3px solid var(--accent)}
+.page-hero-inner{max-width:1400px;margin:0 auto}
+.hero-eyebrow{font-size:0.7rem;letter-spacing:0.12em;text-transform:uppercase;opacity:0.7;margin-bottom:8px}
+.hero-title{font-weight:700;font-size:clamp(1.5rem,3vw,2.25rem);line-height:1.2;margin-bottom:12px;letter-spacing:-0.01em}
+.hero-meta{display:flex;flex-wrap:wrap;gap:16px;font-size:0.8rem;opacity:0.85}
+.hero-meta span{display:flex;align-items:center;gap:6px}
+.hero-meta span::before{content:'\00B7';opacity:0.5}
+.hero-meta span:first-child::before{display:none}
+.org-container{max-width:1400px;margin:0 auto;padding:32px 24px 64px}
+.section-label{background:var(--surface-2);border:1px solid var(--border);border-radius:6px;padding:6px 14px;font-size:0.7rem;letter-spacing:0.1em;text-transform:uppercase;font-weight:600;color:var(--text-muted);margin-bottom:16px;display:inline-block}
+.status-bar{background:var(--accent-light);border:1px solid var(--accent);border-radius:8px;padding:14px 18px;margin-bottom:24px;font-size:0.85rem;color:var(--text);display:flex;gap:12px;align-items:flex-start;flex-wrap:wrap;line-height:1.55}
+.status-bar strong{color:var(--primary)}
+.tier{margin-bottom:36px}
+.tier-row{display:flex;justify-content:center;gap:16px;flex-wrap:wrap}
+.connector-v{width:2px;height:24px;background:var(--border);margin:0 auto}
+.connector-v.thick{background:var(--primary);opacity:0.4;height:32px}
+.node-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:14px 18px;min-width:200px;max-width:280px;display:inline-flex;flex-direction:column;gap:4px;box-shadow:var(--shadow-sm)}
+.node-card.primary-card{border-top:3px solid var(--accent)}
+.node-card.new-card{border-color:var(--status-new-border);background:var(--status-new-bg)}
+.node-card.acting{border-color:var(--status-acting-border);background:var(--status-acting-bg)}
+.node-card.vacant{border-color:var(--status-vacant-border);background:var(--status-vacant-bg);opacity:0.85}
+.node-tier{font-size:0.64rem;letter-spacing:0.1em;text-transform:uppercase;font-weight:600;margin-bottom:2px;color:var(--text-muted)}
+.node-tier.accent{color:var(--accent)}
+.node-tier.primary-tier{color:var(--primary)}
+.node-name{font-weight:600;font-size:0.9rem;line-height:1.3;color:var(--text)}
+.node-role{font-size:0.78rem;color:var(--text-muted);line-height:1.4}
+.node-meta{font-size:0.72rem;color:var(--text-faint);line-height:1.4;margin-top:2px}
+.node-badge{display:inline-flex;align-items:center;gap:3px;font-size:0.62rem;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;margin-top:4px;padding:2px 6px;border-radius:20px;background:rgba(69,123,157,0.15);color:var(--accent);align-self:flex-start}
+.node-badge.vacant-badge{background:rgba(92,107,122,0.15);color:var(--text-muted)}
+.node-badge.new-badge{background:rgba(69,123,157,0.18);color:var(--accent)}
+.children-group{display:flex;gap:14px;flex-wrap:wrap;justify-content:center;position:relative;padding-top:24px}
+.children-group::before{content:'';position:absolute;top:0;left:10%;right:10%;height:2px;background:var(--border)}
+.child-col{display:flex;flex-direction:column;align-items:center;position:relative}
+.child-col::before{content:'';position:absolute;top:-24px;left:50%;width:2px;height:24px;background:var(--border);transform:translateX(-50%)}
+.hca-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:12px;margin-top:16px}
+.hca-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:14px 16px;display:flex;flex-direction:column;gap:4px;transition:border-color 0.15s,transform 0.15s}
+.hca-card:hover{border-color:var(--primary);box-shadow:var(--shadow-sm)}
+.hca-card.is-new{border-color:var(--status-new-border);background:var(--status-new-bg)}
+.hca-card.is-acting{border-left:3px solid var(--status-acting)}
+.hca-opdiv{font-size:0.72rem;letter-spacing:0.08em;text-transform:uppercase;font-weight:700;color:var(--accent)}
+.hca-name{font-weight:600;font-size:0.95rem;color:var(--text);line-height:1.3}
+.hca-meta{font-size:0.78rem;color:var(--text-muted);line-height:1.45}
+.hca-email{font-size:0.78rem;color:var(--accent);text-decoration:none;word-break:break-all}
+.hca-email:hover{text-decoration:underline}
+.source-footer{background:var(--surface-2);border:1px solid var(--border);border-radius:var(--radius-lg);padding:18px 22px;margin-top:32px;font-size:0.78rem;color:var(--text-muted);line-height:1.6}
+.source-footer strong{color:var(--text);font-weight:600}
+.source-footer a{color:var(--accent);text-decoration:none}
+.source-footer a:hover{text-decoration:underline}
+.back-link{display:inline-flex;align-items:center;gap:6px;font-size:0.85rem;color:var(--accent);text-decoration:none;margin-bottom:20px;font-weight:500}
+.back-link:hover{text-decoration:underline}
+.callout{background:var(--surface);border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:var(--radius);padding:16px 20px;margin:24px 0;font-size:0.9rem;color:var(--text);line-height:1.55}
+@media(max-width:768px){.org-container{padding:20px 14px 48px}.tier-row{gap:10px}.node-card{min-width:160px;padding:12px 14px}}
+</style>
+<script>
+(function(){
+  var isPremium=localStorage.getItem('mmt_premium')==='true';
+  var ts=localStorage.getItem('mmt_premium_ts');
+  var withinWindow=ts&&(Date.now()-parseInt(ts))<30*24*60*60*1000;
+  if(!isPremium||!withinWindow){window.location.href='/dashboard.html';}
+})();
+</script>
+</head>
+<body>
+
+<div class="page-hero">
+  <div class="page-hero-inner">
+    <div class="hero-eyebrow">Organizational Intelligence &middot; MMT Premium</div>
+    <h1 class="hero-title">U.S. Department of Health and Human Services<br>Contracting Organization</h1>
+    <div class="hero-meta">
+      <span>Structure effective January 2026 (OMAS realignment)</span>
+      <span>Leadership data as of April 27, 2026</span>
+      <span>10 Heads of Contracting Activity</span>
+      <span>Page last updated May 18, 2026</span>
+    </div>
+  </div>
+</div>
+
+<div class="org-container">
+  <a href="/agencies/hhs" class="back-link">&larr; HHS profile</a>
+
+  <div class="status-bar">
+    <span style="font-size:1rem">&#8505;</span>
+    <div><strong>This is a moving picture.</strong> OMAS realigned under ASFR in January 2026 and grew from ~40 staff at standup to ~180 by May 2026. ACF and AHRQ independent contracting authority was eliminated; their portfolios now flow through OMAS SBC-Mission. HHS dropped from 13 contracting activities to 10. The FY26 Budget in Brief signals a further consolidation of 28 operating divisions to 15.</div>
+  </div>
+
+  <!-- TIER 1: Office of the Secretary -->
+  <div class="tier">
+    <div style="text-align:center"><div class="section-label">Office of the Secretary</div></div>
+    <div class="tier-row">
+      <div class="node-card primary-card">
+        <div class="node-tier primary-tier">Cabinet Department</div>
+        <div class="node-name">Office of the Secretary (OS)</div>
+        <div class="node-role">Policy, rulemaking, OCIO-level enterprise coordination</div>
+      </div>
+    </div>
+    <div class="connector-v thick"></div>
+  </div>
+
+  <!-- TIER 2: ASA / ASFR -->
+  <div class="tier">
+    <div style="text-align:center"><div class="section-label">Department-Level Administration</div></div>
+    <div class="tier-row">
+      <div class="node-card">
+        <div class="node-tier">Administration</div>
+        <div class="node-name">Office of the Assistant Secretary for Administration (ASA)</div>
+        <div class="node-role">Department-level administration</div>
+      </div>
+      <div class="node-card primary-card">
+        <div class="node-tier accent">Financial Resources &middot; Owns Acquisitions</div>
+        <div class="node-name">Office of the Assistant Secretary for Financial Resources (ASFR)</div>
+        <div class="node-role">Hubert H. Humphrey Building, Room 514-G</div>
+        <div class="node-meta">Principal Deputy ASFR: VACANT &middot; DAS for Operations &amp; Management: VACANT</div>
+      </div>
+    </div>
+    <div class="connector-v thick"></div>
+  </div>
+
+  <!-- TIER 3: ASFR Sub-Offices (focus on Office of Acquisitions) -->
+  <div class="tier">
+    <div style="text-align:center"><div class="section-label">ASFR Sub-Offices</div></div>
+    <div class="tier-row">
+      <div class="node-card">
+        <div class="node-tier">Budget</div>
+        <div class="node-name">Office of Budget</div>
+        <div class="node-role">DAS: Norris Cochran</div>
+      </div>
+      <div class="node-card">
+        <div class="node-tier">Finance</div>
+        <div class="node-name">Office of Finance</div>
+        <div class="node-role">DAS: Teresa Miranda</div>
+        <div class="node-meta">Also: HHS Deputy CFO</div>
+      </div>
+      <div class="node-card">
+        <div class="node-tier">Grants</div>
+        <div class="node-name">Office of Grants</div>
+        <div class="node-role">DAS: Dale Bell</div>
+      </div>
+      <div class="node-card primary-card">
+        <div class="node-tier accent">Acquisitions &middot; Where OMAS Lives</div>
+        <div class="node-name">Office of Acquisitions (OA)</div>
+        <div class="node-role">DAS: Jennifer Johnson &middot; Senior Procurement Executive</div>
+        <div class="node-meta">771-215-0133 &middot; ~$28B annual contract spend</div>
+      </div>
+    </div>
+    <div class="connector-v thick"></div>
+  </div>
+
+  <!-- TIER 4: OA Divisions -->
+  <div class="tier">
+    <div style="text-align:center"><div class="section-label">Office of Acquisitions Divisions</div></div>
+    <div class="tier-row">
+      <div class="node-card">
+        <div class="node-tier">Strategic Programs</div>
+        <div class="node-name">Strategic Programs &amp; Business Systems Division</div>
+        <div class="node-role">Exec Director: Sonya Carrion</div>
+      </div>
+      <div class="node-card">
+        <div class="node-tier">Policy</div>
+        <div class="node-name">Office of Acquisition Policy, Legislation, Oversight &amp; Workforce</div>
+        <div class="node-role">Exec Director: Mahua Muzamdar</div>
+      </div>
+      <div class="node-card">
+        <div class="node-tier">Small Business</div>
+        <div class="node-name">OSDBU (Office of Small &amp; Disadvantaged Business Utilization)</div>
+        <div class="node-role">Exec Director: Shannon Jackson</div>
+        <div class="node-meta">Reports to HHS Deputy Secretary &middot; Est. 1979, P.L. 95-507</div>
+      </div>
+      <div class="node-card">
+        <div class="node-tier">Recipient Integrity</div>
+        <div class="node-name">Office of Recipient Integrity Coordination</div>
+        <div class="node-role">Director: Tiffani Redding</div>
+      </div>
+      <div class="node-card new-card">
+        <div class="node-tier accent">New Since Jan 2026</div>
+        <div class="node-name">Office of Mission Acquisition Solutions (OMAS)</div>
+        <div class="node-role">Formerly OAMS &middot; The new common-IT and Professional Services HCA</div>
+        <span class="node-badge new-badge">New HCA</span>
+      </div>
+      <div class="node-card">
+        <div class="node-tier">Innovation</div>
+        <div class="node-name">HHS IDEAS Lab &amp; Acquisition Program Support</div>
+        <div class="node-role">Director: Kimberly Himes</div>
+        <div class="node-meta">Also: Acquisition Innovation Advocate (AIA) + Industry Liaison</div>
+      </div>
+    </div>
+    <div class="connector-v thick"></div>
+  </div>
+
+  <!-- TIER 5: OMAS Leadership -->
+  <div class="tier">
+    <div style="text-align:center"><div class="section-label">OMAS Leadership</div></div>
+    <div class="tier-row">
+      <div class="node-card primary-card">
+        <div class="node-tier accent">HCA &middot; Permanent</div>
+        <div class="node-name">Quentin McCoy</div>
+        <div class="node-role">Executive Director, Head of Contracting Activity</div>
+        <div class="node-meta">Quentin.McCoy@hhs.gov &middot; 301-492-5456</div>
+      </div>
+      <div class="node-card">
+        <div class="node-tier">Chief of Staff</div>
+        <div class="node-name">Colette Magwood</div>
+        <div class="node-role">Chief of Staff, OMAS</div>
+      </div>
+      <div class="node-card vacant">
+        <div class="node-tier">Deputy</div>
+        <div class="node-name">VACANT</div>
+        <div class="node-role">Deputy Head of Contracting Activity</div>
+        <span class="node-badge vacant-badge">Open Role</span>
+      </div>
+      <div class="node-card">
+        <div class="node-tier">Operations Support</div>
+        <div class="node-name">Lisa Portner</div>
+        <div class="node-role">Director, Procurement Operations Support (POS)</div>
+      </div>
+    </div>
+    <div class="connector-v thick"></div>
+  </div>
+
+  <!-- TIER 6: Strategic Buying Centers -->
+  <div class="tier">
+    <div style="text-align:center"><div class="section-label">OMAS Strategic Buying Centers (the three SBCs)</div></div>
+    <div class="tier-row">
+      <div class="node-card primary-card">
+        <div class="node-tier accent">SBC-Mission</div>
+        <div class="node-name">Tatricia (Trish) James</div>
+        <div class="node-role">Director, Strategic Buying Center for Mission</div>
+        <div class="node-meta">Scope: ACF + AHRQ + Staff Divisions + Secretary mission needs</div>
+      </div>
+      <div class="node-card primary-card">
+        <div class="node-tier accent">SBC-IT</div>
+        <div class="node-name">Adam Vance</div>
+        <div class="node-role">Director, Strategic Buying Center for Information Technology</div>
+        <div class="node-meta">Scope: Common enterprise IT, software, cyber, cloud, AI tools</div>
+      </div>
+      <div class="node-card primary-card">
+        <div class="node-tier accent">SBC-PS</div>
+        <div class="node-name">Scott Bredow</div>
+        <div class="node-role">Director, Strategic Buying Center for Professional Services</div>
+        <div class="node-meta">Scope: Advisory, scientific, training, programmatic services</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="callout">
+    <strong>Category management lead:</strong> Sonya Carrion (Executive Director, Strategic Programs &amp; Business Systems) is featured alongside the three SBC directors on slide 22 for category-management partnership.
+  </div>
+
+  <!-- 10 HCA ROSTER -->
+  <div class="tier" style="margin-top:48px">
+    <div style="text-align:center"><div class="section-label">The 10 HHS Heads of Contracting Activity</div></div>
+    <p style="text-align:center;font-size:0.9rem;color:var(--text-muted);max-width:720px;margin:0 auto 8px">Three of ten are Acting (ARPA-H, CDC, CMS) — three of the biggest spend agencies. Expect leadership churn. The roster table view with all phone numbers, small business specialists, and filters lives at <a href="/agencies/hhs/hcas" style="color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(69,123,157,0.3)">/agencies/hhs/hcas</a>.</p>
+    <div class="hca-grid">
+
+      <div class="hca-card is-new">
+        <div class="hca-opdiv">OMAS (new)</div>
+        <div class="hca-name">Quentin McCoy</div>
+        <div class="hca-meta">Permanent &middot; Office of the Secretary / ASFR</div>
+        <a class="hca-email" href="mailto:Quentin.McCoy@hhs.gov">Quentin.McCoy@hhs.gov</a>
+      </div>
+
+      <div class="hca-card is-acting">
+        <div class="hca-opdiv">ARPA-H</div>
+        <div class="hca-name">Benjamin Bryant</div>
+        <div class="hca-meta">Acting &middot; Advanced Research Projects Agency for Health</div>
+        <a class="hca-email" href="mailto:benjamin.bryant@arpa-h.gov">benjamin.bryant@arpa-h.gov</a>
+      </div>
+
+      <div class="hca-card is-acting">
+        <div class="hca-opdiv">CDC</div>
+        <div class="hca-name">Christine Godfrey</div>
+        <div class="hca-meta">Acting &middot; Centers for Disease Control and Prevention</div>
+        <a class="hca-email" href="mailto:cnp9@cdc.gov">cnp9@cdc.gov</a>
+      </div>
+
+      <div class="hca-card is-acting">
+        <div class="hca-opdiv">CMS</div>
+        <div class="hca-name">Doug Bergevin</div>
+        <div class="hca-meta">Acting &middot; Centers for Medicare &amp; Medicaid Services</div>
+        <a class="hca-email" href="mailto:douglas.bergevin@cms.hhs.gov">douglas.bergevin@cms.hhs.gov</a>
+      </div>
+
+      <div class="hca-card">
+        <div class="hca-opdiv">FDA</div>
+        <div class="hca-name">Leonard Grant</div>
+        <div class="hca-meta">Permanent &middot; Food and Drug Administration</div>
+        <a class="hca-email" href="mailto:Leonard.Grant@fda.hhs.gov">Leonard.Grant@fda.hhs.gov</a>
+      </div>
+
+      <div class="hca-card">
+        <div class="hca-opdiv">HRSA</div>
+        <div class="hca-name">Brian Goodger</div>
+        <div class="hca-meta">Permanent &middot; Health Resources &amp; Services Administration</div>
+        <a class="hca-email" href="mailto:BGoodger@hrsa.gov">BGoodger@hrsa.gov</a>
+      </div>
+
+      <div class="hca-card">
+        <div class="hca-opdiv">IHS</div>
+        <div class="hca-name">Chantel Smith</div>
+        <div class="hca-meta">Permanent &middot; Indian Health Service</div>
+        <a class="hca-email" href="mailto:Chantel.Smith@ihs.gov">Chantel.Smith@ihs.gov</a>
+      </div>
+
+      <div class="hca-card">
+        <div class="hca-opdiv">NIH</div>
+        <div class="hca-name">Olga Acosta</div>
+        <div class="hca-meta">Permanent &middot; National Institutes of Health</div>
+        <a class="hca-email" href="mailto:olga.acosta@nih.gov">olga.acosta@nih.gov</a>
+      </div>
+
+      <div class="hca-card">
+        <div class="hca-opdiv">ASPR</div>
+        <div class="hca-name">Makoto P. Braxton</div>
+        <div class="hca-meta">Permanent &middot; Admin. for Strategic Preparedness and Response</div>
+        <a class="hca-email" href="mailto:makoto.braxton@hhs.gov">makoto.braxton@hhs.gov</a>
+      </div>
+
+      <div class="hca-card">
+        <div class="hca-opdiv">OIG</div>
+        <div class="hca-name">John Marshall</div>
+        <div class="hca-meta">Permanent &middot; Office of Inspector General</div>
+        <a class="hca-email" href="mailto:john.marshall@oig.hhs.gov">john.marshall@oig.hhs.gov</a>
+      </div>
+
+    </div>
+  </div>
+
+  <div class="source-footer">
+    <strong>Sources.</strong> HHS HCA and Key Managers roster (verified 2026-04-27, <a href="https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html" rel="noopener">hhs.gov</a>). HHS ASFR Key Personnel page (verified 2026-04-27, <a href="https://www.hhs.gov/about/agencies/asfr/key-personnel/index.html" rel="noopener">hhs.gov</a>). HHS OSDBU page (verified 2026-05-07). HHS Acquisition Solutions Day (May 2026) Industry Day deck and transcripts. Otter mishearings corrected against the official ASFR personnel and HCA roster pages. Data current as of April 27, 2026 for the roster; page last updated May 18, 2026.<br><br>
+    <strong>What changed since this was published?</strong> Vacancies fill. Acting designations turn Permanent. We re-verify the HCA roster quarterly. If you spot a stale entry, email <a href="mailto:mary@missionmeetstech.com">mary@missionmeetstech.com</a> — we'll update and re-cite.
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/premium/policy/pact.html
+++ b/premium/policy/pact.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PACT, the 3 EOs, and OMB M-25-31 &middot; MMT Premium</title>
+  <meta name="robots" content="noindex">
+  <meta name="description" content="The federal procurement consolidation playbook driving the HHS OMAS standup. EO 14210 (workforce), EO 14222 (cost), EO 14240 (procurement consolidation), OMB M-25-31. Plus the FY26 Budget consolidation outlook.">
+  <link rel="stylesheet" href="/styles/tailwind.css">
+  <link rel="icon" href="/favicon-v3.png" type="image/png">
+  <style>
+    :root { --mmt-navy:#0A192F; --mmt-teal:#457B9D; --mmt-white:#FFFFFF; --mmt-surface:#F3F4F6; --mmt-text-secondary:#6B7280; --mmt-border:#E5E7EB; --ci-gold:#92710A; --dash-sidebar:220px; }
+    body { font-family:Inter,system-ui,sans-serif; color:var(--mmt-navy); background:var(--mmt-surface); margin:0; line-height:1.55; }
+    .dash-shell { display:grid; grid-template-columns:var(--dash-sidebar) 1fr; min-height:100vh; }
+    .dash-nav { background:var(--mmt-navy); padding:24px 0; display:flex; flex-direction:column; position:sticky; top:0; height:100vh; overflow-y:auto; }
+    .dash-nav-brand { padding:0 20px 24px; border-bottom:1px solid rgba(255,255,255,0.1); margin-bottom:16px; }
+    .dash-nav-brand a { color:#fff; text-decoration:none; font-weight:800; font-size:14px; }
+    .dash-nav-brand small { display:block; font-size:11px; color:rgba(255,255,255,0.5); font-weight:400; margin-top:2px; }
+    .dash-nav-link { display:flex; align-items:center; gap:10px; padding:10px 20px; color:rgba(255,255,255,0.6); text-decoration:none; font-size:13px; font-weight:500; transition:all 0.15s; }
+    .dash-nav-link:hover { color:#fff; background:rgba(255,255,255,0.05); }
+    .dash-nav-link.active { color:#fff; background:rgba(69,123,157,0.3); border-left:3px solid var(--mmt-teal); }
+    .dash-nav-section { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.12em; color:rgba(255,255,255,0.3); padding:16px 20px 6px; }
+    .dash-header { background:var(--mmt-white); padding:16px 32px; border-bottom:1px solid var(--mmt-border); display:flex; align-items:center; justify-content:space-between; }
+    .dash-main { padding:32px; max-width:880px; }
+    .dash-card { background:var(--mmt-white); border-radius:12px; padding:28px; margin-bottom:18px; border:1px solid var(--mmt-border); }
+    .eyebrow { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.10em; color:var(--mmt-text-secondary); margin-bottom:8px; }
+    h1 { font-size:28px; font-weight:800; margin:0 0 8px; letter-spacing:-0.02em; }
+    h2 { font-size:20px; font-weight:800; margin:0 0 12px; letter-spacing:-0.01em; color:var(--mmt-navy); }
+    h3 { font-size:15px; font-weight:700; margin:0 0 6px; color:var(--mmt-navy); }
+    .lede { font-size:16px; color:var(--mmt-text-secondary); margin:0 0 14px; line-height:1.6; }
+    .meta-row { font-size:12px; color:var(--mmt-text-secondary); margin-bottom:24px; }
+    .meta-row a { color:var(--mmt-teal); text-decoration:none; }
+    p { font-size:14.5px; margin:0 0 12px; }
+    ul { font-size:14.5px; padding-left:20px; margin:0 0 12px; }
+    ul li { margin-bottom:5px; }
+    .eo-card { background:var(--mmt-white); border:1px solid var(--mmt-border); border-left:3px solid var(--mmt-teal); border-radius:8px; padding:18px 22px; margin-bottom:14px; }
+    .eo-card .eo-meta { display:flex; flex-wrap:wrap; gap:12px; font-size:12px; color:var(--mmt-text-secondary); margin-bottom:6px; }
+    .eo-card .eo-meta span { display:inline-flex; align-items:center; gap:4px; }
+    .eo-card .eo-meta strong { color:var(--mmt-navy); font-weight:700; }
+    .eo-card h3 { margin-top:0; }
+    .eo-block { font-size:13.5px; color:var(--mmt-text-secondary); line-height:1.55; margin:6px 0; }
+    .eo-block strong { color:var(--mmt-navy); display:block; font-size:12px; text-transform:uppercase; letter-spacing:0.06em; font-weight:700; margin-bottom:2px; }
+    .eo-card a.read { font-size:12px; font-weight:600; color:var(--mmt-teal); text-decoration:none; }
+    .eo-card a.read:hover { text-decoration:underline; }
+    .goals-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; margin-top:8px; }
+    .goal-card { background:var(--mmt-surface); border:1px solid var(--mmt-border); border-radius:8px; padding:14px 16px; }
+    .goal-card .num { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.08em; color:var(--mmt-teal); margin-bottom:6px; }
+    .goal-card .what { font-size:14px; color:var(--mmt-navy); font-weight:600; line-height:1.4; }
+    .callout { background:var(--mmt-surface); border:1px solid var(--mmt-border); border-left:3px solid var(--ci-gold); border-radius:6px; padding:14px 18px; margin:16px 0; font-size:14px; line-height:1.55; }
+    .callout strong { color:var(--mmt-navy); }
+    .source-block { font-size:12.5px; color:var(--mmt-text-secondary); line-height:1.6; }
+    .source-block a { color:var(--mmt-teal); text-decoration:none; }
+    .pill-row { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+    .pill-row a { font-size:12px; font-weight:600; color:var(--mmt-navy); background:var(--mmt-white); border:1px solid var(--mmt-border); padding:6px 12px; border-radius:6px; text-decoration:none; }
+    .pill-row a:hover { border-color:var(--mmt-navy); }
+    @media (max-width:768px) { .dash-shell { grid-template-columns:1fr; } .dash-nav { display:none; } .dash-main { padding:16px; padding-bottom:80px; } }
+  </style>
+  <script>
+    (function() {
+      var isPremium = localStorage.getItem('mmt_premium') === 'true';
+      var ts = localStorage.getItem('mmt_premium_ts');
+      var withinWindow = ts && (Date.now() - parseInt(ts)) < 30 * 24 * 60 * 60 * 1000;
+      if (!isPremium || !withinWindow) { window.location.href = '/dashboard.html'; }
+    })();
+  </script>
+</head>
+<body>
+  <div class="dash-shell">
+    <nav class="dash-nav">
+      <div class="dash-nav-brand"><a href="/premium/dashboard.html">&#9733; MMT Premium<small>Intelligence Dashboard</small></a></div>
+      <div class="dash-nav-section">Intelligence</div>
+      <a href="/premium/dashboard.html" class="dash-nav-link">Dashboard</a>
+      <a href="/agencies/" class="dash-nav-link">Agencies</a>
+      <a href="/premium/briefings.html" class="dash-nav-link">Friday Brief</a>
+      <a href="/premium/monthly-briefs.html" class="dash-nav-link">Monthly Brief</a>
+      <a href="/premium/key-people.html" class="dash-nav-link">Key People</a>
+      <a href="/premium/gao-sustain.html" class="dash-nav-link">GAO Sustains</a>
+      <div class="dash-nav-section">Tools</div>
+      <a href="/premium/pursuit-score.html" class="dash-nav-link">Pursuit Score</a>
+      <a href="/premium/compliance-check.html" class="dash-nav-link">Compliance Check</a>
+      <a href="/premium/signal-chain.html" class="dash-nav-link">Signal Chain</a>
+      <div class="dash-nav-section">Policy</div>
+      <a href="/policy/pact" class="dash-nav-link active">PACT &amp; EOs</a>
+      <a href="/policy/rfo-8-4" class="dash-nav-link">RFO 8.4</a>
+      <a href="/premium/fpds-migration.html" class="dash-nav-link">FPDS Sunset</a>
+      <a href="/premium/cr-exposure.html" class="dash-nav-link">CR Exposure</a>
+      <div class="dash-nav-section">Resources</div>
+      <a href="/premium/calendar.html" class="dash-nav-link">Pursuit Calendar</a>
+      <a href="/contract-tracker.html" class="dash-nav-link">Contract Tracker</a>
+      <a href="/idiq-tracker.html" class="dash-nav-link">IDIQ Tracker</a>
+      <a href="/premium/ask-mmt.html" class="dash-nav-link">Ask MMT</a>
+      <div class="dash-nav-section">Account</div>
+      <a href="/premium/settings.html" class="dash-nav-link">Settings</a>
+      <a href="/" class="dash-nav-link" style="margin-top:auto; border-top:1px solid rgba(255,255,255,0.1); padding-top:16px;">&larr; Back to site</a>
+    </nav>
+    <div>
+      <div class="dash-header">
+        <span style="font-size:14px; font-weight:700;">&#9733; Premium Dashboard</span>
+        <div style="display:flex; align-items:center; gap:16px;">
+          <span style="font-size:13px; color:var(--mmt-text-secondary);" id="dash-email"></span>
+          <a href="/" style="font-size:12px; color:var(--mmt-teal); text-decoration:none;">Back to site</a>
+          <a href="#" onclick="localStorage.removeItem('mmt_premium');localStorage.removeItem('mmt_premium_ts');localStorage.removeItem('mmt_email');document.cookie='mmt_premium=;path=/;max-age=0';window.location.href='/';return false;" style="font-size:12px; color:var(--mmt-text-secondary); text-decoration:none;">Sign out</a>
+        </div>
+      </div>
+      <div class="dash-main">
+
+        <div class="eyebrow">Policy &middot; Federal procurement consolidation</div>
+        <h1>PACT, the three Executive Orders, and OMB M-25-31</h1>
+        <p class="lede">If you want to understand why OMAS exists and where this is headed, you have to read the four documents that set the rules. Three EOs and one OMB memo. Plain English version on this page; primary sources linked at the bottom.</p>
+        <div class="meta-row">
+          Data current as of May 18, 2026.
+          &middot; <a href="/agencies/hhs/omas">OMAS deep dive</a>
+          &middot; <a href="/policy/rfo-8-4">RFO 8.4 tier playbook</a>
+          &middot; <a href="/updates/2026-05-18-hhs-omas">May 18 changelog</a>
+        </div>
+
+        <div class="dash-card">
+          <h2>PACT — Procurement Alignment and Collaboration Task Force</h2>
+          <p>PACT was stood up at HHS roughly 12 months ago (early FY25) after the GSA consolidation EO. As of the May 2026 Acquisition Solutions Day, PACT is a formal HHS Agency Priority Goal. The three goals:</p>
+          <div class="goals-grid">
+            <div class="goal-card">
+              <div class="num">Goal 1</div>
+              <div class="what">Centralize common IT and common professional services through OMAS.</div>
+            </div>
+            <div class="goal-card">
+              <div class="num">Goal 2</div>
+              <div class="what">Modernize the acquisition system stack — HCAS and related tools configured for OMAS workflows, financial-system integration, data standardization.</div>
+            </div>
+            <div class="goal-card">
+              <div class="num">Goal 3</div>
+              <div class="what">Preserve mission-specialized procurement at operating divisions with mission-critical authority.</div>
+            </div>
+          </div>
+          <div class="callout">
+            <strong>The standardization spectrum.</strong> OMAS uses a Standardization Suitability Spectrum to decide what consolidates. Less suitable: complex, mission-unique, high program enablement (Divisions handle). More suitable: simple, mission-agnostic, easy to standardize (OMAS handles). Source: Acquisition Solutions Day deck, slide 10.
+          </div>
+        </div>
+
+        <div class="dash-card">
+          <h2>The four documents that made this happen</h2>
+
+          <div class="eo-card">
+            <div class="eo-meta"><span><strong>EO 14210</strong></span> <span>Feb 11, 2025</span> <span>White House</span></div>
+            <h3>Implementing the DOGE Workforce Optimization Initiative</h3>
+            <div class="eo-block"><strong>Plain English</strong> 4-to-1 hiring ratio, RIF prep, agency reorganization plans within 30 days.</div>
+            <div class="eo-block"><strong>Vendor impact</strong> Tightens the acquisition workforce on the buyer side. Expect fewer COs handling more files, longer cycle times, and more emphasis on consolidated buying to scale CO capacity.</div>
+            <a class="read" href="https://www.whitehouse.gov/presidential-actions/2025/02/implementing-the-presidents-department-of-government-efficiency-workforce-optimization-initiative/" rel="noopener">Read the EO &rarr;</a>
+          </div>
+
+          <div class="eo-card">
+            <div class="eo-meta"><span><strong>EO 14222</strong></span> <span>Feb 26, 2025</span> <span>White House</span></div>
+            <h3>Implementing the DOGE Cost Efficiency Initiative</h3>
+            <div class="eo-block"><strong>Plain English</strong> Centralizes contract payment justification systems, requires a 30-day contract review, and freezes new CO warrants during the review window.</div>
+            <div class="eo-block"><strong>Vendor impact</strong> Existing contracts may be terminated for convenience or de-scoped. Modifications now require a written justification linked to the payment system. This is the EO that produced the FY25 $16.3B HHS spend reduction (HCEI).</div>
+            <a class="read" href="https://www.whitehouse.gov/presidential-actions/2025/02/implementing-the-presidents-department-of-government-efficiency-cost-efficiency-initiative/" rel="noopener">Read the EO &rarr;</a>
+          </div>
+
+          <div class="eo-card">
+            <div class="eo-meta"><span><strong>EO 14240</strong></span> <span>Mar 20, 2025</span> <span>White House</span></div>
+            <h3>Eliminating Waste and Saving Taxpayer Dollars by Consolidating Procurement</h3>
+            <div class="eo-block"><strong>Plain English</strong> Mandates the transfer of common goods and services procurement to GSA. This is the root authority behind PACT and the OMAS standup.</div>
+            <div class="eo-block"><strong>Vendor impact</strong> Common IT and Professional Services contracting consolidates through GSA Best-in-Class vehicles or, at HHS, through OMAS. If your firm sells laptops, cloud, cyber tools, or advisory services into HHS, your CO has moved.</div>
+            <a class="read" href="https://www.whitehouse.gov/wp-content/uploads/2025/07/M-25-31-Consolidating-Federal-Procurement-Activities.pdf" rel="noopener">Read the implementing memo &rarr;</a>
+          </div>
+
+          <div class="eo-card">
+            <div class="eo-meta"><span><strong>OMB M-25-31</strong></span> <span>Jul 18, 2025</span> <span>OMB</span></div>
+            <h3>Consolidating Federal Procurement Activities</h3>
+            <div class="eo-block"><strong>Plain English</strong> Implementation guidance for EO 14240. Two workstreams: (1) increased GSA use across agencies, (2) physical centralization of the procurement function at GSA for specified categories.</div>
+            <div class="eo-block"><strong>Vendor impact</strong> Names the canonical buying paths: GSA MAS IT, NASA SEWP, NITAAC CIO-SP, and category-managed Best-in-Class. Be on these vehicles or be invisible to OMAS.</div>
+            <a class="read" href="https://www.whitehouse.gov/wp-content/uploads/2025/07/M-25-31-Consolidating-Federal-Procurement-Activities.pdf" rel="noopener">Read OMB M-25-31 (PDF) &rarr;</a>
+          </div>
+
+          <p style="margin-top:14px;">Additional driver named on the PACT slide: the Secretary's "Make America Healthy Again" framing for realignment of mission support functions.</p>
+        </div>
+
+        <div class="dash-card">
+          <h2>The FY26 consolidation that's coming next</h2>
+          <p>The HHS FY2026 Budget in Brief signals consolidation of 28 operating divisions to 15 and closure of 5 of HHS's most costly regional offices. That returns HHS FTE strength to roughly FY1990s levels.</p>
+          <p>Today's 10 HCAs is a snapshot, not a steady state. Expect additional OpDiv mergers across FY26 and FY27. The OpDivs whose contracting authority has already been absorbed — ACF and AHRQ — are the early signal of the pattern.</p>
+          <p style="margin-bottom:0;"><a href="https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf" rel="noopener" style="color:var(--mmt-teal); font-weight:600; text-decoration:none;">Read the FY2026 Budget in Brief (PDF) &rarr;</a></p>
+        </div>
+
+        <div class="dash-card">
+          <h2>What to do with this</h2>
+          <ul>
+            <li><strong>If you sell common IT or professional services into HHS</strong> — build the OMAS SBC-IT (Adam Vance) or SBC-PS (Scott Bredow) relationship. Confirm presence on GSA MAS IT, NASA SEWP, NITAAC CIO-SP, and OASIS+.</li>
+            <li><strong>If you sell mission-unique work to NIH, CDC, CMS, FDA, HRSA, IHS, ASPR, ARPA-H, or OIG</strong> — your CO is unchanged. Watch the FY26 Budget for any merger that affects your buyer.</li>
+            <li><strong>If you sold into ACF or AHRQ</strong> — your CO is now in OMAS SBC-Mission (Trish James). Expect outreach if you hold a current contract.</li>
+            <li><strong>If you're a small business</strong> — register in SBCX (osdbu.hhs.gov). The subcontracting opportunity posting feature is in development. HHS FY26 SB goal is 25% overall, but they earned a B on the FY24 scorecard — strengthening that score is an OSDBU priority.</li>
+          </ul>
+        </div>
+
+        <div class="dash-card">
+          <h2>How this connects</h2>
+          <div class="pill-row">
+            <a href="/agencies/hhs">HHS profile</a>
+            <a href="/agencies/hhs/omas">OMAS deep dive</a>
+            <a href="/agencies/hhs/hcas">All 10 HCAs</a>
+            <a href="/agencies/hhs/orgchart">Visual org chart</a>
+            <a href="/policy/rfo-8-4">RFO 8.4 tier playbook</a>
+            <a href="/premium/fpds-migration.html">FPDS Sunset Watch</a>
+            <a href="/premium/cr-exposure.html">CR &amp; Appropriations Exposure</a>
+          </div>
+        </div>
+
+        <div class="dash-card source-block">
+          <strong>Sources.</strong> White House primary EO text (EO 14210, EO 14222 — direct).
+          OMB M-25-31 PDF (canonical text for EO 14240 and the implementation guidance).
+          <a href="https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf" rel="noopener">HHS FY2026 Budget in Brief</a> (verified 2025-06-02).
+          HHS Acquisition Solutions Day deck (May 2026, slides 4 and 10 on PACT and the standardization spectrum).<br><br>
+          <strong>What changes after this?</strong> The implementation timeline. OMB publishes operational guidance throughout FY26. We re-verify quarterly and after any change to the underlying memos.
+        </div>
+
+      </div>
+    </div>
+  </div>
+  <script>
+    var email=localStorage.getItem('mmt_email');var __de=document.getElementById('dash-email');if(__de&&email)__de.textContent=email;
+  </script>
+</body>
+</html>

--- a/premium/policy/rfo-8-4.html
+++ b/premium/policy/rfo-8-4.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RFO 8.4 / GSAR 538.7103 Tier Playbook &middot; MMT Premium</title>
+  <meta name="robots" content="noindex">
+  <meta name="description" content="The FAR Overhaul rewrites FSS / schedule ordering procedures. Three tiers (at-or-below MPT, MPT-to-SAT, above-SAT), three different vendor moves. RFIs went from black hole to spotlight.">
+  <link rel="stylesheet" href="/styles/tailwind.css">
+  <link rel="icon" href="/favicon-v3.png" type="image/png">
+  <style>
+    :root { --mmt-navy:#0A192F; --mmt-teal:#457B9D; --mmt-white:#FFFFFF; --mmt-surface:#F3F4F6; --mmt-text-secondary:#6B7280; --mmt-border:#E5E7EB; --ci-gold:#92710A; --dash-sidebar:220px; }
+    body { font-family:Inter,system-ui,sans-serif; color:var(--mmt-navy); background:var(--mmt-surface); margin:0; line-height:1.55; }
+    .dash-shell { display:grid; grid-template-columns:var(--dash-sidebar) 1fr; min-height:100vh; }
+    .dash-nav { background:var(--mmt-navy); padding:24px 0; display:flex; flex-direction:column; position:sticky; top:0; height:100vh; overflow-y:auto; }
+    .dash-nav-brand { padding:0 20px 24px; border-bottom:1px solid rgba(255,255,255,0.1); margin-bottom:16px; }
+    .dash-nav-brand a { color:#fff; text-decoration:none; font-weight:800; font-size:14px; }
+    .dash-nav-brand small { display:block; font-size:11px; color:rgba(255,255,255,0.5); font-weight:400; margin-top:2px; }
+    .dash-nav-link { display:flex; align-items:center; gap:10px; padding:10px 20px; color:rgba(255,255,255,0.6); text-decoration:none; font-size:13px; font-weight:500; transition:all 0.15s; }
+    .dash-nav-link:hover { color:#fff; background:rgba(255,255,255,0.05); }
+    .dash-nav-link.active { color:#fff; background:rgba(69,123,157,0.3); border-left:3px solid var(--mmt-teal); }
+    .dash-nav-section { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.12em; color:rgba(255,255,255,0.3); padding:16px 20px 6px; }
+    .dash-header { background:var(--mmt-white); padding:16px 32px; border-bottom:1px solid var(--mmt-border); display:flex; align-items:center; justify-content:space-between; }
+    .dash-main { padding:32px; max-width:920px; }
+    .dash-card { background:var(--mmt-white); border-radius:12px; padding:28px; margin-bottom:18px; border:1px solid var(--mmt-border); }
+    .eyebrow { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.10em; color:var(--mmt-text-secondary); margin-bottom:8px; }
+    h1 { font-size:28px; font-weight:800; margin:0 0 8px; letter-spacing:-0.02em; }
+    h2 { font-size:20px; font-weight:800; margin:0 0 10px; letter-spacing:-0.01em; color:var(--mmt-navy); }
+    .lede { font-size:16px; color:var(--mmt-text-secondary); margin:0 0 14px; line-height:1.6; }
+    .meta-row { font-size:12px; color:var(--mmt-text-secondary); margin-bottom:24px; }
+    .meta-row a { color:var(--mmt-teal); text-decoration:none; }
+    p { font-size:14.5px; margin:0 0 12px; }
+    ul, ol { font-size:14.5px; padding-left:22px; margin:0 0 12px; }
+    ul li, ol li { margin-bottom:6px; }
+    .tier-card { background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:12px; padding:22px 24px; margin-bottom:16px; border-top:4px solid var(--mmt-teal); }
+    .tier-eyebrow { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.10em; color:var(--mmt-teal); margin-bottom:6px; }
+    .tier-title { font-size:18px; font-weight:800; color:var(--mmt-navy); margin:0 0 4px; }
+    .tier-cite { font-size:12px; color:var(--mmt-text-secondary); margin-bottom:14px; font-family:'SF Mono','Menlo',monospace; }
+    .tier-section { margin-bottom:12px; }
+    .tier-section h3 { font-size:12px; font-weight:700; text-transform:uppercase; letter-spacing:0.08em; color:var(--mmt-navy); margin:0 0 6px; }
+    .vendor-move { background:var(--mmt-surface); border-left:3px solid var(--ci-gold); border-radius:6px; padding:12px 16px; margin-top:10px; font-size:14px; line-height:1.55; }
+    .vendor-move strong { color:var(--ci-gold); display:inline-block; font-size:11px; text-transform:uppercase; letter-spacing:0.08em; margin-right:6px; }
+    .callout { background:var(--mmt-surface); border:1px solid var(--mmt-border); border-left:3px solid var(--mmt-teal); border-radius:6px; padding:14px 18px; margin:14px 0; font-size:14px; line-height:1.55; }
+    .callout strong { color:var(--mmt-navy); }
+    .source-block { font-size:12.5px; color:var(--mmt-text-secondary); line-height:1.6; }
+    .source-block a { color:var(--mmt-teal); text-decoration:none; }
+    .pill-row { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+    .pill-row a { font-size:12px; font-weight:600; color:var(--mmt-navy); background:var(--mmt-white); border:1px solid var(--mmt-border); padding:6px 12px; border-radius:6px; text-decoration:none; }
+    .pill-row a:hover { border-color:var(--mmt-navy); }
+    @media (max-width:768px) { .dash-shell { grid-template-columns:1fr; } .dash-nav { display:none; } .dash-main { padding:16px; padding-bottom:80px; } }
+  </style>
+  <script>
+    (function() {
+      var isPremium = localStorage.getItem('mmt_premium') === 'true';
+      var ts = localStorage.getItem('mmt_premium_ts');
+      var withinWindow = ts && (Date.now() - parseInt(ts)) < 30 * 24 * 60 * 60 * 1000;
+      if (!isPremium || !withinWindow) { window.location.href = '/dashboard.html'; }
+    })();
+  </script>
+</head>
+<body>
+  <div class="dash-shell">
+    <nav class="dash-nav">
+      <div class="dash-nav-brand"><a href="/premium/dashboard.html">&#9733; MMT Premium<small>Intelligence Dashboard</small></a></div>
+      <div class="dash-nav-section">Intelligence</div>
+      <a href="/premium/dashboard.html" class="dash-nav-link">Dashboard</a>
+      <a href="/agencies/" class="dash-nav-link">Agencies</a>
+      <a href="/premium/briefings.html" class="dash-nav-link">Friday Brief</a>
+      <a href="/premium/monthly-briefs.html" class="dash-nav-link">Monthly Brief</a>
+      <a href="/premium/key-people.html" class="dash-nav-link">Key People</a>
+      <a href="/premium/gao-sustain.html" class="dash-nav-link">GAO Sustains</a>
+      <div class="dash-nav-section">Tools</div>
+      <a href="/premium/pursuit-score.html" class="dash-nav-link">Pursuit Score</a>
+      <a href="/premium/compliance-check.html" class="dash-nav-link">Compliance Check</a>
+      <a href="/premium/signal-chain.html" class="dash-nav-link">Signal Chain</a>
+      <div class="dash-nav-section">Policy</div>
+      <a href="/policy/pact" class="dash-nav-link">PACT &amp; EOs</a>
+      <a href="/policy/rfo-8-4" class="dash-nav-link active">RFO 8.4</a>
+      <a href="/premium/fpds-migration.html" class="dash-nav-link">FPDS Sunset</a>
+      <a href="/premium/cr-exposure.html" class="dash-nav-link">CR Exposure</a>
+      <div class="dash-nav-section">Resources</div>
+      <a href="/premium/calendar.html" class="dash-nav-link">Pursuit Calendar</a>
+      <a href="/contract-tracker.html" class="dash-nav-link">Contract Tracker</a>
+      <a href="/idiq-tracker.html" class="dash-nav-link">IDIQ Tracker</a>
+      <a href="/premium/ask-mmt.html" class="dash-nav-link">Ask MMT</a>
+      <div class="dash-nav-section">Account</div>
+      <a href="/premium/settings.html" class="dash-nav-link">Settings</a>
+      <a href="/" class="dash-nav-link" style="margin-top:auto; border-top:1px solid rgba(255,255,255,0.1); padding-top:16px;">&larr; Back to site</a>
+    </nav>
+    <div>
+      <div class="dash-header">
+        <span style="font-size:14px; font-weight:700;">&#9733; Premium Dashboard</span>
+        <div style="display:flex; align-items:center; gap:16px;">
+          <span style="font-size:13px; color:var(--mmt-text-secondary);" id="dash-email"></span>
+          <a href="/" style="font-size:12px; color:var(--mmt-teal); text-decoration:none;">Back to site</a>
+          <a href="#" onclick="localStorage.removeItem('mmt_premium');localStorage.removeItem('mmt_premium_ts');localStorage.removeItem('mmt_email');document.cookie='mmt_premium=;path=/;max-age=0';window.location.href='/';return false;" style="font-size:12px; color:var(--mmt-text-secondary); text-decoration:none;">Sign out</a>
+        </div>
+      </div>
+      <div class="dash-main">
+
+        <div class="eyebrow">Policy &middot; FAR Overhaul</div>
+        <h1>RFO 8.4 / GSAR 538.7103 — the schedule-buying changes vendors must absorb</h1>
+        <p class="lede">The Revised FAR Overhaul (RFO) rewrites schedule ordering procedures (FAR Part 8 / GSAR Subpart 538.7103). Three tiers, three different competition rules, three different vendor moves. The biggest behavior shift: RFIs now determine whether your firm even makes the RFQ list.</p>
+        <div class="meta-row">
+          Data current as of May 18, 2026.
+          &middot; <a href="/policy/pact">PACT &amp; the 3 EOs</a>
+          &middot; <a href="/agencies/hhs/omas">OMAS deep dive</a>
+        </div>
+
+        <div class="tier-card">
+          <div class="tier-eyebrow">Tier 1 &middot; At or below MPT</div>
+          <div class="tier-title">Micro-Purchase Threshold buys</div>
+          <div class="tier-cite">GSAR 538.7103-1</div>
+          <div class="tier-section">
+            <h3>Rule</h3>
+            <p>CO can place an order or establish a BPA with any FSS contractor that can meet the need.</p>
+          </div>
+          <div class="vendor-move"><strong>Vendor move</strong> Keep catalog data current. Make small-dollar buying frictionless. The CO who buys a $9K license renewal isn't running a competition — make sure your terms, pricing, and contact path are accurate in GSA Advantage and your catalog.</div>
+        </div>
+
+        <div class="tier-card">
+          <div class="tier-eyebrow">Tier 2 &middot; Above MPT, at or below SAT</div>
+          <div class="tier-title">Above Micro, up to the Simplified Acquisition Threshold</div>
+          <div class="tier-cite">GSAR 538.7103-2</div>
+          <div class="tier-section">
+            <h3>Rule</h3>
+            <p>CO may place the order after doing one of the following:</p>
+            <ol>
+              <li>Survey 3+ FSS contractors on GSA Advantage.</li>
+              <li>Review FSS catalogs of 3+ FSS contractors.</li>
+              <li>Publish RFQ on GSA eBuy.</li>
+              <li>Issue RFQ to 3+ FSS contractors.</li>
+            </ol>
+          </div>
+          <div class="vendor-move"><strong>Vendor move</strong> Be discoverable in GSA Advantage and eLibrary. Respond quickly and clearly. If a buyer can't find you in 90 seconds on Advantage, you're not in the comparison set.</div>
+        </div>
+
+        <div class="tier-card">
+          <div class="tier-eyebrow">Tier 3 &middot; Above SAT</div>
+          <div class="tier-title">Above the Simplified Acquisition Threshold</div>
+          <div class="tier-cite">GSAR 538.7103-3</div>
+          <div class="tier-section">
+            <h3>Rule</h3>
+            <p>Unless a justification under 538.7104-3(b) applies, the CO must either:</p>
+            <ol>
+              <li>Publish an RFQ on GSA's eBuy, or</li>
+              <li>Issue an RFQ to enough FSS contractors to reasonably ensure quotations from at least three.</li>
+            </ol>
+          </div>
+          <div class="vendor-move"><strong>Vendor move</strong> Your RFI / Market Research responses determine whether you're considered capable and included on the RFQ. If you treat RFIs as optional, you'll be invisible at SAT-plus dollar levels.</div>
+        </div>
+
+        <div class="dash-card">
+          <h2>Other RFO 8.4 changes you should know</h2>
+          <ul>
+            <li><strong>Market Research is critical.</strong> Procurement is now a research-driven process, not an RFP-driven one.</li>
+            <li><strong>FSS ordering procedures are consolidated</strong> in GSAR Subpart 538.7103. One stop for the rules.</li>
+            <li><strong>Unsuccessful quoters may request a brief explanation within 3 days.</strong> Use it. Even one sentence of feedback informs the next quote.</li>
+            <li><strong>No additional order-level responsibility determination</strong> for FSS orders. You are already determined responsible at the schedule level.</li>
+            <li><strong>Expect leaner RFQs with clearer selection basis</strong> — not lengthy FAR Part 15 style proposals. Calibrate your response volume to what the RFQ actually asks.</li>
+          </ul>
+          <div class="callout">
+            <strong>"RFIs went from black hole to spotlight."</strong> Verbatim from Kimberly Himes, HHS Acquisition Innovation Advocate, at the May 2026 Acquisition Solutions Day. The shift is real: market research data is now the input that constructs the RFQ recipient list.
+          </div>
+        </div>
+
+        <div class="dash-card">
+          <h2>What this means for your BD calendar</h2>
+          <p>The capture rhythm changes. Under the old regime, you waited for the RFP, then put a proposal together. Under RFO 8.4:</p>
+          <ul>
+            <li><strong>RFI response quality drives RFQ inclusion.</strong> Treat every RFI like a capability statement that decides your seat at the table.</li>
+            <li><strong>Catalog hygiene is now a capture function</strong>, not a logistics function. Stale GSA Advantage entries cost you Tier-1 and Tier-2 work.</li>
+            <li><strong>The 3-day debrief window is a feedback loop.</strong> Run a standing process to request and capture it.</li>
+            <li><strong>Calibrate proposal volume.</strong> If the RFQ runs 6 pages with a 4-criterion selection basis, a 60-page response isn't compliance — it's noise.</li>
+          </ul>
+        </div>
+
+        <div class="dash-card">
+          <h2>The Periodic Table of Acquisition Innovation</h2>
+          <p>The canonical reference for these techniques is the Periodic Table of Acquisition Innovation (PTAI) on <a href="https://acquisitiongateway.gov" rel="noopener" style="color:var(--mmt-teal);">AcquisitionGateway.gov</a>. It's organized by phase (market research, requirements, evaluation, contract administration) and named technique. Worth a bookmark.</p>
+        </div>
+
+        <div class="dash-card">
+          <h2>How this connects</h2>
+          <div class="pill-row">
+            <a href="/policy/pact">PACT &amp; the 3 EOs</a>
+            <a href="/agencies/hhs/omas">OMAS deep dive</a>
+            <a href="/agencies/hhs/hcas">All 10 HCAs</a>
+            <a href="/agencies/hhs">HHS profile</a>
+            <a href="/premium/fpds-migration.html">FPDS Sunset Watch</a>
+            <a href="/idiq-tracker.html">IDIQ Tracker</a>
+          </div>
+        </div>
+
+        <div class="dash-card source-block">
+          <strong>Sources.</strong> HHS Acquisition Solutions Day (May 2026) Industry Day deck, slides 23-25. "Periodic Table of Acquisition Innovation" reference on <a href="https://acquisitiongateway.gov" rel="noopener">AcquisitionGateway.gov</a>. Kimberly Himes (HHS IDEAS Lab and Acquisition Innovation Advocate) verbatim presentation transcript.<br><br>
+          <strong>What changes after this?</strong> GSAR Subpart 538.7103 is the regulation, and OMB will publish operational guidance through FY26. We re-verify on any rule change.
+        </div>
+
+      </div>
+    </div>
+  </div>
+  <script>
+    var email=localStorage.getItem('mmt_email');var __de=document.getElementById('dash-email');if(__de&&email)__de.textContent=email;
+  </script>
+</body>
+</html>

--- a/premium/updates/2026-05-18-hhs-omas.html
+++ b/premium/updates/2026-05-18-hhs-omas.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>What changed at HHS this week (May 18, 2026) &middot; MMT Premium</title>
+  <meta name="robots" content="noindex">
+  <meta name="description" content="The eight changes from the May 2026 HHS Acquisition Solutions Day that reshape FY26 BD plans. OMAS, the 10 HCAs, EO 14240, OMB M-25-31, RFO 8.4, Market Hour, FY26 consolidation.">
+  <link rel="stylesheet" href="/styles/tailwind.css">
+  <link rel="icon" href="/favicon-v3.png" type="image/png">
+  <style>
+    :root { --mmt-navy:#0A192F; --mmt-teal:#457B9D; --mmt-white:#FFFFFF; --mmt-surface:#F3F4F6; --mmt-text-secondary:#6B7280; --mmt-border:#E5E7EB; --ci-gold:#92710A; --dash-sidebar:220px; }
+    body { font-family:Inter,system-ui,sans-serif; color:var(--mmt-navy); background:var(--mmt-surface); margin:0; line-height:1.6; }
+    .dash-shell { display:grid; grid-template-columns:var(--dash-sidebar) 1fr; min-height:100vh; }
+    .dash-nav { background:var(--mmt-navy); padding:24px 0; display:flex; flex-direction:column; position:sticky; top:0; height:100vh; overflow-y:auto; }
+    .dash-nav-brand { padding:0 20px 24px; border-bottom:1px solid rgba(255,255,255,0.1); margin-bottom:16px; }
+    .dash-nav-brand a { color:#fff; text-decoration:none; font-weight:800; font-size:14px; }
+    .dash-nav-brand small { display:block; font-size:11px; color:rgba(255,255,255,0.5); font-weight:400; margin-top:2px; }
+    .dash-nav-link { display:flex; align-items:center; gap:10px; padding:10px 20px; color:rgba(255,255,255,0.6); text-decoration:none; font-size:13px; font-weight:500; transition:all 0.15s; }
+    .dash-nav-link:hover { color:#fff; background:rgba(255,255,255,0.05); }
+    .dash-nav-link.active { color:#fff; background:rgba(69,123,157,0.3); border-left:3px solid var(--mmt-teal); }
+    .dash-nav-section { font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.12em; color:rgba(255,255,255,0.3); padding:16px 20px 6px; }
+    .dash-header { background:var(--mmt-white); padding:16px 32px; border-bottom:1px solid var(--mmt-border); display:flex; align-items:center; justify-content:space-between; }
+    .dash-main { padding:32px; max-width:780px; }
+    .dash-card { background:var(--mmt-white); border-radius:12px; padding:28px 32px; margin-bottom:18px; border:1px solid var(--mmt-border); }
+    .eyebrow { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:0.10em; color:var(--mmt-text-secondary); margin-bottom:8px; }
+    h1 { font-size:30px; font-weight:800; margin:0 0 8px; letter-spacing:-0.02em; line-height:1.15; }
+    h2 { font-size:18px; font-weight:800; margin:0 0 8px; letter-spacing:-0.01em; color:var(--mmt-navy); }
+    .lede { font-size:16px; color:var(--mmt-text-secondary); margin:0 0 14px; line-height:1.6; }
+    .meta-row { font-size:12px; color:var(--mmt-text-secondary); margin-bottom:24px; }
+    .meta-row a { color:var(--mmt-teal); text-decoration:none; }
+    p { font-size:14.5px; margin:0 0 14px; }
+    .item { background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:10px; padding:20px 24px; margin-bottom:12px; }
+    .item-num { display:inline-block; font-size:11px; font-weight:700; letter-spacing:0.10em; color:var(--mmt-teal); margin-bottom:6px; }
+    .item-headline { font-size:17px; font-weight:800; color:var(--mmt-navy); margin:0 0 8px; line-height:1.35; }
+    .item-body { font-size:14.5px; color:var(--mmt-navy); margin:0 0 10px; line-height:1.6; }
+    .item-links { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+    .item-links a { font-size:12px; font-weight:600; color:var(--mmt-teal); text-decoration:none; border-bottom:1px solid rgba(69,123,157,0.3); padding-bottom:1px; }
+    .item-links a:hover { color:var(--mmt-navy); border-bottom-color:var(--mmt-navy); }
+    .closer { background:linear-gradient(180deg, var(--mmt-white) 0%, var(--mmt-surface) 100%); border:1px solid var(--mmt-border); border-radius:12px; padding:24px 28px; margin-top:24px; }
+    .closer h2 { margin-bottom:10px; }
+    .source-block { font-size:12.5px; color:var(--mmt-text-secondary); line-height:1.6; }
+    .source-block a { color:var(--mmt-teal); text-decoration:none; }
+    @media (max-width:768px) { .dash-shell { grid-template-columns:1fr; } .dash-nav { display:none; } .dash-main { padding:16px; padding-bottom:80px; } }
+  </style>
+  <script>
+    (function() {
+      var isPremium = localStorage.getItem('mmt_premium') === 'true';
+      var ts = localStorage.getItem('mmt_premium_ts');
+      var withinWindow = ts && (Date.now() - parseInt(ts)) < 30 * 24 * 60 * 60 * 1000;
+      if (!isPremium || !withinWindow) { window.location.href = '/dashboard.html'; }
+    })();
+  </script>
+</head>
+<body>
+  <div class="dash-shell">
+    <nav class="dash-nav">
+      <div class="dash-nav-brand"><a href="/premium/dashboard.html">&#9733; MMT Premium<small>Intelligence Dashboard</small></a></div>
+      <div class="dash-nav-section">Intelligence</div>
+      <a href="/premium/dashboard.html" class="dash-nav-link">Dashboard</a>
+      <a href="/agencies/" class="dash-nav-link">Agencies</a>
+      <a href="/premium/briefings.html" class="dash-nav-link">Friday Brief</a>
+      <a href="/premium/monthly-briefs.html" class="dash-nav-link">Monthly Brief</a>
+      <a href="/premium/key-people.html" class="dash-nav-link">Key People</a>
+      <a href="/premium/gao-sustain.html" class="dash-nav-link">GAO Sustains</a>
+      <div class="dash-nav-section">Tools</div>
+      <a href="/premium/pursuit-score.html" class="dash-nav-link">Pursuit Score</a>
+      <a href="/premium/compliance-check.html" class="dash-nav-link">Compliance Check</a>
+      <a href="/premium/signal-chain.html" class="dash-nav-link">Signal Chain</a>
+      <div class="dash-nav-section">Policy</div>
+      <a href="/policy/pact" class="dash-nav-link">PACT &amp; EOs</a>
+      <a href="/policy/rfo-8-4" class="dash-nav-link">RFO 8.4</a>
+      <a href="/premium/fpds-migration.html" class="dash-nav-link">FPDS Sunset</a>
+      <a href="/premium/cr-exposure.html" class="dash-nav-link">CR Exposure</a>
+      <div class="dash-nav-section">Resources</div>
+      <a href="/premium/calendar.html" class="dash-nav-link">Pursuit Calendar</a>
+      <a href="/contract-tracker.html" class="dash-nav-link">Contract Tracker</a>
+      <a href="/idiq-tracker.html" class="dash-nav-link">IDIQ Tracker</a>
+      <a href="/premium/ask-mmt.html" class="dash-nav-link">Ask MMT</a>
+      <div class="dash-nav-section">Account</div>
+      <a href="/premium/settings.html" class="dash-nav-link">Settings</a>
+      <a href="/" class="dash-nav-link" style="margin-top:auto; border-top:1px solid rgba(255,255,255,0.1); padding-top:16px;">&larr; Back to site</a>
+    </nav>
+    <div>
+      <div class="dash-header">
+        <span style="font-size:14px; font-weight:700;">&#9733; Premium Dashboard</span>
+        <div style="display:flex; align-items:center; gap:16px;">
+          <span style="font-size:13px; color:var(--mmt-text-secondary);" id="dash-email"></span>
+          <a href="/" style="font-size:12px; color:var(--mmt-teal); text-decoration:none;">Back to site</a>
+          <a href="#" onclick="localStorage.removeItem('mmt_premium');localStorage.removeItem('mmt_premium_ts');localStorage.removeItem('mmt_email');document.cookie='mmt_premium=;path=/;max-age=0';window.location.href='/';return false;" style="font-size:12px; color:var(--mmt-text-secondary); text-decoration:none;">Sign out</a>
+        </div>
+      </div>
+      <div class="dash-main">
+
+        <div class="eyebrow">Update &middot; May 18, 2026</div>
+        <h1>HHS just made 8 changes that reshape your FY26 BD plan</h1>
+        <p class="lede">Last week's HHS Acquisition Solutions Day quietly rewrote how federal health agencies will buy from your company. I sat with the slide deck, the transcripts, and the official HHS rosters. Here's what changed, and where to go on the site for the deep version.</p>
+        <div class="meta-row">
+          Data current as of April 27, 2026 (HHS HCA roster) and May 15, 2026 (Acquisition Solutions Day).
+          &middot; <a href="/agencies/hhs">HHS profile</a>
+          &middot; <a href="/agencies/hhs/omas">OMAS deep dive</a>
+          &middot; <a href="/agencies/hhs/orgchart">Visual org chart</a>
+        </div>
+
+        <div class="item">
+          <div class="item-num">CHANGE 1 OF 8</div>
+          <h2 class="item-headline">A new HHS contracting activity exists: OMAS.</h2>
+          <p class="item-body">The Office of Mission Acquisition Solutions (formerly OAMS) was realigned under ASFR / Office of Acquisitions in January 2026 and is now a designated HCA on the official HHS roster. Quentin McCoy is the HCA.</p>
+          <div class="item-links">
+            <a href="https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html" rel="noopener">HHS HCA roster &rarr;</a>
+            <a href="/agencies/hhs/omas">OMAS deep dive &rarr;</a>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="item-num">CHANGE 2 OF 8</div>
+          <h2 class="item-headline">HHS contracting activities dropped from 13 to 10.</h2>
+          <p class="item-body">ACF and AHRQ independent contracting authority was eliminated. Both portfolios now flow through OMAS SBC-Mission (Trish James). Quentin McCoy on the May 2026 transcript: "Those two offices were eliminated, and now we serve those customers."</p>
+          <div class="item-links">
+            <a href="/agencies/hhs/hcas">All 10 HCAs &rarr;</a>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="item-num">CHANGE 3 OF 8</div>
+          <h2 class="item-headline">Common IT and Professional Services consolidate through OMAS.</h2>
+          <p class="item-body">Driven by EO 14240 (Procurement Consolidation, March 20, 2025) and OMB M-25-31 (July 18, 2025). Mission-specific procurement stays with the operating division.</p>
+          <div class="item-links">
+            <a href="/policy/pact">PACT &amp; the 3 EOs &rarr;</a>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="item-num">CHANGE 4 OF 8</div>
+          <h2 class="item-headline">HHS FY25 spend dropped to $28.2B.</h2>
+          <p class="item-body">A $16.3B reduction from final FY25 obligations, driven by the HHS Cost Efficiency Initiative (HCEI). FY22-FY24 averaged ~$40B per year. The contract universe is smaller and tighter than it was 18 months ago.</p>
+        </div>
+
+        <div class="item">
+          <div class="item-num">CHANGE 5 OF 8</div>
+          <h2 class="item-headline">OMAS Market Hour launches June 2026.</h2>
+          <p class="item-body">10-minute capability demo + 5-minute Q&amp;A virtual sessions. Customer-interest-driven selection from a Vendor Profile Form. Contact IndustryLiaison@hhs.gov. Only completed Vendor Profile Forms are considered, so submit early.</p>
+          <div class="item-links">
+            <a href="/agencies/hhs/omas">OMAS deep dive &rarr;</a>
+            <a href="mailto:IndustryLiaison@hhs.gov">IndustryLiaison@hhs.gov</a>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="item-num">CHANGE 6 OF 8</div>
+          <h2 class="item-headline">GSAR 538.7103 / "RFO 8.4" rewrote schedule-based buying.</h2>
+          <p class="item-body">Three tiers (at-or-below MPT / MPT-to-SAT / above-SAT) with different competition rules. RFIs went "from black hole to spotlight" — they now drive whether your firm makes the RFQ list.</p>
+          <div class="item-links">
+            <a href="/policy/rfo-8-4">RFO 8.4 tier playbook &rarr;</a>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="item-num">CHANGE 7 OF 8</div>
+          <h2 class="item-headline">The HHS IDEAS Lab is central, not optional.</h2>
+          <p class="item-body">Kimberly Himes is the new HHS Acquisition Innovation Advocate (AIA) and Industry Liaison. Acquisition Innovation moved from optional practice to key driver under the FAR Overhaul.</p>
+        </div>
+
+        <div class="item">
+          <div class="item-num">CHANGE 8 OF 8</div>
+          <h2 class="item-headline">HHS may consolidate further.</h2>
+          <p class="item-body">The FY2026 Budget in Brief signals consolidation of 28 operating divisions to 15 and closure of 5 of the most costly regional offices. Today's 10-HCA org chart is a snapshot, not a steady state.</p>
+          <div class="item-links">
+            <a href="https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf" rel="noopener">FY2026 Budget in Brief (PDF) &rarr;</a>
+          </div>
+        </div>
+
+        <div class="closer">
+          <h2>If you only do one thing this week</h2>
+          <p style="margin-bottom:8px;">Submit the OMAS Vendor Profile Form. The Market Hour roster will fill on customer interest, not on first-come-first-served. Email <a href="mailto:IndustryLiaison@hhs.gov" style="color:var(--mmt-teal); font-weight:600;">IndustryLiaison@hhs.gov</a> and ask for the form.</p>
+          <p style="margin:0;">After that, work the map: <a href="/agencies/hhs">/agencies/hhs</a> for the navigation, <a href="/agencies/hhs/orgchart">/agencies/hhs/orgchart</a> for the visual, <a href="/agencies/hhs/omas">/agencies/hhs/omas</a> for the OMAS strategy, <a href="/agencies/hhs/hcas">/agencies/hhs/hcas</a> for every name and email, <a href="/policy/pact">/policy/pact</a> for the policy backbone, and <a href="/policy/rfo-8-4">/policy/rfo-8-4</a> for the new schedule-buying rules.</p>
+        </div>
+
+        <div class="dash-card source-block">
+          <strong>Primary sources for this update.</strong>
+          <a href="https://www.hhs.gov/grants-contracts/grants-business-contacts/hca-and-key-managers/index.html" rel="noopener">HHS HCA and Key Managers roster</a> (verified 2026-04-27).
+          <a href="https://www.hhs.gov/about/agencies/asfr/key-personnel/index.html" rel="noopener">HHS ASFR Key Personnel</a> (verified 2026-04-27).
+          <a href="https://www.hhs.gov/about/agencies/asfr/acquisition/osdbu/index.html" rel="noopener">HHS OSDBU</a> (verified 2026-05-07).
+          <a href="https://www.hhs.gov/sites/default/files/fy-2026-budget-in-brief.pdf" rel="noopener">HHS FY2026 Budget in Brief</a> (verified 2025-06-02).
+          HHS Acquisition Solutions Day (May 2026) Industry Day deck and Otter.ai transcripts.
+          White House primary text: <a href="https://www.whitehouse.gov/presidential-actions/2025/02/implementing-the-presidents-department-of-government-efficiency-workforce-optimization-initiative/" rel="noopener">EO 14210</a>, <a href="https://www.whitehouse.gov/presidential-actions/2025/02/implementing-the-presidents-department-of-government-efficiency-cost-efficiency-initiative/" rel="noopener">EO 14222</a>, <a href="https://www.whitehouse.gov/wp-content/uploads/2025/07/M-25-31-Consolidating-Federal-Procurement-Activities.pdf" rel="noopener">OMB M-25-31 (covers EO 14240)</a>.<br><br>
+          <strong>Otter mishearings corrected:</strong> ASTR &rarr; ASFR. ARC &rarr; AHRQ. Scott Bluedown &rarr; Scott Bredow. Verified against the official ASFR Key Personnel page and the HCA roster.
+        </div>
+
+      </div>
+    </div>
+  </div>
+  <script>
+    var email=localStorage.getItem('mmt_email');var __de=document.getElementById('dash-email');if(__de&&email)__de.textContent=email;
+  </script>
+</body>
+</html>

--- a/reports/capture-corner-inventory.json
+++ b/reports/capture-corner-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-18T13:25:27.893Z",
+  "generated_at": "2026-05-18T18:57:36.075Z",
   "candidate_count": 11,
   "newest_eligible": {
     "id": "capture-corner-2026-05-17.html",

--- a/reports/newsletter-inventory.json
+++ b/reports/newsletter-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-18T02:58:37.654Z",
+  "generated_at": "2026-05-18T18:57:35.772Z",
   "source_dir": "content/newsletter",
   "source_count": 110,
   "newest_in_source": {


### PR DESCRIPTION
3 commits stacked on this branch — all green locally (build clean, validate-dist + validate-routes pass).

## 1. `feat(hhs):` HHS OMAS realignment coverage (Phase 1)
Phase 1 of the 2026-05-18 HHS update package. Phase 2 (Resend email) is gated on your explicit go — not in this PR.

- 4 data files: `data/orgcharts/hhs.json`, `data/orgcharts/index.json`, `data/policy/eo-procurement.json`, `data/changelog/2026-05-18-hhs-omas.json`
- HHS profile JSON rewritten for OMAS realignment (`data/premium/agency-profiles/agencies.json`)
- 7 new paid pages (`mmt_premium` gate, `noindex`):
  - `/agencies/hhs/orgchart` — visual org chart with 10-HCAs grid
  - `/agencies/hhs/omas` — OMAS deep dive
  - `/agencies/hhs/hcas` — sortable + filterable HCA table
  - `/policy/pact` — PACT + 3 EOs + OMB M-25-31
  - `/policy/rfo-8-4` — GSAR 538.7103 tier playbook
  - `/updates/2026-05-18-hhs-omas` — subscriber-email landing
  - Plus existing `/agencies/hhs` rebuilt with OMAS facts + "View HHS Org Chart" CTA
- 6 netlify.toml redirects, 6 entries in `docs/member-features.json`, new auto-discovery loop in build.js for `premium/{agencies,policy,updates}/`

## 2. `fix(build):` decode HTML entities at brief title/desc extraction
Dashboard's "Latest Friday Brief" tile rendered `DHA Budget &amp; Org Realignment` (literal `&amp;` shown). Source `<h1>` had properly-escaped `&amp;`, but `getBriefFiles()` captured the encoded string verbatim and `generateFridayBriefLatestTileHtml()` then ran `escapeHtml()` again → `&amp;amp;` in DOM → browser rendered literal `&amp;`. Fix: added `decodeHtmlEntities()` helper, wired at both `getBriefFiles()` and `getCaptureCornerFiles()` extraction sites. Verified the dashboard tile now reads `DHA Budget & Org Realignment`.

## 3. `feat(capture-intel):` 2026-05-18 cleanup + refresh
Applies the full cleanup + refresh spec to `intel-capture-intelligence.html`:

**Cleanup:** CCN Dental removed from table + collapsed to closed stub; EHRM withhold rewritten (deadline corrected to **July 1, 2026** — was June 1; full 5-condition statutory list); Issue 2 freshness banner; date stamp swapped to "Last reviewed May 18, 2026 · Next review May 25, 2026"; deep-dive heading updated to "Deep Dive: All 30 Signals".

**REFRESH-A (12 corrections):** A4 (HTI-5 Final Rule), A5 (PRMRP FOAs released May 8), A6 (PCRP April 24), A7 (EIDS Koniag + ESS Next), A8 (Data Strategy March 11), A9 (CCN Medical timeline), A10 (DHIT + DHIA II), A11 (AHA not appropriated), A12 ($47.8M Decision Intel), A13 ($596M Q2 NRM). A2/A3 folded into the EHRM withhold rewrite.

**REFRESH-B/C (6 new accordions s26-s31):**
- s26 VA Ambient Scribe Enterprise IDIQ (36C10B26R0006, $775.7M ceiling)
- s27 DHA EDC Phase 2 / FY26-30 Data Strategy
- s28 HCDS EHR Follow-on (HT003826X0000)
- s29 DHA Deployment Solutions IDIQ (HT003826RE001, closed April 21)
- s30 ARPA-H ADVOCATE (team selections June 2026)
- s31 HTI-5 Final Rule Compliance Window

EDC (#s18) chipped as "Responses closed Jan 9, 2026 · pending award" with GAO B-424295.1 dismissal context.

## Counts after refresh
- Hero: `21 live signals · 12 agencies`
- Table header: `21 live signals · 12 agencies · Last reviewed May 18, 2026 · Next review May 25, 2026`
- Deep-dive heading: `Deep Dive: All 30 Signals`
- Paywall teaser: JS-dynamic (`accordions.length - 3`) — auto-updates

## Test plan
- [x] `node build.js` clean (392 dist pages)
- [x] `node scripts/validate-dist.js` — OK
- [x] `node scripts/validate-routes.js` — all 29 features resolve
- [x] `node scripts/validate-agency-profiles.js` — 11 agencies pass
- [x] `node scripts/validate-agency-parity.js` — 11 agencies pass
- [x] All 7 new HHS URLs return 200 in local preview
- [x] Dashboard tile renders `DHA Budget & Org Realignment` (no `&amp;`)
- [x] Capture intel page renders `Deep Dive: All 30 Signals` + `21 live signals · 12 agencies`
- [x] Zero console errors

After merge: confirm Netlify deploy green, then say "go" to trigger Phase 2 of the HHS package (Resend email to paid subscribers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)