### PR TITLE
feat: surface eBuy Open RFQs on Tracker + honest search fallbacks (close Ryan gap)

### DIFF
--- a/contract-tracker.html
+++ b/contract-tracker.html
@@ -169,7 +169,13 @@
         <button class="radar-filter text-xs font-semibold px-3 py-1.5 rounded-full transition-all" data-filter="8(a)" style="background:rgba(69,123,157,0.08);color:var(--mmt-teal);border:1px solid rgba(69,123,157,0.2);">8(a)</button>
         <button class="radar-filter text-xs font-semibold px-3 py-1.5 rounded-full transition-all" data-filter="SDVOSB" style="background:rgba(69,123,157,0.08);color:var(--mmt-teal);border:1px solid rgba(69,123,157,0.2);">SDVOSB</button>
         <button class="radar-filter text-xs font-semibold px-3 py-1.5 rounded-full transition-all" data-filter="WOSB" style="background:rgba(69,123,157,0.08);color:var(--mmt-teal);border:1px solid rgba(69,123,157,0.2);">WOSB</button>
+        <button class="radar-filter text-xs font-semibold px-3 py-1.5 rounded-full transition-all" data-filter="ebuy" style="background:rgba(146,113,10,0.10);color:#92710A;border:1px solid rgba(146,113,10,0.25);">eBuy RFQs</button>
       </div>
+
+      <!-- Why some opportunities aren't here: SAM.gov is public; eBuy is Schedule-only -->
+      <p class="text-xs mb-6" style="color:var(--mmt-text-secondary);line-height:1.6;max-width:72ch;">
+        <strong style="color:var(--mmt-navy);">Why some opportunities aren't here:</strong> SAM.gov lists public solicitations; GSA eBuy lists RFQs visible only to Schedule holders. We surface eBuy RFQ existence and a link here (tagged <span style="color:#92710A;font-weight:600;">eBuy RFQ</span>), but reading the full RFQ and submitting a quote require the relevant GSA Schedule. If a search comes up empty, check <a href="https://www.ebuy.gsa.gov/advantage/ebuy/start_page.do" target="_blank" rel="noopener" style="color:var(--mmt-teal);font-weight:600;">eBuy Open</a> and <a href="https://sam.gov/search" target="_blank" rel="noopener" style="color:var(--mmt-teal);font-weight:600;">SAM.gov</a> directly.
+      </p>
 
       <!-- Opportunity cards container -->
       <div id="radar-container">

--- a/js/contract-tracker.js
+++ b/js/contract-tracker.js
@@ -78,7 +78,8 @@
             note = '<p class="text-sm" style="color:var(--mmt-text-secondary);">No scan results yet. The scanner runs daily at 7 AM ET.</p>';
           }
         }
-        return '<div class="card rounded-xl p-8 text-center" data-testid="radar-empty"><p class="text-base mb-2" style="color:var(--mmt-text-secondary);">No opportunities match the current filter.</p>' + note + '</div>';
+        var fallback = '<p class="text-sm" style="color:var(--mmt-text-secondary);margin-top:12px;">Not seeing it here? Some RFQs post only to GSA eBuy for Schedule holders and never appear on SAM.gov. Search directly: <a href="https://www.ebuy.gsa.gov/advantage/ebuy/start_page.do" target="_blank" rel="noopener" style="color:var(--mmt-teal);font-weight:600;">eBuy Open</a> &middot; <a href="https://sam.gov/search" target="_blank" rel="noopener" style="color:var(--mmt-teal);font-weight:600;">SAM.gov search</a></p>';
+        return '<div class="card rounded-xl p-8 text-center" data-testid="radar-empty"><p class="text-base mb-2" style="color:var(--mmt-text-secondary);">No opportunities match the current filter.</p>' + note + fallback + '</div>';
       }
       var isPremium = isPremiumUser();
       var html = '<div class="grid md:grid-cols-2 gap-4">';
@@ -87,7 +88,10 @@
         // Header with type badge, confidence, and deadline
         html += '<div class="flex items-start justify-between gap-2 mb-2">';
         html += '<div class="flex flex-wrap gap-2">';
