### PR TITLE
fix(ops): contract freshness from data, not a single event name

### DIFF
--- a/netlify/functions/contract-intel-refresh-background.js
+++ b/netlify/functions/contract-intel-refresh-background.js
@@ -37,6 +37,16 @@ const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
 const NETLIFY_BUILD_HOOK_URL = process.env.NETLIFY_BUILD_HOOK_URL;
 
+// Netlify background functions are hard-killed at 15 min. With a 55-contract
+// roster each doing 2 slow Claude/Perplexity calls sequentially, the loop can
+// blow past that wall and get killed mid-pass — rows already upserted stay
+// fresh, but the end-of-run completion log (logOpsEvent contract_data_refresh)
+// never fires and, being a platform timeout, leaves NO exception in ops_events.
+// A self-imposed wall-clock budget lets the function break the loop cleanly and
+// reach its completion log every run; contracts not reached are picked up next
+// run via the 20h-fresh skip below (continuation is already designed for).
+const RUN_BUDGET_MS = 13 * 60 * 1000;
+
 // Refresh roster is derived from contracts.json at runtime via
 // getRefreshRoster() — see _UNUSED_LEGACY_CONTRACTS below for the old
 // hardcoded list kept only for reference until the next cleanup pass.
@@ -559,6 +569,7 @@ exports.handler = async (event) => {
   const killCheck = checkKillSwitch("contract-intel-refresh-background");
   if (killCheck.blocked) return killCheck.response;
 
+  const runStart = Date.now();
   console.log("Contract intel refresh triggered:", new Date().toISOString());
 
   if (!ANTHROPIC_API_KEY || !SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
@@ -610,7 +621,17 @@ exports.handler = async (event) => {
   }
 
   // Process contracts sequentially to avoid rate limits
+  let truncatedForBudget = false;
   for (const contract of contractsToProcess) {
+    // Stop before the 15-min platform kill so the end-of-run completion log
+    // still fires. Remaining contracts are refreshed on the next scheduled
+    // run (the 20h-fresh skip above carries the continuation).
+    if (!forceContract && Date.now() - runStart > RUN_BUDGET_MS) {
+      truncatedForBudget = true;
+      console.log(`Run budget (${RUN_BUDGET_MS}ms) reached — stopping loop early; remaining contracts deferred to next run.`);
+      break;
+    }
+
     // Skip contracts that already have fresh data (unless force-refreshing)
     if (!forceContract && freshContracts.has(contract.name)) {
       console.log(`Skipping (fresh): ${contract.name}`);
@@ -811,8 +832,10 @@ exports.handler = async (event) => {
       validated: successCount,
       rejected: errorCount,
       total: contractsToProcess.length,
+      truncated_for_budget: truncatedForBudget,
       cost_estimate: costEstimate,
       api_calls: totalCalls,
+      run_ms: Date.now() - runStart,
     },
   });
 

--- a/netlify/functions/quality-drift-check-background.js
+++ b/netlify/functions/quality-drift-check-background.js
@@ -53,21 +53,25 @@ exports.handler = async () => {
       }
     }
 
-    // Contract data freshness
-    const { data: contractEvents } = await supabase
-      .from("ops_events")
-      .select("created_at")
-      .eq("event_type", "contract_data_refresh")
-      .order("created_at", { ascending: false })
+    // Contract data freshness — measured from the ACTUAL data the refresh
+    // writes (contract_intel.last_updated), not a single completion-event
+    // name. The refresh background function keeps updating these rows even
+    // when its end-of-run completion event goes silent (e.g. a 15-min
+    // background timeout kills it mid-loop). Reading the table directly
+    // can't be silently broken by an event rename or a missed completion log.
+    const { data: freshestIntel } = await supabase
+      .from("contract_intel")
+      .select("last_updated")
+      .order("last_updated", { ascending: false })
       .limit(1);
 
-    if (contractEvents && contractEvents.length > 0) {
-      const hoursSince = (Date.now() - new Date(contractEvents[0].created_at).getTime()) / 3600000;
+    if (freshestIntel && freshestIntel.length > 0 && freshestIntel[0].last_updated) {
+      const hoursSince = (Date.now() - new Date(freshestIntel[0].last_updated).getTime()) / 3600000;
       if (hoursSince > 48) {
         alerts.push("Contract data is " + Math.round(hoursSince) + " hours stale");
       }
     } else {
-      alerts.push("No contract data refresh events found");
+      alerts.push("No contract intel rows found");
     }
 
     // Held emails


### PR DESCRIPTION
## Summary
- Fixes the weekly quality-drift alert firing a false "Contract data is NN hours stale" warning while contract data is actually fresh.
- `quality-drift-check-background.js` now measures freshness from `max(contract_intel.last_updated)` instead of the newest `ops_events` row named `contract_data_refresh`. Can't be silently broken by an event rename or a missed completion log. Same >48h threshold.
- `contract-intel-refresh-background.js` root cause: the 55-contract roster blows past the 15-min background-function wall and gets hard-killed mid-loop — rows already upserted stay fresh, but the line-806 completion event never fires (and a platform timeout leaves no exception). Added a 13-min wall-clock budget so the loop breaks cleanly and reaches its completion log every run; deferred contracts are picked up next run via the existing 20h-fresh skip.

## Root cause evidence
- Newest `contract_data_refresh` event: 2026-05-30T11:48 (the day it went silent).
- Newest `contract_intel.last_updated`: 2026-06-01T11:49 (~5.7h old) — data was never stale.

## Verification
- Ran the new freshness logic against live data: reports FRESH (5.65h), no alert.
- `node build.js` clean; `validate-dist` OK (461 pages).
- Held-emails branch untouched (separately remediated).

## Notes
- Scoped to only the two quality-drift / contract-intel-refresh files — no overlap with concurrent vote-feature work.