-        if (o.opportunity_type) {
+        var isEbuy = o.source === 'ebuy_open' || o.opportunity_type === 'ebuy_rfq';
+        if (isEbuy) {
+          html += '<span class="text-xs font-bold px-2 py-0.5 rounded" style="background:rgba(146,113,10,0.10);color:#92710A;">eBuy RFQ</span>';
+        } else if (o.opportunity_type) {
           html += '<span class="text-xs px-2 py-0.5 rounded" style="background:rgba(69,123,157,0.08);color:var(--mmt-teal);">' + esc(o.opportunity_type) + '</span>';
         }
         if (o.contract_vehicle) {
@@ -104,6 +108,16 @@
         html += '<h3 class="text-sm font-bold mb-1" style="color:var(--mmt-navy);">' + esc(o.title) + '</h3>';
         // Agency (always public)
         html += '<p class="text-xs mb-2" style="color:var(--mmt-teal);">' + esc(o.agency) + '</p>';
+        // eBuy RFQs: public access note + public source link. These are
+        // Schedule-only RFQs that never hit SAM.gov; surface existence so a
+        // search never dead-ends, even for free readers (the Ryan gap).
+        if (isEbuy) {
+          html += '<p class="text-xs mb-2" style="color:#92710A;">Requires a GSA Schedule to respond.';
+          if (isValidSourceUrl(o.source_url)) {
+            html += ' <a href="' + esc(o.source_url) + '" target="_blank" rel="noopener" style="color:#92710A;font-weight:600;text-decoration:underline;">View on eBuy Open &rarr;</a>';
+          }
+          html += '</p>';
+        }
         // Premium content: description, reasoning, metadata
         if (isPremium) {
           if (o.ai_summary) {
@@ -153,6 +167,8 @@
         filtered = opps;
       } else if (activeFilter === 'small_business') {
         filtered = opps.filter(function(o) { return o.small_business_eligible; });
+      } else if (activeFilter === 'ebuy') {
+        filtered = opps.filter(function(o) { return o.source === 'ebuy_open' || o.opportunity_type === 'ebuy_rfq'; });
       } else {
         filtered = opps.filter(function(o) { return o.set_aside_type === activeFilter; });
       }

--- a/migrations/20260528193000_opportunity_radar_source_column.sql
+++ b/migrations/20260528193000_opportunity_radar_source_column.sql
@@ -1,0 +1,14 @@
+-- ============================================================
+-- 20260528193000_opportunity_radar_source_column.sql
+--
+-- Adds a `source` column to opportunity_radar so eBuy Open RFQs can be
+-- distinguished from the default radar scan. Existing rows default to
+-- 'radar'; the eBuy scanner stamps 'ebuy_open'.
+--
+-- Idempotent. Apply via the Supabase SQL Editor — migrations do not
+-- self-apply. Apply BEFORE the ebuy-open-radar scanner runs and before
+-- the Tracker's ?source= filter is used in production.
+-- ============================================================
+
+ALTER TABLE opportunity_radar ADD COLUMN IF NOT EXISTS source text DEFAULT 'radar';
+CREATE INDEX IF NOT EXISTS idx_opportunity_radar_source ON opportunity_radar(source);

--- a/netlify.toml
+++ b/netlify.toml
@@ -98,6 +98,14 @@
 [functions."opportunity-radar"]
   schedule = "0 */4 * * *"
 
+# eBuy Open surfacing: triggers ebuy-open-radar-background to scan GSA
+# eBuy Open (Schedule-only RFQs that never hit SAM.gov) for federal
+# health IT RFQs. 11:30 UTC = 7:30 AM ET, 30 min after the SAM/agency
+# radar and offset from every other radar cron (no collision). Requires
+# the opportunity_radar `source` column (migration 20260528193000).
+[functions."ebuy-open-radar"]
+  schedule = "30 11 * * *"
+
 [functions."sb-vehicle-radar"]
   schedule = "0 13 * * *"
 

--- a/netlify/functions/ebuy-open-radar-background.js
+++ b/netlify/functions/ebuy-open-radar-background.js
@@ -1,0 +1,286 @@
+// ============================================================
+// ebuy-open-radar-background.js — Netlify Background Function
+//
+// Surfaces ACTIVE federal health IT RFQs posted on GSA eBuy Open
+// (https://www.ebuy.gsa.gov). eBuy has no API (GSA confirmed,
+// GSA-APIs#37), so this reuses the SAME Perplexity sonar-pro web-search
+// pattern as opportunity-radar-background.js.
+//
+// eBuy RFQs are visible to Schedule holders only. The goal here is to
+// surface EXISTENCE + metadata + link so a Schedule-only RFQ is no
+// longer invisible to a reader searching the Tracker (the Ryan /
+// RFQ1810815 gap). Every row is stamped source='ebuy_open' and
+// opportunity_type='ebuy_rfq' and upserted into opportunity_radar.
+//
+// Requires the `source` column on opportunity_radar (migration
+// 20260528193000). Until that migration is applied the upserts fail and
+// the run logs EBUY_SCAN_FAILED — non-fatal, nothing else is affected.
+//
+// Triggered by ebuy-open-radar.js (scheduled dispatcher, netlify.toml).
+// ============================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { withRetry } = require("./lib/retry");
+const { validateOpportunity } = require("./lib/contract-validator");
+const { CANCELLED_VEHICLES } = require("./lib/contract-facts");
+const { checkKillSwitch } = require("./lib/kill-switch");
+const { trackAnthropic } = require("./lib/cost-tracker");
+const { logInference } = require("./lib/inference");
+const { logOpsEvent } = require("./lib/ops-ledger");
+
+const PERPLEXITY_URL = "https://api.perplexity.ai/chat/completions";
+const PERPLEXITY_MODEL = "sonar-pro";
+const PERPLEXITY_TIMEOUT_MS = 60000;
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
+
+const NAICS_CODES = ["541512", "541511", "541519", "541611", "524292", "621999", "334510"];
+
+const SCAN_PROMPT = `You are a federal procurement intelligence analyst specializing in federal health IT. You have web search. Your task is to find ACTIVE federal health IT RFQs (Requests for Quote) posted on GSA eBuy Open (https://www.ebuy.gsa.gov), which surfaces Schedule-based RFQs that do NOT appear on SAM.gov.
+
+Focus on RFQs from these agencies: DHA, VA, HHS, CMS, CDC, NIH, IHS. Relevant NAICS codes: ${NAICS_CODES.join(", ")}.
+
+For each RFQ found, extract:
+- title: The RFQ title
+- solicitation_number: The eBuy RFQ number (e.g., RFQ1810815) if available
+- agency: The issuing agency
+- description: Brief description (1-2 sentences). eBuy Open exposes limited public detail — capture existence + whatever metadata is shown.
+- value_estimate: Estimated value if shown (often not public on eBuy)
+- response_deadline: Response deadline in ISO 8601 format if shown
+- set_aside_type: Set-aside if shown (8(a), SDVOSB, VOSB, WOSB, HUBZone, SDB, or "Full & Open")
+- naics_codes: Array of applicable NAICS codes
+- source_url: The ebuy.gsa.gov RFQ URL when present (otherwise the eBuy Open search URL)
+- relevance_score: 0-100 for relevance to federal health IT
+- ai_summary: 1-2 sentence summary of why this matters, and note that responding requires a GSA Schedule.
+
+Only include RFQs genuinely related to health IT, health data, EHR, telehealth, medical devices, health analytics, or military/veteran healthcare systems.
+
+CRITICAL GUARDRAILS:
+- These are eBuy Schedule RFQs — responding requires the relevant GSA Schedule.
+- source_url MUST be an ebuy.gsa.gov URL when one exists.
+- NEVER use "T-5 BPA" — correct name is T4NG / T4NG2.
+- CIO-SP4 was cancelled February 2026 — do not include as an active vehicle.
+- Always include a source URL for every RFQ.
+
+Return ONLY valid JSON, no markdown fences, shaped as: { "opportunities": [...] }`;
+
+async function callPerplexity(systemPrompt, userMessage, maxTokens, supabase) {
+  const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY;
+  if (!PERPLEXITY_API_KEY) {
+    throw new Error("PERPLEXITY_API_KEY not configured (required by ebuy-open-radar-background)");
+  }
+
+  const _t = Date.now();
+  const response = await withRetry(() => {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), PERPLEXITY_TIMEOUT_MS);
+    return fetch(PERPLEXITY_URL, {
+      method: "POST",
+      signal: ac.signal,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${PERPLEXITY_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        max_tokens: maxTokens,
+        temperature: 0.3,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userMessage },
+        ],
+        web_search_options: { search_context_size: "high" },
+      }),
+    }).finally(() => clearTimeout(timer));
+  }, { maxRetries: 2, baseDelayMs: 3000 });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`Perplexity API error ${response.status}: ${errText.slice(0, 300)}`);
+  }
+
+  const finalData = await response.json();
+
+  if (supabase) {
+    try {
+      const u = finalData.usage || {};
+      await trackAnthropic(supabase, {
+        functionName: "ebuy-open-radar-background",
+        product: "mmt-intel",
+        model: PERPLEXITY_MODEL,
+        usage: { input_tokens: u.prompt_tokens || u.input_tokens || 0, output_tokens: u.completion_tokens || u.output_tokens || 0 },
+        latencyMs: Date.now() - _t,
+      });
+    } catch (_costErr) { /* never break parent */ }
+  }
+  logInference({
+    agent: "ebuy-open-radar", model: PERPLEXITY_MODEL, provider: "perplexity",
+    input_tokens: finalData.usage?.prompt_tokens || finalData.usage?.input_tokens || 0,
+    output_tokens: finalData.usage?.completion_tokens || finalData.usage?.output_tokens || 0,
+    task_type: "ebuy_scan", latency_ms: Date.now() - _t, status: "success",
+  });
+
+  const textContent = finalData.choices?.[0]?.message?.content || "";
+
+  function cleanJson(str) {
+    str = str.replace(/,\s*([\]}])/g, "$1");
+    str = str.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
+    return str;
+  }
+  function extractJsonString(text) {
+    try { return JSON.parse(cleanJson(text)); } catch { /* continue */ }
+    const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (jsonMatch) {
+      try { return JSON.parse(cleanJson(jsonMatch[1].trim())); } catch { /* continue */ }
+    }
+    const braceStart = text.indexOf("{");
+    const braceEnd = text.lastIndexOf("}");
+    if (braceStart >= 0 && braceEnd > braceStart) {
+      const candidate = text.substring(braceStart, braceEnd + 1);
+      try { return JSON.parse(cleanJson(candidate)); } catch { /* continue */ }
+    }
+    return null;
+  }
+
+  const parsed = extractJsonString(textContent);
+  if (!parsed) {
+    console.error("eBuy JSON parse failed. First 500 chars:", textContent.substring(0, 500));
+    throw new Error(`Could not parse JSON from Perplexity response (${textContent.length} chars)`);
+  }
+  return parsed;
+}
+
+async function _runEbuyScan() {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+  const allOpportunities = [];
+
+  try {
+    console.log("eBuy Open scan: federal health IT RFQs...");
+    const result = await callPerplexity(SCAN_PROMPT, `Search GSA eBuy Open (https://www.ebuy.gsa.gov) for ACTIVE federal health IT RFQs posted in the last 30 days.
+
+Focus your web searches on:
+1. eBuy Open health IT RFQs from DHA, VA, and HHS (NAICS 541512, 541511, 541519)
+2. eBuy Open RFQs for EHR, telehealth, health data, and clinical IT support services
+3. eBuy Open small business / Schedule set-aside RFQs in federal health technology
+
+Return the RFQs found as JSON. source_url must be the ebuy.gsa.gov RFQ URL when present.`, 8000, supabase);
+
+    if (result.opportunities) {
+      allOpportunities.push(...result.opportunities);
+      console.log(`  Found ${result.opportunities.length} eBuy RFQs`);
+    }
+  } catch (err) {
+    console.error("eBuy scan failed:", err.message);
+  }
+
+  // Dedup + filter + stamp source
+  const seen = new Set();
+  const filtered = [];
+  for (const opp of allOpportunities) {
+    const key = opp.solicitation_number || opp.title;
+    if (!key || seen.has(key.toLowerCase())) continue;
+    seen.add(key.toLowerCase());
+
+    const relevance = typeof opp.relevance_score === "number" ? opp.relevance_score : 50;
+    if (relevance < 40) continue;
+
+    const oppValidation = validateOpportunity(opp);
+    if (!oppValidation.valid) continue;
+    if (opp.contract_vehicle && CANCELLED_VEHICLES.includes(opp.contract_vehicle)) continue;
+
+    filtered.push({
+      title: (opp.title || "Untitled").substring(0, 500),
+      solicitation_number: opp.solicitation_number || null,
+      agency: (opp.agency || "Unknown").substring(0, 200),
+      description: (opp.description || "").substring(0, 1000),
+      value_estimate: (opp.value_estimate || "").substring(0, 100),
+      response_deadline: opp.response_deadline || null,
+      set_aside_type: (opp.set_aside_type || "").substring(0, 50),
+      naics_codes: Array.isArray(opp.naics_codes) ? opp.naics_codes.slice(0, 10) : [],
+      source_url: (opp.source_url || "").substring(0, 500),
+      relevance_score: relevance,
+      opportunity_type: "ebuy_rfq",
+      small_business_eligible: opp.small_business_eligible === true,
+      ai_summary: (opp.ai_summary || "").substring(0, 500),
+      scan_date: new Date().toISOString().split("T")[0],
+      model_used: PERPLEXITY_MODEL,
+      source: "ebuy_open",
+    });
+  }
+
+  console.log(`eBuy: ${filtered.length} RFQs after dedup/filter`);
+
+  let upsertCount = 0;
+  let errorCount = 0;
+  for (const opp of filtered) {
+    try {
+      if (opp.solicitation_number) {
+        const { error } = await supabase
+          .from("opportunity_radar")
+          .upsert(opp, { onConflict: "solicitation_number" });
+        if (error) { console.error("Upsert error:", error.message); errorCount++; } else { upsertCount++; }
+      } else {
+        const { error } = await supabase.from("opportunity_radar").insert(opp);
+        if (error) {
+          if (error.code === "23505") continue;
+          console.error("Insert error:", error.message);
+          errorCount++;
+        } else { upsertCount++; }
+      }
+    } catch (err) {
+      console.error("DB error:", err.message);
+      errorCount++;
+    }
+  }
+
+  console.log(`eBuy radar complete: ${upsertCount} upserted, ${errorCount} errors`);
+
+  try {
+    await logOpsEvent(supabase, {
+      event_type: upsertCount > 0 ? "EBUY_SCAN_OK" : (errorCount > 0 ? "EBUY_SCAN_FAILED" : "EBUY_SCAN_EMPTY"),
+      source_function: "ebuy-open-radar-background",
+      severity: upsertCount === 0 && errorCount > 0 ? "error" : (upsertCount === 0 ? "warn" : "info"),
+      signature: "ebuy_scan_complete",
+      details: { scanned: allOpportunities.length, filtered: filtered.length, upserted: upsertCount, errors: errorCount },
+    });
+  } catch (logErr) {
+    console.error("ops_ledger heartbeat failed:", logErr.message);
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ scanned: allOpportunities.length, filtered: filtered.length, upserted: upsertCount, errors: errorCount }),
+  };
+}
+
+exports.handler = async () => {
+  const killCheck = checkKillSwitch("ebuy-open-radar-background");
+  if (killCheck.blocked) return killCheck.response;
+
+  console.log("eBuy Open radar scan started:", new Date().toISOString());
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+    console.error("Missing required env vars");
+    return { statusCode: 500, body: "Missing env vars" };
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+  try {
+    return await _runEbuyScan();
+  } catch (err) {
+    const errMsg = (err && err.message ? err.message : String(err)).slice(0, 1000);
+    const errStack = (err && err.stack ? err.stack : "").slice(0, 4000);
+    console.error("ebuy-open-radar-background FAILED:", errMsg);
+    try {
+      await logOpsEvent(supabase, {
+        event_type: "EBUY_SCAN_FAILED",
+        source_function: "ebuy-open-radar-background",
+        severity: "error",
+        signature: "ebuy_scan_failed",
+        details: { error_message: errMsg, error_stack: errStack, started_at: new Date().toISOString() },
+      });
+    } catch (_logErr) { /* never mask the real failure */ }
+    return { statusCode: 500, body: JSON.stringify({ error: "ebuy_scan_failed", message: errMsg }) };
+  }
+};

--- a/netlify/functions/ebuy-open-radar.js
+++ b/netlify/functions/ebuy-open-radar.js
@@ -1,0 +1,44 @@
+// ============================================================
+// ebuy-open-radar.js — Netlify Scheduled Function (Trigger)
+//
+// Thin trigger that invokes ebuy-open-radar-background.
+// Schedule configured in netlify.toml:
+//   [functions."ebuy-open-radar"]
+//     schedule = "30 11 * * *"
+// Runs at 7:30 AM ET — 30 min after the SAM/agency radar's 7 AM sweep
+// and offset from every other radar cron (no collision).
+// ============================================================
+
+const { withOpsLogging } = require("./lib/scheduled-fn-wrapper");
+
+const SITE_URL = process.env.URL || "https://missionmeetstech.com";
+
+async function _handler() {
+  console.log("eBuy Open radar trigger:", new Date().toISOString());
+
+  try {
+    const response = await fetch(
+      `${SITE_URL}/.netlify/functions/ebuy-open-radar-background`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ triggered_by: "schedule" }),
+      }
+    );
+
+    console.log(`Background function response: ${response.status}`);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ status: "triggered", code: response.status }),
+    };
+  } catch (err) {
+    console.error("Failed to trigger ebuy-open-radar-background:", err.message);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: err.message }),
+    };
+  }
+}
+
+exports.handler = withOpsLogging("ebuy_open_radar", _handler);

--- a/netlify/functions/opportunity-feed.js
+++ b/netlify/functions/opportunity-feed.js
@@ -46,6 +46,7 @@ exports.handler = async (event) => {
   const hasVehicle = params.has_vehicle === "true";
   const minConfidence = parseInt(params.min_confidence) || 0;
   const sortBy = params.sort || null;
+  const source = params.source || null;
 
   try {
     const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
@@ -86,6 +87,10 @@ exports.handler = async (event) => {
       query = query.gte("vehicle_confidence", minConfidence);
     }
 
+    if (source) {
+      query = query.eq("source", source);
+    }
+
     const { data: opportunities, error: fetchErr } = await query;
 
     if (fetchErr) {
@@ -108,6 +113,7 @@ exports.handler = async (event) => {
     if (vehicle) countQuery = countQuery.eq("contract_vehicle", vehicle);
     if (hasVehicle) countQuery = countQuery.not("contract_vehicle", "is", null);
     if (minConfidence > 0) countQuery = countQuery.gte("vehicle_confidence", minConfidence);
+    if (source) countQuery = countQuery.eq("source", source);
 
     const { count } = await countQuery;
 


### PR DESCRIPTION
## Summary
Schedule-only RFQs post to GSA eBuy and never appear on SAM.gov, so a reader searching the Contract Tracker for one (the Ryan / RFQ1810815 gap) dead-ends. This adds eBuy Open as a second source: it surfaces RFQ **existence + metadata + link**, sets honest expectations ("requires a GSA Schedule to respond"), and makes a no-match never dead-end.

- **T1 — migration** `migrations/20260528193000_opportunity_radar_source_column.sql`: idempotent `source` column (default `'radar'`) + index.
- **T2 — scanner** `netlify/functions/ebuy-open-radar-background.js`: same Perplexity `sonar-pro` web-search pattern as the existing radar; scans `ebuy.gsa.gov` for active federal health IT RFQs; `validateOpportunity` + relevance≥40 + dedup; stamps `source:'ebuy_open'`, `opportunity_type:'ebuy_rfq'`; upserts onConflict `solicitation_number`; `EBUY_SCAN_OK`/`EMPTY`/`FAILED` heartbeats.
- **T3 — schedule** `ebuy-open-radar.js` dispatcher + `netlify.toml` cron `30 11 * * *` (7:30 AM ET), offset from the `0 */4` radar crons.
- **T4 — feed** `opportunity-feed.js`: optional `?source=` filter (`.select("*")` already returns the column).
- **T5/T6 — Tracker UI** `js/contract-tracker.js` + `contract-tracker.html`: eBuy RFQ card variant with a public access note + "View on eBuy Open →" link; empty-state fallback links to eBuy Open + SAM.gov; "eBuy RFQs" filter chip; "Why some opportunities aren't here" explainer.

## ⚠️ Apply the migration BEFORE merging
The eBuy scanner's upsert and the feed's `?source=` filter need the `source` column. Apply `migrations/20260528193000_opportunity_radar_source_column.sql` in the Supabase SQL Editor first, then merge. (`opportunity-feed` uses `.select("*")`, so a normal feed query is safe pre-migration; only the eBuy scanner and an explicit `?source=` call need the column.)

## Gate checks (all pass)
- `grep -c 'source: "ebuy_open"' …ebuy-open-radar-background.js` → 1 (codebase uses double quotes; spec's single-quote grep is style-only)
- `grep -c "ebuy-open-radar-background" netlify.toml` → 1
- `source` filter present in opportunity-feed.js; `ebuy` present in contract-tracker.js
- `node -e require(ebuy-open-radar-background.js)` → no syntax error
- `node build.js` exit 0; validate-dist OK (431 pages); validate-routes ✓; qa-contrast 0 issues
- **Cron offset:** `30 11` is clear of the radar (`0 */4`). Note: `premium-digest-send` also runs `30 11` — benign (independent jobs, eBuy uses Perplexity not SAM, no shared quota).

## Manual steps for Mary
- Apply the `source` migration in Supabase SQL Editor (before merge).
- No radar fix needed — pipeline verified healthy 2026-05-28.
- `SAM_GOV_API_KEY` expires 2026-07-28 (reminder cron covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)