### PR TITLE
MMT Loop System v1 — shared runner + L1 (Opportunity Discovery) + L3 (Freshness)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,9 @@ Verification (ran 2026-06-10):
 - `npx vitest run tests/unit` — 350/350 pass (28 files).
 - Dry-run + CJS smoke: both specs load, all step/eval fns resolve, scorer +
   dedupe + PII eval behave.
-- Migration NOT applied (gated); `LOOP_RUNNER_SECRET` to be set by Mary.
+- Migration NOT applied (gated). Mary sets `LOOP_RUNNER_SECRET` +
+  `LOOPS_ENABLED=true` (scheduled crons no-op until the flag is on, so
+  they don't error/alert before the migration is applied).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,75 @@ Before declaring work complete, verify:
 
 ---
 
+## Sprint 2026-06-10 — MMT Loop System v1 (shared runner + L1 + L3)
+
+Triggered by Perplexity's `MMT_LOOP_SYSTEM_v1.md` proposal (8 loops on a
+GitHub-Actions/`lib/loops` stack). Translated to repo reality and shipped a
+deliberate subset. Full doc: `docs/MMT-Loop-System.md`.
+
+What shipped (one PR):
+- **Shared runner** at `netlify/functions/lib/loops/` — one declarative JSON
+  spec per loop (`specs/*.json`), a universal `runner.js` (load spec → run
+  steps → run evals → GATED publish → write `loop_runs` + `loop_evals` +
+  `ops_ledger`), and a static-`require` `registry.js` (so esbuild bundles every
+  step/eval module). Adding a loop = one JSON + its fn modules. CLI dry-run:
+  `node netlify/functions/lib/loops/runner.js --loop <name> --dry-run`.
+- **L1 Opportunity Discovery** (`loop-opportunity-discovery.js`, daily 12:00
+  UTC): SAM fetch → dedupe → USASpending incumbent enrich → quota-safe
+  heuristic score → upsert to the STAGED `loop_opportunities` table. Evals:
+  freshness, score-distribution sanity, PII scan, dup-rate.
+- **L3 Contract Tracker Freshness** (`loop-contract-freshness.js`, hourly):
+  ping unauthenticated upstreams + measure Supabase row-lag → write
+  `loop_status` → drift-alert Mary. Served publicly at `/status.json`
+  (`status.js` + netlify redirect).
+- **On-demand entry** `loop-runner.js` (secret-gated by `LOOP_RUNNER_SECRET`).
+- **Gated migration** `migrations/20260610000000_loop_infra.sql` (loop_runs,
+  loop_evals, loop_config, loop_opportunities, loop_status). NOT applied —
+  awaits Mary's approval per repo convention.
+- 12 new unit tests (`tests/unit/loops.test.js`); full suite 350/350 pass.
+
+Deliberately changed/dropped from the proposal (per Mary's "you have authority
+to change/remove bad loops" + "nothing touching podcast or newsletter"):
+- **L5 (Newsletter QA), L7 (Podcast pipeline)** — OUT. Mary handles newsletter
+  and podcast content independently.
+- **L6 (Friday Brief integrity)** — OUT. It pauses Mary's premium SEND
+  pipeline; her sends are hers to run.
+- **L4 (Agency drift)** — DROPPED as duplicative: `org-chart-monitor.js`
+  already hashes agency leadership pages and emails Mary on change. A second
+  detector would double-notify.
+- **L2 (Pursuit Score QA), L8 (Agent regression)** — DEFERRED. L2 needs Mary's
+  50-row hand-graded golden set (fabricating it would break the
+  no-fabricated-fixtures rule); L8 needs an agent registry + admin dashboard.
+
+Hard rules (do not regress):
+- **Loops stage DATA only; never write a publishable dir.** The runner has no
+  path to `content/newsletter|podcast|friday-briefs|capture-corner`. L1 writes
+  to `loop_opportunities` (separate from live `opportunity_radar`) — a human
+  promotes rows.
+- **Per-item `scorePursuit()` is NOT quota-safe for a daily loop.** It hits
+  SAM.gov per call and SAM has a small SHARED DAILY quota. L1 scores from
+  already-fetched SAM metadata + unauthenticated USASpending data instead (zero
+  extra SAM calls, $0, deterministic). Any new scheduled SAM consumer must
+  budget against the daily cap; L1 fires once/day with 5 queries — do not move
+  it to a tighter cadence. L3 deliberately does NOT live-ping SAM hourly.
+- **`registry.js` must use static `require`** — dynamic requires drop modules
+  from the Netlify bundle.
+- **Evals gate the publish step.** A `"publish": true` step only runs when every
+  eval passes; otherwise it's skipped and Mary is alerted (run still recorded).
+- **New loop = JSON spec + fn modules + registry entry + a scheduled function +
+  a `netlify.toml` schedule block + a `loop_config` seed row.** No new
+  orchestration code.
+
+Verification (ran 2026-06-10):
+- `node build.js` clean (exit 0); `validate-dist` OK (489 pages);
+  `validate-routes` ✓ (30 features).
+- `npx vitest run tests/unit` — 350/350 pass (28 files).
+- Dry-run + CJS smoke: both specs load, all step/eval fns resolve, scorer +
+  dedupe + PII eval behave.
+- Migration NOT applied (gated); `LOOP_RUNNER_SECRET` to be set by Mary.
+
+---
+
 ## Sprint 2026-05-28 (later) — Pursuit Calendar false-STALE freshness banner
 
 Mary saw `/premium/calendar` flagged "Last refreshed: May 21, 2026 (149h

--- a/docs/MMT-Loop-System.md
+++ b/docs/MMT-Loop-System.md
@@ -135,10 +135,17 @@ curl -X POST "$SITE/.netlify/functions/loop-runner?key=$LOOP_RUNNER_SECRET" \
 - `SUPABASE_URL`, `SUPABASE_SERVICE_KEY` — already set.
 - `SAM_GOV_API_KEY` — already set (L1 fetch; daily-quota shared).
 - `LOOP_RUNNER_SECRET` — **new**, gates the on-demand `loop-runner` endpoint.
+- `LOOPS_ENABLED` — **new**, must be `true` for the scheduled crons to run.
+  Off by default so the crons no-op (no failure alerts) until the gated
+  migration is applied. The manual `loop-runner` endpoint ignores this flag,
+  so you can test a loop before flipping it on.
 
 ## Deploy checklist
 
 1. Apply `migrations/20260610000000_loop_infra.sql` to production (gated).
 2. Set `LOOP_RUNNER_SECRET` in Netlify.
-3. Deploy. The two scheduled functions self-register from `netlify.toml`.
-4. Verify `/status.json` returns JSON after the first L3 run.
+3. (Optional) Smoke-test via the manual endpoint while the crons are still off:
+   `curl -X POST "$SITE/.netlify/functions/loop-runner?key=$LOOP_RUNNER_SECRET" -d '{"loop_name":"contract_tracker_freshness"}'`
+4. Set `LOOPS_ENABLED=true` to turn on the scheduled crons.
+5. Deploy. The two scheduled functions self-register from `netlify.toml`.
+6. Verify `/status.json` returns JSON after the first L3 run.

--- a/docs/MMT-Loop-System.md
+++ b/docs/MMT-Loop-System.md
@@ -1,0 +1,144 @@
+# MMT Loop System — v1 (shipped)
+
+A loop is: **trigger → fetch → reason → eval → write → alert**. Each loop is
+declared in one JSON spec; a single shared runner executes any spec. Adding a
+loop is a JSON file plus the small fn modules it references — no new
+orchestration code.
+
+This doc describes what actually shipped in v1, which is a deliberate subset of
+the original `MMT_LOOP_SYSTEM_v1.md` architecture proposal, translated to this
+repo's reality (static-HTML site + Netlify scheduled functions + Supabase, not
+the GitHub-Actions/`lib/loops` stack the proposal assumed).
+
+## Editorial boundary (non-negotiable)
+
+No loop writes to `content/newsletter/`, `content/podcast/`,
+`content/friday-briefs/`, or `content/capture-corner/`. **Loops detect and
+stage DATA only; Mary owns all editorial output and all sends.** The runner has
+no path to a publishable directory.
+
+## What shipped vs. what was skipped
+
+| Loop | Status | Why |
+|---|---|---|
+| **L1 Opportunity Discovery** | ✅ shipped | Daily SAM.gov discovery, staged for review |
+| **L3 Contract Tracker Freshness** | ✅ shipped | Hourly data-trust guard + public `/status.json` |
+| L2 Pursuit Score QA | ⏸ deferred | Needs Mary's 50-row hand-graded golden set; fabricating it would violate the repo's no-fabricated-fixtures rule. Fast-follow once the golden set exists. |
+| L4 Agency Drift | ❌ dropped | `netlify/functions/org-chart-monitor.js` already hashes agency leadership pages and emails Mary on change. A second detector would just double-notify. Future: port org-chart-monitor into this framework + add budget-delta. |
+| L5 Newsletter QA | ❌ out of scope | Mary handles newsletter content independently. |
+| L6 Friday Brief Integrity | ❌ out of scope | Pauses Mary's premium send pipeline — her sends, her call. |
+| L7 Podcast Pipeline | ❌ out of scope | Mary handles podcast content independently. |
+| L8 Agent Regression | ⏸ deferred | Larger (agent registry + admin dashboard + LLM judge); lower near-term ROI. |
+
+## Architecture (as built)
+
+```
+Netlify cron ──▶ loop-opportunity-discovery.js   (0 12 * * *)
+Netlify cron ──▶ loop-contract-freshness.js       (0 * * * *)
+manual/CI ─────▶ loop-runner.js  (secret-gated, ?key=LOOP_RUNNER_SECRET)
+                        │
+                        ▼
+        netlify/functions/lib/loops/runner.js  ── loads specs/<name>.json
+                        │                          resolves step/eval fns via registry.js
+        steps ─▶ evals ─▶ (gated) publish ─▶ loop_runs + loop_evals + ops_ledger
+                        │
+                        ▼  on fail/drift
+                   Resend → mary@missionmeetstech.com
+```
+
+- **Reasoning lives in `netlify/functions/lib/loops/`** (runner, registry,
+  specs, fetchers, transforms, enrichers, scorers, publishers, evals). The
+  Netlify functions are thin HTTP/cron entry points only.
+- **`registry.js` uses static `require`s** so Netlify's esbuild bundles every
+  step/eval module. A dynamic `require(varPath)` would drop modules from the
+  bundle.
+- **Evals gate the publish step.** A step marked `"publish": true` only runs
+  when every eval passes. On fail/drift the publish is skipped and Mary is
+  alerted; the run is still recorded.
+
+## Database
+
+`migrations/20260610000000_loop_infra.sql` (**GATED — apply only after Mary
+approves**, per repo convention). Idempotent, non-destructive:
+
+- `loop_runs` — one row per execution (status, trigger, input_hash, cost, error)
+- `loop_evals` — one row per eval per run (passed, score, threshold, details)
+- `loop_config` — enable/disable + retune a loop without a code deploy
+- `loop_opportunities` — L1 staged output (separate from live `opportunity_radar`)
+- `loop_status` — L3 source-health snapshots (served by `/status.json`)
+
+## L1 — Opportunity Discovery
+
+`specs/opportunity_discovery.json`. Daily 12:00 UTC.
+
+`fetch` (SAM.gov, 5 health-IT queries) → `dedupe` (by notice_id, dup-rate) →
+`enrich` (top-3 USASpending incumbents per agency) → `score` (quota-safe
+heuristic) → **`publish`** (upsert `loop_opportunities`, gated on evals).
+
+Evals: `freshness` (newest ≤ 72h), `score_distribution` (mean 25–85, stdev ≥ 6),
+`no_pii_leak` (zero customer emails / Stripe ids), `dup_rate` (≤ 0.4).
+
+**Why a heuristic scorer, not the premium `scorePursuit()` engine:** that engine
+hits SAM.gov on every call, and `SAM_GOV_API_KEY` has a **small shared daily
+quota** (CLAUDE.md hard rule). Scoring ~15 opportunities/day through it would
+exhaust the pool and break the on-demand tools. The L1 scorer
+(`scorers/pursuit_score.js`) scores from data already in hand — SAM metadata +
+the unauthenticated USASpending incumbent set — so it makes **zero** extra SAM
+calls, costs $0, and is deterministic. It's a triage signal to prioritize
+Mary's review of staged rows, not a published bid/no-bid verdict.
+
+L1 output lands in `loop_opportunities` for review. Nothing auto-promotes to the
+live tracker.
+
+## L3 — Contract Tracker Freshness
+
+`specs/contract_tracker_freshness.json`. Hourly.
+
+`health` (ping unauthenticated upstreams + measure Supabase row-lag per source)
+→ `snapshot` (write `loop_status`). Eval `lag_thresholds` marks any
+reachable-but-stale or non-2xx source as **drift** → alerts Mary.
+
+- **SAM.gov is not live-pinged hourly** (would burn the daily quota). SAM-backed
+  freshness is observed via row lag of the tables its crons populate.
+- Unknown lag (table/column unresolved) is treated as "unknown", never a false
+  STALE (see the CLAUDE.md false-STALE sprint).
+- `/status.json` serves the newest row per source for an uptime badge.
+
+## Running locally
+
+```bash
+# Plan a loop without touching the network or DB:
+node netlify/functions/lib/loops/runner.js --loop opportunity_discovery --dry-run
+
+# Unit tests:
+npx vitest run tests/unit/loops.test.js
+```
+
+On-demand in production (secret-gated):
+
+```bash
+curl -X POST "$SITE/.netlify/functions/loop-runner?key=$LOOP_RUNNER_SECRET" \
+  -H 'content-type: application/json' \
+  -d '{"loop_name":"contract_tracker_freshness"}'
+```
+
+## Operating the loops
+
+- **Disable without a deploy:** `update loop_config set enabled=false where loop_name='...'`.
+- **Retune cost cap:** `update loop_config set max_cost_usd=... where loop_name='...'`.
+- **Audit:** every run writes a `loop_runs` row (even dry-run/skipped), with its
+  evals in `loop_evals` and a `LOOP_PASS`/`LOOP_FAIL`/`LOOP_DRIFT` event in
+  `ops_ledger`.
+
+## Env vars (Mary sets in Netlify)
+
+- `SUPABASE_URL`, `SUPABASE_SERVICE_KEY` — already set.
+- `SAM_GOV_API_KEY` — already set (L1 fetch; daily-quota shared).
+- `LOOP_RUNNER_SECRET` — **new**, gates the on-demand `loop-runner` endpoint.
+
+## Deploy checklist
+
+1. Apply `migrations/20260610000000_loop_infra.sql` to production (gated).
+2. Set `LOOP_RUNNER_SECRET` in Netlify.
+3. Deploy. The two scheduled functions self-register from `netlify.toml`.
+4. Verify `/status.json` returns JSON after the first L3 run.

--- a/migrations/20260610000000_loop_infra.sql
+++ b/migrations/20260610000000_loop_infra.sql
@@ -1,0 +1,100 @@
+-- ============================================================
+-- 20260610000000_loop_infra.sql — MMT Loop System v1 shared schema
+--
+-- Adds the run ledger + eval store + per-loop config that the loop
+-- runner (netlify/functions/lib/loops/runner.js) writes to, plus the
+-- ISOLATED output tables for the three loops shipped in v1:
+--   L1 opportunity_discovery  -> loop_opportunities  (staged, NOT the
+--                                live opportunity_radar table — loops
+--                                stage data, a human promotes it)
+--   L3 contract_tracker_freshness -> loop_status     (source health +
+--                                lag, served at /status.json)
+--
+-- (Agency drift detection is intentionally NOT included: the existing
+--  org-chart-monitor.js already hashes agency leadership pages and
+--  alerts Mary on change. No second change-detector / table is added.)
+--
+-- GATED: do NOT apply to production until Mary approves. Idempotent
+-- (create-if-not-exists), no destructive statements, safe to re-run.
+-- ============================================================
+
+-- One row per loop execution -------------------------------------------------
+create table if not exists loop_runs (
+  id          uuid primary key default gen_random_uuid(),
+  loop_name   text not null,
+  started_at  timestamptz not null default now(),
+  ended_at    timestamptz,
+  status      text not null check (status in ('running','pass','fail','drift','skipped')),
+  trigger     text,                       -- 'cron' | 'webhook' | 'manual'
+  input_hash  text,                       -- idempotency key (hash of fetched input)
+  output_ref  text,                       -- storage path or row id of produced output
+  cost_usd    numeric(10,4) default 0,
+  error       text
+);
+create index if not exists idx_loop_runs_name_started on loop_runs(loop_name, started_at desc);
+create index if not exists idx_loop_runs_input_hash    on loop_runs(loop_name, input_hash);
+
+-- One row per eval inside a run (a run may have N evals) ----------------------
+create table if not exists loop_evals (
+  id         uuid primary key default gen_random_uuid(),
+  run_id     uuid references loop_runs(id) on delete cascade,
+  eval_name  text not null,
+  passed     boolean,
+  score      numeric,
+  threshold  numeric,
+  details    jsonb default '{}'::jsonb
+);
+create index if not exists idx_loop_evals_run on loop_evals(run_id);
+
+-- Loop config (disable / retune a loop without a code deploy) -----------------
+create table if not exists loop_config (
+  loop_name    text primary key,
+  enabled      boolean not null default true,
+  cron_expr    text,
+  alert_email  text default 'mary@missionmeetstech.com',
+  max_cost_usd numeric(10,4) not null default 1.00,
+  notes        text,
+  updated_at   timestamptz default now()
+);
+
+-- L1 staged output. Deliberately separate from opportunity_radar so a
+-- loop bug can never corrupt the live premium tracker. Mary/an importer
+-- promotes reviewed rows; the loop only ever upserts here.
+create table if not exists loop_opportunities (
+  notice_id        text primary key,
+  title            text,
+  solicitation_number text,
+  type             text,
+  agency           text,
+  naics            text,
+  set_aside        text,
+  posted_date      timestamptz,
+  response_deadline timestamptz,
+  sam_url          text,
+  incumbents       jsonb default '[]'::jsonb,   -- top USASpending incumbents on NAICS+agency
+  pursuit_score    numeric,
+  pursuit_verdict  text,
+  first_seen_at    timestamptz not null default now(),
+  last_seen_at     timestamptz not null default now(),
+  source_run_id    uuid references loop_runs(id) on delete set null
+);
+create index if not exists idx_loop_opps_score on loop_opportunities(pursuit_score desc nulls last);
+
+-- L3 source-health snapshot. /status.json reads the newest row per source.
+create table if not exists loop_status (
+  id           uuid primary key default gen_random_uuid(),
+  checked_at   timestamptz not null default now(),
+  source       text not null,             -- sam_gov | usaspending | fpds | gao
+  http_status  integer,
+  latency_ms   integer,
+  lag_hours    numeric,                   -- now - max(updated_at) of that source's rows
+  healthy      boolean,
+  run_id       uuid references loop_runs(id) on delete set null
+);
+create index if not exists idx_loop_status_source_checked on loop_status(source, checked_at desc);
+
+-- Seed config for the two v1 loops (idempotent upsert).
+insert into loop_config (loop_name, enabled, cron_expr, max_cost_usd, notes) values
+  ('opportunity_discovery',     true, '0 12 * * *', 0.75, 'L1 — SAM.gov daily discovery + dedupe + incumbent enrich + quota-safe heuristic score'),
+  ('contract_tracker_freshness',true, '0 * * * *',  0.05, 'L3 — hourly source health + lag, served at /status.json')
+on conflict (loop_name) do nothing;

--- a/netlify.toml
+++ b/netlify.toml
@@ -149,6 +149,17 @@
 [functions."protest-monitor"]
   schedule = "0 12 * * *"
 
+# MMT Loop System v1 (see docs/MMT-Loop-System.md).
+# L1 Opportunity Discovery — daily 12:00 UTC (08:00 ET). Once/day to stay
+# inside the shared SAM.gov daily quota.
+[functions."loop-opportunity-discovery"]
+  schedule = "0 12 * * *"
+
+# L3 Contract Tracker Freshness — hourly. No LLM, no SAM calls; writes the
+# loop_status snapshot that /status.json serves.
+[functions."loop-contract-freshness"]
+  schedule = "0 * * * *"
+
 [functions."score-cleanup"]
   schedule = "*/30 * * * *"
 
@@ -447,6 +458,12 @@
 
 [context.staging]
   command = "node build.js"
+
+# Public data-freshness endpoint (MMT Loop System L3)
+[[redirects]]
+  from = "/status.json"
+  to = "/.netlify/functions/status"
+  status = 200
 
 # Premium dashboard sub-page rewrites (clean URLs)
 [[redirects]]

--- a/netlify/functions/lib/loops/enrichers/usaspending_incumbents.js
+++ b/netlify/functions/lib/loops/enrichers/usaspending_incumbents.js
@@ -1,0 +1,44 @@
+// ============================================================
+// enrichers/usaspending_incumbents.js (L1 step "enrich")
+//
+// For each distinct USASpending toptier agency referenced by the deduped
+// opportunities, pulls the top-N recent contract awards (the likely
+// incumbent set on that agency) and attaches them to every opportunity
+// from that agency. USASpending is public + unauthenticated (no quota),
+// so this is free to run daily — and it is what makes the quota-safe
+// scorer's incumbent-vulnerability signal possible WITHOUT spending SAM
+// quota on per-item scoring.
+// ============================================================
+
+const { fetchAwardsByAgency } = require("../../usaspending-client");
+const { mapLimit } = require("../util");
+
+async function run(ctx, config) {
+  const items = (ctx.data.dedupe && ctx.data.dedupe.items) || [];
+  const topN = config.topN || 3;
+
+  // Unique toptier agency names present in this batch.
+  const agencies = [...new Set(items.map((i) => i._query && i._query.usaspending_agency).filter(Boolean))];
+
+  const byAgency = {};
+  await mapLimit(agencies, 3, async (agencyName) => {
+    const awards = await fetchAwardsByAgency(agencyName, { limit: topN, daysBack: 365 });
+    byAgency[agencyName] = awards.slice(0, topN).map((a) => ({
+      recipient: a.recipient,
+      value: a.value,
+      action_date: a.action_date,
+      award_id: a.award_id,
+    }));
+  });
+
+  let enrichedCount = 0;
+  for (const it of items) {
+    const agency = it._query && it._query.usaspending_agency;
+    it.incumbents = (agency && byAgency[agency]) || [];
+    if (it.incumbents.length) enrichedCount++;
+  }
+
+  return { items, agenciesEnriched: agencies.length, enrichedCount };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/evals/dup_rate.js
+++ b/netlify/functions/lib/loops/evals/dup_rate.js
@@ -1,0 +1,21 @@
+// ============================================================
+// evals/dup_rate.js
+//
+// A runaway fetcher (same solicitation pulled many times, or a paging
+// bug) shows up as a high duplicate ratio. Gate the publish on it so a
+// fetcher loop never floods the staged table.
+// ============================================================
+
+async function run(ctx, config) {
+  const maxDup = config.max_dup_rate ?? 0.4;
+  const d = ctx.data.dedupe || {};
+  const dupRate = Number(d.dupRate || 0);
+  return {
+    passed: dupRate <= maxDup,
+    score: Number(dupRate.toFixed(3)),
+    threshold: maxDup,
+    details: { raw: d.rawCount || 0, unique: d.uniqueCount || 0, dup_rate: Number(dupRate.toFixed(3)) },
+  };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/evals/freshness.js
+++ b/netlify/functions/lib/loops/evals/freshness.js
@@ -1,0 +1,36 @@
+// ============================================================
+// evals/freshness.js
+//
+// Gate: the data this run produced must be fresh. Passes if the newest
+// posted opportunity is within max_age_hours. An empty batch passes
+// vacuously (a quiet news day is not a failure) but is reported in
+// details so a sustained run of zeros is visible in the eval history.
+// ============================================================
+
+const { hoursSince } = require("../util");
+
+async function run(ctx, config) {
+  const maxAge = config.max_age_hours || 72;
+  const items = (ctx.data.dedupe && ctx.data.dedupe.items) || [];
+  const fetchErrors = (ctx.data.fetch && ctx.data.fetch.errors) || [];
+
+  if (!items.length) {
+    return {
+      passed: true,
+      score: null,
+      threshold: maxAge,
+      details: { count: 0, note: "no opportunities returned this run", fetch_errors: fetchErrors.length },
+    };
+  }
+
+  const ages = items.map((i) => hoursSince(i.posted_date));
+  const newest = Math.min(...ages);
+  return {
+    passed: newest <= maxAge,
+    score: Number(newest.toFixed(1)),
+    threshold: maxAge,
+    details: { count: items.length, newest_hours: Number(newest.toFixed(1)), fetch_errors: fetchErrors.length },
+  };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/evals/lag_thresholds.js
+++ b/netlify/functions/lib/loops/evals/lag_thresholds.js
@@ -1,0 +1,32 @@
+// ============================================================
+// evals/lag_thresholds.js (L3)
+//
+// Drift gate: any source that is reachable-but-stale (lag over its
+// threshold) or returning a non-2xx ping is "drift" from the healthy
+// baseline. Sources with unknown lag are not counted against health
+// (no false STALE). A drift result makes the run status=drift, which
+// fires the on_drift alert to Mary.
+// ============================================================
+
+async function run(ctx) {
+  const sources = (ctx.data.health && ctx.data.health.sources) || [];
+  const unhealthy = sources.filter((s) => s.healthy === false);
+
+  return {
+    passed: unhealthy.length === 0,
+    drift: unhealthy.length > 0,
+    score: unhealthy.length,
+    threshold: 0,
+    details: {
+      total: sources.length,
+      unhealthy: unhealthy.map((s) => ({
+        source: s.source,
+        lag_hours: s.lag_hours,
+        max_lag_hours: s.max_lag_hours,
+        http_status: s.http_status,
+      })),
+    },
+  };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/evals/scan_pii.js
+++ b/netlify/functions/lib/loops/evals/scan_pii.js
@@ -1,0 +1,51 @@
+// ============================================================
+// evals/scan_pii.js
+//
+// Pre-publish scan of everything this run would store. Federal
+// opportunity data is public-record and its POC emails are .gov/.mil
+// (allow-listed), so a hit here means something unexpected (a customer
+// email, a Stripe id) leaked into the pipeline — block the publish.
+//
+// Mirrors the allow-list + patterns in scripts/scan-pii.js. Pure text
+// scan: no network, no LLM.
+// ============================================================
+
+const ALLOW_EMAIL_PATTERNS = [
+  /@anthropic\.com$/i,
+  /@example\.(com|org|net)$/i,
+  /@missionmeetstech\.com$/i,
+  /@[a-z0-9.-]+\.gov$/i,
+  /@[a-z0-9.-]+\.mil$/i,
+];
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const STRIPE_RE = /\b(sub_|py_|ch_|cus_|in_|pi_)[A-Za-z0-9]{14,}/g;
+
+function isAllowedEmail(email) {
+  return ALLOW_EMAIL_PATTERNS.some((re) => re.test(email));
+}
+
+async function run(ctx) {
+  // Scan the exact objects that will be persisted.
+  const items = (ctx.data.score && ctx.data.score.items) || (ctx.data.dedupe && ctx.data.dedupe.items) || [];
+  const text = JSON.stringify(items);
+
+  const findings = [];
+  let m;
+  EMAIL_RE.lastIndex = 0;
+  while ((m = EMAIL_RE.exec(text)) !== null) {
+    if (!isAllowedEmail(m[0])) findings.push({ type: "customer_email", token: m[0] });
+  }
+  STRIPE_RE.lastIndex = 0;
+  while ((m = STRIPE_RE.exec(text)) !== null) {
+    findings.push({ type: "stripe_id", token: m[0] });
+  }
+
+  return {
+    passed: findings.length === 0,
+    score: findings.length,
+    threshold: 0,
+    details: { findings: findings.slice(0, 10), total: findings.length },
+  };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/evals/score_sanity.js
+++ b/netlify/functions/lib/loops/evals/score_sanity.js
@@ -1,0 +1,47 @@
+// ============================================================
+// evals/score_sanity.js
+//
+// Catches a stuck/degenerate scorer: a healthy batch should have a mean
+// in a plausible band and enough spread (stdev) that it isn't returning
+// one constant. With too few items to judge a distribution, it passes
+// with a note rather than firing a false alarm.
+// ============================================================
+
+const { mean, stdev } = require("../util");
+
+async function run(ctx, config) {
+  const minMean = config.min_mean ?? 25;
+  const maxMean = config.max_mean ?? 85;
+  const minStdev = config.min_stdev ?? 6;
+  const minItems = config.min_items ?? 4;
+
+  const scores = ((ctx.data.score && ctx.data.score.scores) || []).filter((n) => Number.isFinite(n));
+
+  if (scores.length < minItems) {
+    return {
+      passed: true,
+      score: scores.length ? Number(mean(scores).toFixed(1)) : null,
+      threshold: null,
+      details: { count: scores.length, note: `fewer than ${minItems} items — distribution not judged` },
+    };
+  }
+
+  const m = mean(scores);
+  const sd = stdev(scores);
+  const passed = m >= minMean && m <= maxMean && sd >= minStdev;
+  return {
+    passed,
+    score: Number(m.toFixed(1)),
+    threshold: maxMean,
+    details: {
+      count: scores.length,
+      mean: Number(m.toFixed(1)),
+      stdev: Number(sd.toFixed(1)),
+      min_mean: minMean,
+      max_mean: maxMean,
+      min_stdev: minStdev,
+    },
+  };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/fetchers/api_health.js
+++ b/netlify/functions/lib/loops/fetchers/api_health.js
@@ -1,0 +1,82 @@
+// ============================================================
+// fetchers/api_health.js (L3 step "health")
+//
+// For each configured source: optionally ping an UNAUTHENTICATED public
+// endpoint (latency + status) and/or measure row-lag (now - newest row)
+// of the Supabase table that feeds the premium Contract Tracker. A source
+// is healthy when its ping (if any) is 2xx AND its known lag is within
+// threshold. Unknown lag (table/column not resolvable) is treated as
+// "unknown", not "unhealthy" — we never fire a false STALE on a schema
+// guess (see CLAUDE.md false-STALE sprint).
+//
+// SAM.gov is intentionally NOT pinged here: it has a small shared daily
+// quota and this loop runs hourly. SAM-backed freshness is observed via
+// the row lag of the tables its crons populate.
+// ============================================================
+
+const { hoursSince } = require("../util");
+
+const CANDIDATE_COLS = ["updated_at", "last_updated", "last_seen_at", "checked_at", "created_at", "scan_date"];
+
+async function pingUrl(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 6000);
+  const t0 = Date.now();
+  try {
+    const res = await fetch(url, { method: "GET", signal: ctrl.signal, headers: { Accept: "application/json,text/html" } });
+    return { http_status: res.status, latency_ms: Date.now() - t0, ok: res.ok };
+  } catch (e) {
+    return { http_status: 0, latency_ms: Date.now() - t0, ok: false, error: String(e && e.message).slice(0, 120) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function newestRowLag(supabase, table, preferredCol) {
+  if (!supabase || !table) return { lag_hours: null };
+  const cols = [preferredCol, ...CANDIDATE_COLS].filter(Boolean);
+  for (const col of cols) {
+    try {
+      const { data, error } = await supabase.from(table).select(col).order(col, { ascending: false }).limit(1);
+      if (error) continue;
+      if (data && data[0] && data[0][col]) {
+        return { lag_hours: Number(hoursSince(data[0][col]).toFixed(1)), col };
+      }
+      // table reachable but empty
+      if (data) return { lag_hours: null, col, empty: true };
+    } catch {
+      /* try next candidate column */
+    }
+  }
+  return { lag_hours: null };
+}
+
+async function run(ctx, config) {
+  const sources = Array.isArray(config.sources) ? config.sources : [];
+  const results = [];
+
+  for (const s of sources) {
+    const ping = s.ping_url ? await pingUrl(s.ping_url) : null;
+    const lag = await newestRowLag(ctx.supabase, s.table, s.updated_col);
+
+    const pingOk = ping ? ping.ok : true; // no ping configured => not a health factor
+    const lagKnown = lag.lag_hours != null;
+    const lagOk = !lagKnown || lag.lag_hours <= (s.max_lag_hours || Infinity);
+    const healthy = pingOk && lagOk;
+
+    results.push({
+      source: s.name,
+      http_status: ping ? ping.http_status : null,
+      latency_ms: ping ? ping.latency_ms : null,
+      lag_hours: lag.lag_hours,
+      max_lag_hours: s.max_lag_hours ?? null,
+      healthy,
+      lag_known: lagKnown,
+      details: { ping_ok: pingOk, lag_ok: lagOk, lag_col: lag.col, ping_error: ping && ping.error },
+    });
+  }
+
+  return { sources: results };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/fetchers/sam_gov.js
+++ b/netlify/functions/lib/loops/fetchers/sam_gov.js
@@ -1,0 +1,57 @@
+// ============================================================
+// fetchers/sam_gov.js (L1 step "fetch")
+//
+// Runs the spec's keyword/NAICS queries against SAM.gov Opportunities
+// via the existing sam-gov-opportunities helper, tags each result with
+// the originating query (so the enricher knows which USASpending toptier
+// agency to look up), and returns a flat list of normalized rows.
+//
+// SAM.gov daily-quota note (CLAUDE.md hard rule): the SAM_GOV_API_KEY has
+// a SMALL SHARED DAILY quota. This loop runs ONCE/day with N queries
+// (5 in the v1 spec). Keep the query count low and the cadence daily so
+// L1 does not starve the on-demand tools (signal-chain, compliance-check,
+// pursuit-score) that share the same pool. Do NOT raise this to hourly.
+// ============================================================
+
+const { sam_search_opportunities } = require("../../sam-gov-opportunities");
+
+async function run(ctx, config) {
+  const queries = Array.isArray(config.queries) ? config.queries : [];
+  const windowDays = Math.max(1, Math.ceil((config.windowHours || 48) / 24));
+  const limit = config.limit || 15;
+
+  const items = [];
+  const errors = [];
+
+  for (const q of queries) {
+    try {
+      const { data } = await sam_search_opportunities({
+        keyword: q.keyword,
+        naics: q.naics,
+        agency: q.agency,
+        set_aside: q.set_aside,
+        posted_from_days_ago: windowDays,
+        limit,
+      });
+      for (const it of data.items || []) {
+        items.push({
+          ...it,
+          _query: {
+            keyword: q.keyword,
+            naics: q.naics || it.naics,
+            usaspending_agency: q.usaspending_agency || null,
+          },
+        });
+      }
+    } catch (e) {
+      // Graceful per-query failure — one bad query (or a quota 429) must
+      // not zero out the whole run. Recorded so freshness/dup evals see it.
+      errors.push({ query: q.keyword, error: String(e && e.message).slice(0, 200) });
+      ctx.log?.warn?.(`L1 sam_gov: query "${q.keyword}" failed — ${e && e.message}`);
+    }
+  }
+
+  return { items, errors, queriedAt: new Date().toISOString(), windowDays };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/publishers/opportunity_upsert.js
+++ b/netlify/functions/lib/loops/publishers/opportunity_upsert.js
@@ -1,0 +1,76 @@
+// ============================================================
+// publishers/opportunity_upsert.js (L1 step "publish" — GATED on evals)
+//
+// Upserts the scored opportunities into loop_opportunities. This is a
+// STAGED table, deliberately separate from the live opportunity_radar /
+// contract tracker: a loop bug can never corrupt the premium surface.
+// Mary (or a future importer) promotes reviewed rows. The loop only ever
+// writes here, and only when every eval passed (the runner enforces the
+// gate; this module is not called on fail/drift).
+//
+// first_seen_at is preserved across runs; only last_seen_at + score
+// fields update on a repeat sighting.
+// ============================================================
+
+async function run(ctx) {
+  const items = (ctx.data.score && ctx.data.score.items) || [];
+  const supabase = ctx.supabase;
+  if (!supabase) {
+    ctx.log?.warn?.("L1 publish: no supabase client — nothing written");
+    return { written: 0, skipped: "no_supabase" };
+  }
+  if (!items.length) {
+    ctx.outputRef = "loop_opportunities:0";
+    return { written: 0, inserted: 0, updated: 0 };
+  }
+
+  const ids = items.map((i) => i.notice_id).filter(Boolean);
+  let existing = new Set();
+  try {
+    const { data } = await supabase.from("loop_opportunities").select("notice_id").in("notice_id", ids);
+    existing = new Set((data || []).map((r) => r.notice_id));
+  } catch (e) {
+    ctx.log?.warn?.(`L1 publish: existing-id lookup failed (${e.message}) — treating all as new`);
+  }
+
+  const nowIso = new Date().toISOString();
+  const rows = items
+    .filter((i) => i.notice_id)
+    .map((i) => {
+      const base = {
+        notice_id: i.notice_id,
+        title: i.title,
+        solicitation_number: i.solicitation_number,
+        type: i.type,
+        agency: i.agency,
+        naics: i.naics || (i._query && i._query.naics) || null,
+        set_aside: i.set_aside || null,
+        posted_date: i.posted_date || null,
+        response_deadline: i.response_deadline || null,
+        sam_url: i.sam_url || null,
+        incumbents: i.incumbents || [],
+        pursuit_score: i.pursuit_score ?? null,
+        pursuit_verdict: i.pursuit_verdict || null,
+        last_seen_at: nowIso,
+        source_run_id: ctx.runId || null,
+      };
+      if (!existing.has(i.notice_id)) base.first_seen_at = nowIso;
+      return base;
+    });
+
+  let written = 0;
+  try {
+    const { error } = await supabase.from("loop_opportunities").upsert(rows, { onConflict: "notice_id" });
+    if (error) throw error;
+    written = rows.length;
+  } catch (e) {
+    // Surface as a harness error so the run is marked fail (not silently lost).
+    throw new Error(`loop_opportunities upsert failed: ${e.message}`);
+  }
+
+  const inserted = rows.filter((r) => r.first_seen_at).length;
+  ctx.outputRef = `loop_opportunities:${written}`;
+  return { written, inserted, updated: written - inserted };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/publishers/opportunity_upsert.js
+++ b/netlify/functions/lib/loops/publishers/opportunity_upsert.js
@@ -8,8 +8,11 @@
 // writes here, and only when every eval passed (the runner enforces the
 // gate; this module is not called on fail/drift).
 //
-// first_seen_at is preserved across runs; only last_seen_at + score
-// fields update on a repeat sighting.
+// first_seen_at is preserved across runs by NOT sending it in the upsert
+// payload: the column's `default now()` sets it on first insert, and an
+// ON CONFLICT update never touches a column that isn't in the payload.
+// (Sending it per-row would let a bulk upsert's column-union wipe the
+// original first_seen_at on every repeat sighting.)
 // ============================================================
 
 async function run(ctx) {
@@ -36,27 +39,25 @@ async function run(ctx) {
   const nowIso = new Date().toISOString();
   const rows = items
     .filter((i) => i.notice_id)
-    .map((i) => {
-      const base = {
-        notice_id: i.notice_id,
-        title: i.title,
-        solicitation_number: i.solicitation_number,
-        type: i.type,
-        agency: i.agency,
-        naics: i.naics || (i._query && i._query.naics) || null,
-        set_aside: i.set_aside || null,
-        posted_date: i.posted_date || null,
-        response_deadline: i.response_deadline || null,
-        sam_url: i.sam_url || null,
-        incumbents: i.incumbents || [],
-        pursuit_score: i.pursuit_score ?? null,
-        pursuit_verdict: i.pursuit_verdict || null,
-        last_seen_at: nowIso,
-        source_run_id: ctx.runId || null,
-      };
-      if (!existing.has(i.notice_id)) base.first_seen_at = nowIso;
-      return base;
-    });
+    .map((i) => ({
+      notice_id: i.notice_id,
+      title: i.title,
+      solicitation_number: i.solicitation_number,
+      type: i.type,
+      agency: i.agency,
+      naics: i.naics || (i._query && i._query.naics) || null,
+      set_aside: i.set_aside || null,
+      posted_date: i.posted_date || null,
+      response_deadline: i.response_deadline || null,
+      sam_url: i.sam_url || null,
+      incumbents: i.incumbents || [],
+      pursuit_score: i.pursuit_score ?? null,
+      pursuit_verdict: i.pursuit_verdict || null,
+      last_seen_at: nowIso,
+      source_run_id: ctx.runId || null,
+      // NOTE: first_seen_at intentionally omitted — DB default sets it on
+      // insert, ON CONFLICT update leaves it untouched.
+    }));
 
   let written = 0;
   try {
@@ -68,7 +69,7 @@ async function run(ctx) {
     throw new Error(`loop_opportunities upsert failed: ${e.message}`);
   }
 
-  const inserted = rows.filter((r) => r.first_seen_at).length;
+  const inserted = rows.filter((r) => !existing.has(r.notice_id)).length;
   ctx.outputRef = `loop_opportunities:${written}`;
   return { written, inserted, updated: written - inserted };
 }

--- a/netlify/functions/lib/loops/publishers/status_snapshot.js
+++ b/netlify/functions/lib/loops/publishers/status_snapshot.js
@@ -1,0 +1,35 @@
+// ============================================================
+// publishers/status_snapshot.js (L3 step "snapshot")
+//
+// Persists one loop_status row per source EVERY run (healthy or not — we
+// want the unhealthy state recorded too, so this is a normal step, not a
+// gated publish). The public /status.json endpoint reads the newest row
+// per source from this table.
+// ============================================================
+
+async function run(ctx) {
+  const sources = (ctx.data.health && ctx.data.health.sources) || [];
+  if (!ctx.supabase || !sources.length) {
+    return { written: 0, skipped: ctx.supabase ? "no_sources" : "no_supabase" };
+  }
+  const checkedAt = new Date().toISOString();
+  const rows = sources.map((s) => ({
+    checked_at: checkedAt,
+    source: s.source,
+    http_status: s.http_status,
+    latency_ms: s.latency_ms,
+    lag_hours: s.lag_hours,
+    healthy: s.healthy,
+    run_id: ctx.runId || null,
+  }));
+  try {
+    const { error } = await ctx.supabase.from("loop_status").insert(rows);
+    if (error) throw error;
+  } catch (e) {
+    throw new Error(`loop_status insert failed: ${e.message}`);
+  }
+  ctx.outputRef = `loop_status:${rows.length}`;
+  return { written: rows.length };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/registry.js
+++ b/netlify/functions/lib/loops/registry.js
@@ -1,0 +1,49 @@
+// ============================================================
+// registry.js — static id -> module map for loop step/eval functions.
+//
+// The runner resolves a spec's `step.fn` / `eval.fn` string (e.g.
+// "fetchers/sam_gov") through this table. We use STATIC requires on
+// purpose: Netlify's esbuild bundler follows static requires, so every
+// referenced module is included in the loop-runner function bundle.
+// A dynamic require(variablePath) would silently drop modules from the
+// bundle and fail at runtime in production.
+//
+// Every module exports `{ run(ctx, config) }`.
+//   - step modules return a value stored at ctx.data[step.id]
+//   - eval modules return { passed, score, threshold, details, drift? }
+// ============================================================
+
+const REGISTRY = {
+  // --- L1: opportunity_discovery ---
+  "fetchers/sam_gov": require("./fetchers/sam_gov"),
+  "transforms/dedupe": require("./transforms/dedupe"),
+  "enrichers/usaspending_incumbents": require("./enrichers/usaspending_incumbents"),
+  "scorers/pursuit_score": require("./scorers/pursuit_score"),
+  "publishers/opportunity_upsert": require("./publishers/opportunity_upsert"),
+  "evals/freshness": require("./evals/freshness"),
+  "evals/score_sanity": require("./evals/score_sanity"),
+  "evals/scan_pii": require("./evals/scan_pii"),
+  "evals/dup_rate": require("./evals/dup_rate"),
+
+  // --- L3: contract_tracker_freshness ---
+  "fetchers/api_health": require("./fetchers/api_health"),
+  "publishers/status_snapshot": require("./publishers/status_snapshot"),
+  "evals/lag_thresholds": require("./evals/lag_thresholds"),
+
+  // NOTE: L4 (agency drift) is intentionally NOT a loop. The existing
+  // netlify/functions/org-chart-monitor.js already hashes the canonical
+  // agency leadership pages and emails Mary on change (weekly, no
+  // auto-edit). A second drift loop would just double-notify. The future
+  // enhancement is to port org-chart-monitor INTO this framework and add
+  // budget-delta tracking — not to run two parallel change-detectors.
+};
+
+function resolve(fnId) {
+  const mod = REGISTRY[fnId];
+  if (!mod || typeof mod.run !== "function") {
+    throw new Error(`loop registry: no module with a run() for "${fnId}"`);
+  }
+  return mod.run;
+}
+
+module.exports = { REGISTRY, resolve };

--- a/netlify/functions/lib/loops/runner.js
+++ b/netlify/functions/lib/loops/runner.js
@@ -1,0 +1,283 @@
+// ============================================================
+// runner.js — universal MMT loop executor.
+//
+// One declarative JSON spec per loop (./specs/<name>.json) describes a
+// trigger, an ordered list of `steps`, a list of `evals`, and `alerts`.
+// This runner loads a spec, runs the steps, runs the evals, GATES the
+// publish step on the evals passing, writes a loop_runs row + one
+// loop_evals row per eval, and alerts Mary on fail/drift.
+//
+//   Adding a new loop  = one JSON spec + the fn modules it references
+//                        (registered in registry.js). No new orchestration.
+//
+// Editorial boundary (non-negotiable, see CLAUDE.md / MMT_LOOP_SYSTEM):
+//   No loop in this runner writes to content/newsletter, content/podcast,
+//   content/friday-briefs, or content/capture-corner. Loops detect and
+//   stage DATA only. Humans publish.
+//
+// Local dry-run (no DB writes, no network, no LLM):
+//   node netlify/functions/lib/loops/runner.js --loop opportunity_discovery --dry-run
+// ============================================================
+
+const fs = require("fs");
+const path = require("path");
+const { resolve: resolveFn } = require("./registry");
+
+const SPEC_DIR = path.join(__dirname, "specs");
+
+function loadSpec(loopName) {
+  const file = path.join(SPEC_DIR, `${loopName}.json`);
+  if (!fs.existsSync(file)) {
+    throw new Error(`loop spec not found: ${file}`);
+  }
+  const spec = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (spec.name !== loopName) {
+    throw new Error(`spec.name "${spec.name}" != requested "${loopName}"`);
+  }
+  if (!Array.isArray(spec.steps) || !spec.steps.length) {
+    throw new Error(`spec "${loopName}" has no steps`);
+  }
+  return spec;
+}
+
+async function readConfig(supabase, loopName) {
+  const fallback = { enabled: true, max_cost_usd: 1.0, alert_email: "mary@missionmeetstech.com" };
+  if (!supabase) return fallback;
+  try {
+    const { data } = await supabase
+      .from("loop_config")
+      .select("enabled, max_cost_usd, alert_email")
+      .eq("loop_name", loopName)
+      .maybeSingle();
+    return data ? { ...fallback, ...data } : fallback;
+  } catch {
+    return fallback; // config table not yet applied -> safe default
+  }
+}
+
+async function insertRun(supabase, row) {
+  if (!supabase) return null;
+  try {
+    const { data, error } = await supabase.from("loop_runs").insert(row).select("id").single();
+    if (error) throw error;
+    return data.id;
+  } catch (e) {
+    console.error(`loop runner: failed to insert loop_runs (${e.message})`);
+    return null;
+  }
+}
+
+async function updateRun(supabase, id, patch) {
+  if (!supabase || !id) return;
+  try {
+    await supabase.from("loop_runs").update(patch).eq("id", id);
+  } catch (e) {
+    console.error(`loop runner: failed to update loop_runs ${id} (${e.message})`);
+  }
+}
+
+async function insertEval(supabase, runId, name, result) {
+  if (!supabase || !runId) return;
+  try {
+    await supabase.from("loop_evals").insert({
+      run_id: runId,
+      eval_name: name,
+      passed: !!result.passed,
+      score: result.score ?? null,
+      threshold: result.threshold ?? null,
+      details: result.details || {},
+    });
+  } catch (e) {
+    console.error(`loop runner: failed to insert loop_evals (${e.message})`);
+  }
+}
+
+async function safeLogOps(supabase, event) {
+  if (!supabase) return;
+  try {
+    const { logOpsEvent } = require("../ops-ledger");
+    await logOpsEvent(supabase, event);
+  } catch (e) {
+    console.error(`loop runner: ops log failed (${e.message})`);
+  }
+}
+
+async function sendAlert(config, loopName, status, summary) {
+  try {
+    const { sendEmail } = require("../send-email");
+    const to = config.alert_email || "mary@missionmeetstech.com";
+    const failed = (summary.evals || []).filter((e) => !e.passed);
+    const lines = failed.map(
+      (e) => `  - ${e.eval_name}: score=${e.score} threshold=${e.threshold} ${JSON.stringify(e.details || {})}`,
+    );
+    await sendEmail({
+      to,
+      from: "intel@missionmeetstech.com",
+      subject: `[MMT Loop ${status.toUpperCase()}] ${loopName}`,
+      text:
+        `Loop "${loopName}" finished with status=${status}.\n\n` +
+        `Failed/triggered evals:\n${lines.join("\n") || "  (none — see run row)"}\n\n` +
+        `run_id: ${summary.runId || "n/a"}\ncost_usd: ${summary.cost?.toFixed?.(4) || 0}\n` +
+        `This is a detection-only notice. No content was published; Mary acts on it.`,
+    });
+  } catch (e) {
+    console.error(`loop runner: alert send failed (${e.message})`);
+  }
+}
+
+/**
+ * Execute a loop end to end.
+ * @param {string} loopName
+ * @param {object} [opts] { trigger, dryRun, supabase, log }
+ * @returns {Promise<object>} run summary
+ */
+async function runLoop(loopName, opts = {}) {
+  const { trigger = "manual", dryRun = false, supabase = null, log = console } = opts;
+  const spec = loadSpec(loopName);
+  const config = await readConfig(supabase, loopName);
+
+  if (!config.enabled) {
+    log.info?.(`loop "${loopName}" disabled in loop_config — skipping`);
+    await insertRun(supabase, { loop_name: loopName, status: "skipped", trigger, error: "disabled" });
+    return { loopName, status: "skipped", reason: "disabled" };
+  }
+
+  const publishSteps = spec.steps.filter((s) => s.publish === true).map((s) => s.id);
+  const workSteps = spec.steps.filter((s) => s.publish !== true);
+
+  if (dryRun) {
+    log.info?.(`\n=== DRY RUN: ${loopName} (v${spec.version || 1}) ===`);
+    log.info?.(`trigger: ${JSON.stringify(spec.trigger)}`);
+    log.info?.(`steps:`);
+    spec.steps.forEach((s) => log.info?.(`  - ${s.id} -> ${s.fn}${s.publish ? "  [gated publish]" : ""}`));
+    log.info?.(`evals (gate the publish step):`);
+    (spec.evals || []).forEach((e) => log.info?.(`  - ${e.name} -> ${e.fn}`));
+    log.info?.(`max_cost_usd: ${config.max_cost_usd}`);
+    log.info?.(`No steps executed, no network, no DB mutations.\n`);
+    // Honor the spec's gate-check: a dry run leaves exactly one ledger row.
+    await insertRun(supabase, {
+      loop_name: loopName,
+      status: "skipped",
+      trigger,
+      ended_at: new Date().toISOString(),
+      error: "dry-run",
+    });
+    return { loopName, status: "skipped", reason: "dry-run", plan: spec.steps.map((s) => s.id) };
+  }
+
+  const runId = await insertRun(supabase, { loop_name: loopName, status: "running", trigger });
+  const ctx = { loopName, trigger, dryRun, supabase, runId, config, data: {}, cost: 0, log };
+
+  try {
+    // --- work steps (everything except the gated publish) ---
+    for (const step of workSteps) {
+      if (ctx.cost > config.max_cost_usd) {
+        log.warn?.(`loop "${loopName}": cost cap ${config.max_cost_usd} exceeded before "${step.id}" — halting`);
+        await updateRun(supabase, runId, {
+          status: "skipped",
+          ended_at: new Date().toISOString(),
+          cost_usd: ctx.cost,
+          error: "cost_cap_exceeded",
+        });
+        return { loopName, status: "skipped", reason: "cost_cap", runId, cost: ctx.cost };
+      }
+      ctx.data[step.id] = await resolveFn(step.fn)(ctx, step);
+    }
+
+    // --- evals (gate the publish step) ---
+    const evalResults = [];
+    let allPassed = true;
+    let anyDrift = false;
+    for (const ev of spec.evals || []) {
+      const result = await resolveFn(ev.fn)(ctx, ev);
+      await insertEval(supabase, runId, ev.name, result);
+      evalResults.push({ eval_name: ev.name, ...result });
+      if (!result.passed) allPassed = false;
+      if (result.drift) anyDrift = true;
+    }
+
+    const status = anyDrift ? "drift" : allPassed ? "pass" : "fail";
+
+    // --- gated publish: only when every eval passes ---
+    if (status === "pass") {
+      for (const step of spec.steps.filter((s) => s.publish === true)) {
+        ctx.data[step.id] = await resolveFn(step.fn)(ctx, step);
+      }
+    } else {
+      log.warn?.(`loop "${loopName}": status=${status} — publish steps [${publishSteps.join(", ")}] SKIPPED`);
+    }
+
+    await updateRun(supabase, runId, {
+      status,
+      ended_at: new Date().toISOString(),
+      cost_usd: ctx.cost,
+      input_hash: ctx.inputHash || null,
+      output_ref: ctx.outputRef || null,
+    });
+
+    const opsType = status === "pass" ? "LOOP_PASS" : status === "drift" ? "LOOP_DRIFT" : "LOOP_FAIL";
+    await safeLogOps(supabase, {
+      event_type: opsType,
+      source_function: `loop:${loopName}`,
+      severity: status === "pass" ? "info" : status === "drift" ? "warn" : "error",
+      signature: `loop_${status}`,
+      details: { runId, cost: ctx.cost, evals: evalResults },
+    });
+
+    const summary = { loopName, status, runId, cost: ctx.cost, evals: evalResults };
+    if ((status === "fail" && spec.alerts?.on_fail) || (status === "drift" && spec.alerts?.on_drift)) {
+      await sendAlert(config, loopName, status, summary);
+    }
+    log.info?.(`loop "${loopName}" -> ${status} (cost $${ctx.cost.toFixed(4)}, run ${runId})`);
+    return summary;
+  } catch (err) {
+    await updateRun(supabase, runId, {
+      status: "fail",
+      ended_at: new Date().toISOString(),
+      cost_usd: ctx.cost,
+      error: String(err && err.message).slice(0, 1000),
+    });
+    await safeLogOps(supabase, {
+      event_type: "HARNESS_FAILURE",
+      source_function: `loop:${loopName}`,
+      severity: "error",
+      signature: "loop_threw",
+      details: { runId, error: err && err.message },
+    });
+    throw err; // surface to scheduled-fn-wrapper's dead-man switch
+  }
+}
+
+module.exports = { runLoop, loadSpec };
+
+// --- CLI -------------------------------------------------------------------
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  const get = (flag) => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const loopName = get("--loop");
+  const dryRun = argv.includes("--dry-run");
+  if (!loopName) {
+    console.error("usage: node runner.js --loop <name> [--dry-run]");
+    process.exit(2);
+  }
+  let supabase = null;
+  if (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_KEY) {
+    const { createClient } = require("@supabase/supabase-js");
+    supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  } else if (!dryRun) {
+    console.error("SUPABASE_URL/SUPABASE_SERVICE_KEY not set — only --dry-run works locally");
+    process.exit(2);
+  }
+  runLoop(loopName, { trigger: "manual", dryRun, supabase })
+    .then((s) => {
+      console.log(JSON.stringify(s, null, 2));
+      process.exit(0);
+    })
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/netlify/functions/lib/loops/scorers/pursuit_score.js
+++ b/netlify/functions/lib/loops/scorers/pursuit_score.js
@@ -1,0 +1,77 @@
+// ============================================================
+// scorers/pursuit_score.js (L1 step "score")
+//
+// QUOTA-SAFE heuristic scorer. Deliberately does NOT call the premium
+// scorePursuit() engine per opportunity: that engine hits SAM.gov on
+// every call, and SAM has a SMALL SHARED DAILY quota (CLAUDE.md hard
+// rule). Scoring ~15-20 opportunities/day through it would exhaust the
+// pool and break the on-demand tools. Instead we score from data we
+// ALREADY have in-context — SAM metadata + the USASpending incumbents the
+// enricher fetched (USASpending is unauthenticated/unquota'd) — so this
+// step costs $0, makes zero extra network calls, and is fully
+// deterministic/testable.
+//
+// The output is a triage signal to help Mary prioritize review of the
+// staged loop_opportunities, NOT a published bid/no-bid verdict.
+// ============================================================
+
+const HEALTH_IT_NAICS = new Set(["541511", "541512", "541513", "541519", "518210", "621111", "621999"]);
+const HIGH_VALUE_TERMS = [
+  "ehr", "electronic health record", "genesis", "oasis", "sewp", "cio-sp",
+  "t4ng", "vista", "interoperab", "telehealth", "ambient", "ai ", "artificial intelligence",
+];
+
+function scoreOne(item) {
+  const factors = {};
+  let score = 40;
+
+  // Response window — near-term open solicitations are the live ones.
+  const deadline = item.response_deadline ? new Date(item.response_deadline).getTime() : null;
+  if (deadline) {
+    const days = (deadline - Date.now()) / 86_400_000;
+    if (days < 0) { score -= 20; factors.window = "closed"; }
+    else if (days <= 45) { score += 15; factors.window = "near_term"; }
+    else { score += 5; factors.window = "future"; }
+  }
+
+  // Incumbent signal from USASpending — any incumbents => a recompete-ish
+  // market; a single dominant incumbent => concentrated/vulnerable.
+  const inc = item.incumbents || [];
+  if (inc.length) {
+    score += 10;
+    factors.incumbents = inc.length;
+    const vals = inc.map((i) => Number(i.value) || 0).sort((a, b) => b - a);
+    const total = vals.reduce((a, b) => a + b, 0);
+    if (total > 0 && vals[0] / total >= 0.6) { score += 10; factors.incumbent_concentration = "high"; }
+  }
+
+  if (item.set_aside) { score += 8; factors.set_aside = item.set_aside; }
+
+  const naics = (item.naics || (item._query && item._query.naics) || "").toString();
+  if (HEALTH_IT_NAICS.has(naics)) { score += 7; factors.naics_match = naics; }
+
+  const title = (item.title || "").toLowerCase();
+  if (HIGH_VALUE_TERMS.some((t) => title.includes(t))) { score += 10; factors.high_value_term = true; }
+
+  const type = (item.type || "").toLowerCase();
+  if (/solicitation|combined synopsis/.test(type)) { score += 5; factors.type = "active"; }
+  else if (/sources sought|presolicitation|special notice/.test(type)) { score += 3; factors.type = "early"; }
+
+  score = Math.max(0, Math.min(100, Math.round(score)));
+  const verdict = score >= 70 ? "PURSUE" : score >= 50 ? "QUALIFY" : score >= 35 ? "MONITOR" : "WATCH";
+  return { score, verdict, factors };
+}
+
+async function run(ctx) {
+  const items = (ctx.data.enrich && ctx.data.enrich.items) || (ctx.data.dedupe && ctx.data.dedupe.items) || [];
+  for (const it of items) {
+    const { score, verdict, factors } = scoreOne(it);
+    it.pursuit_score = score;
+    it.pursuit_verdict = verdict;
+    it.score_factors = factors;
+  }
+  // No network, no LLM => no marginal cost.
+  return { items, scored: items.length, scores: items.map((i) => i.pursuit_score) };
+}
+
+module.exports = { run, scoreOne };

--- a/netlify/functions/lib/loops/specs/contract_tracker_freshness.json
+++ b/netlify/functions/lib/loops/specs/contract_tracker_freshness.json
@@ -1,0 +1,26 @@
+{
+  "name": "contract_tracker_freshness",
+  "version": 1,
+  "description": "L3 — hourly health + row-lag check on the data sources behind the premium Contract Tracker. Writes a loop_status snapshot served at /status.json. No LLM, no SAM.gov calls (SAM has a shared daily quota; an hourly live ping would exhaust it, so SAM-backed freshness is measured via row lag instead).",
+  "trigger": { "type": "cron", "expr": "0 * * * *" },
+  "steps": [
+    {
+      "id": "health",
+      "fn": "fetchers/api_health",
+      "sources": [
+        { "name": "usaspending", "ping_url": "https://api.usaspending.gov/api/v2/references/toptier_agencies/", "table": "award_tracker", "updated_col": "created_at", "max_lag_hours": 50 },
+        { "name": "opportunity_radar", "table": "opportunity_radar", "updated_col": "created_at", "max_lag_hours": 25 },
+        { "name": "gao", "ping_url": "https://www.gao.gov/", "max_lag_hours": 168 },
+        { "name": "loop_opportunities", "table": "loop_opportunities", "updated_col": "last_seen_at", "max_lag_hours": 30 }
+      ]
+    },
+    { "id": "snapshot", "fn": "publishers/status_snapshot" }
+  ],
+  "evals": [
+    { "name": "lag_thresholds", "fn": "evals/lag_thresholds" }
+  ],
+  "alerts": {
+    "on_fail": { "email": "mary@missionmeetstech.com", "ops_event": "LOOP_FAIL" },
+    "on_drift": { "email": "mary@missionmeetstech.com", "ops_event": "LOOP_DRIFT" }
+  }
+}

--- a/netlify/functions/lib/loops/specs/opportunity_discovery.json
+++ b/netlify/functions/lib/loops/specs/opportunity_discovery.json
@@ -1,0 +1,35 @@
+{
+  "name": "opportunity_discovery",
+  "version": 1,
+  "description": "L1 — daily SAM.gov discovery for federal-health-IT opportunities, deduped, enriched with USASpending incumbents, scored with a quota-safe heuristic, staged to loop_opportunities for Mary to review.",
+  "trigger": { "type": "cron", "expr": "0 12 * * *" },
+  "steps": [
+    {
+      "id": "fetch",
+      "fn": "fetchers/sam_gov",
+      "windowHours": 48,
+      "limit": 15,
+      "queries": [
+        { "keyword": "DHA health IT", "naics": "541512", "usaspending_agency": "Department of Defense" },
+        { "keyword": "MHS GENESIS", "usaspending_agency": "Department of Defense" },
+        { "keyword": "VA electronic health record", "usaspending_agency": "Department of Veterans Affairs" },
+        { "keyword": "VA artificial intelligence health", "usaspending_agency": "Department of Veterans Affairs" },
+        { "keyword": "HHS health information technology", "naics": "541512", "usaspending_agency": "Department of Health and Human Services" }
+      ]
+    },
+    { "id": "dedupe", "fn": "transforms/dedupe" },
+    { "id": "enrich", "fn": "enrichers/usaspending_incumbents", "topN": 3 },
+    { "id": "score", "fn": "scorers/pursuit_score" },
+    { "id": "publish", "fn": "publishers/opportunity_upsert", "publish": true }
+  ],
+  "evals": [
+    { "name": "no_stale_data", "fn": "evals/freshness", "max_age_hours": 72 },
+    { "name": "score_distribution", "fn": "evals/score_sanity", "min_mean": 25, "max_mean": 85, "min_stdev": 6, "min_items": 4 },
+    { "name": "no_pii_leak", "fn": "evals/scan_pii" },
+    { "name": "dup_rate", "fn": "evals/dup_rate", "max_dup_rate": 0.4 }
+  ],
+  "alerts": {
+    "on_fail": { "email": "mary@missionmeetstech.com", "ops_event": "LOOP_FAIL" },
+    "on_drift": { "email": "mary@missionmeetstech.com", "ops_event": "LOOP_DRIFT" }
+  }
+}

--- a/netlify/functions/lib/loops/transforms/dedupe.js
+++ b/netlify/functions/lib/loops/transforms/dedupe.js
@@ -1,0 +1,40 @@
+// ============================================================
+// transforms/dedupe.js (L1 step "dedupe")
+//
+// Collapses SAM rows by notice_id (a single solicitation can match more
+// than one query), keeps the most-recently-posted instance, computes the
+// duplicate rate (the dup_rate eval gates on this — a runaway fetcher
+// loop shows up as a high dup rate), and sets ctx.inputHash for run-row
+// idempotency.
+// ============================================================
+
+const { sha256 } = require("../util");
+
+async function run(ctx) {
+  const raw = (ctx.data.fetch && ctx.data.fetch.items) || [];
+  const byId = new Map();
+
+  for (const it of raw) {
+    const id = it.notice_id || `${it.solicitation_number || it.title}`;
+    const existing = byId.get(id);
+    if (!existing) {
+      byId.set(id, it);
+      continue;
+    }
+    const a = new Date(it.posted_date || 0).getTime();
+    const b = new Date(existing.posted_date || 0).getTime();
+    if (a >= b) byId.set(id, it);
+  }
+
+  const items = [...byId.values()];
+  const rawCount = raw.length;
+  const uniqueCount = items.length;
+  const dupRate = rawCount > 0 ? (rawCount - uniqueCount) / rawCount : 0;
+
+  // Idempotency key for this run: the sorted set of notice ids.
+  ctx.inputHash = sha256(items.map((i) => i.notice_id).sort());
+
+  return { items, rawCount, uniqueCount, dupRate };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/util.js
+++ b/netlify/functions/lib/loops/util.js
@@ -1,0 +1,53 @@
+// ============================================================
+// util.js — small shared helpers for loop modules.
+// No side effects, no network, fully unit-testable.
+// ============================================================
+
+const crypto = require("crypto");
+
+// Bounded-concurrency map. Keeps heavy fan-out (e.g. pursuit scoring,
+// which itself fans out to ~5 upstream APIs per item) from stampeding
+// the upstreams or blowing the function timeout.
+async function mapLimit(items, limit, fn) {
+  const results = new Array(items.length);
+  let i = 0;
+  const workers = new Array(Math.max(1, Math.min(limit, items.length)))
+    .fill(0)
+    .map(async () => {
+      while (true) {
+        const idx = i++;
+        if (idx >= items.length) return;
+        results[idx] = await fn(items[idx], idx);
+      }
+    });
+  await Promise.all(workers);
+  return results;
+}
+
+function sha256(value) {
+  const s = typeof value === "string" ? value : JSON.stringify(value);
+  return crypto.createHash("sha256").update(s).digest("hex");
+}
+
+function hoursSince(dateLike) {
+  if (!dateLike) return Infinity;
+  const t = new Date(dateLike).getTime();
+  if (Number.isNaN(t)) return Infinity;
+  return (Date.now() - t) / 3_600_000;
+}
+
+function mean(nums) {
+  const xs = nums.filter((n) => Number.isFinite(n));
+  if (!xs.length) return 0;
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+function stdev(nums) {
+  const xs = nums.filter((n) => Number.isFinite(n));
+  if (xs.length < 2) return 0;
+  const m = mean(xs);
+  const v = xs.reduce((a, b) => a + (b - m) ** 2, 0) / (xs.length - 1);
+  return Math.sqrt(v);
+}
+
+module.exports = { mapLimit, sha256, hoursSince, mean, stdev };

--- a/netlify/functions/loop-contract-freshness.js
+++ b/netlify/functions/loop-contract-freshness.js
@@ -1,0 +1,22 @@
+// ============================================================
+// loop-contract-freshness.js — scheduled entry for L3.
+//
+// Cron '0 * * * *' (see netlify.toml). Hourly source-health + row-lag
+// check; writes a loop_status snapshot that /status.json serves. No LLM,
+// no SAM.gov calls. Wrapped with withOpsLogging for the dead-man switch.
+// ============================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { withOpsLogging } = require("./lib/scheduled-fn-wrapper");
+const { runLoop } = require("./lib/loops/runner");
+
+async function _handler() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
+    return { statusCode: 500, body: JSON.stringify({ error: "supabase env missing" }) };
+  }
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  const summary = await runLoop("contract_tracker_freshness", { trigger: "cron", supabase });
+  return { statusCode: 200, body: JSON.stringify(summary) };
+}
+
+exports.handler = withOpsLogging("loop_contract_freshness", _handler);

--- a/netlify/functions/loop-contract-freshness.js
+++ b/netlify/functions/loop-contract-freshness.js
@@ -11,6 +11,11 @@ const { withOpsLogging } = require("./lib/scheduled-fn-wrapper");
 const { runLoop } = require("./lib/loops/runner");
 
 async function _handler() {
+  // Feature flag — see loop-opportunity-discovery.js. Off until the gated
+  // loop_infra migration is applied and LOOPS_ENABLED=true is set.
+  if (process.env.LOOPS_ENABLED !== "true") {
+    return { statusCode: 200, body: JSON.stringify({ status: "skipped", reason: "LOOPS_ENABLED!=true" }) };
+  }
   if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
     return { statusCode: 500, body: JSON.stringify({ error: "supabase env missing" }) };
   }

--- a/netlify/functions/loop-opportunity-discovery.js
+++ b/netlify/functions/loop-opportunity-discovery.js
@@ -1,0 +1,26 @@
+// ============================================================
+// loop-opportunity-discovery.js — scheduled entry for L1.
+//
+// Cron '0 12 * * *' (see netlify.toml). Runs the opportunity_discovery
+// loop once a day. Wrapped with withOpsLogging so the run produces the
+// START/OK/FAILED dead-man's-switch ops events even if it throws.
+//
+// SAM.gov quota: this fires ONCE/day with the 5 queries in the spec.
+// Do not move to a tighter cadence without re-budgeting the shared SAM
+// daily quota against the on-demand tools (CLAUDE.md hard rule).
+// ============================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { withOpsLogging } = require("./lib/scheduled-fn-wrapper");
+const { runLoop } = require("./lib/loops/runner");
+
+async function _handler() {
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
+    return { statusCode: 500, body: JSON.stringify({ error: "supabase env missing" }) };
+  }
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  const summary = await runLoop("opportunity_discovery", { trigger: "cron", supabase });
+  return { statusCode: 200, body: JSON.stringify(summary) };
+}
+
+exports.handler = withOpsLogging("loop_opportunity_discovery", _handler);

--- a/netlify/functions/loop-opportunity-discovery.js
+++ b/netlify/functions/loop-opportunity-discovery.js
@@ -15,6 +15,12 @@ const { withOpsLogging } = require("./lib/scheduled-fn-wrapper");
 const { runLoop } = require("./lib/loops/runner");
 
 async function _handler() {
+  // Feature flag: stays off until Mary has applied the gated loop_infra
+  // migration and set LOOPS_ENABLED=true. Prevents this cron from erroring
+  // (and emailing failure alerts) on every run before the tables exist.
+  if (process.env.LOOPS_ENABLED !== "true") {
+    return { statusCode: 200, body: JSON.stringify({ status: "skipped", reason: "LOOPS_ENABLED!=true" }) };
+  }
   if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
     return { statusCode: 500, body: JSON.stringify({ error: "supabase env missing" }) };
   }

--- a/netlify/functions/loop-runner.js
+++ b/netlify/functions/loop-runner.js
@@ -1,0 +1,50 @@
+// ============================================================
+// loop-runner.js — on-demand HTTP entry point for the loop runner.
+//
+// Secret-gated (LOOP_RUNNER_SECRET via ?key= or x-loop-secret header).
+// Lets Mary (or a CI step) trigger a named loop out of band, including a
+// --dry-run plan. Scheduled execution does NOT go through here — each
+// loop has its own thin scheduled function (loop-opportunity-discovery,
+// loop-contract-freshness) so Netlify's cron can target it directly.
+// ============================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { runLoop } = require("./lib/loops/runner");
+
+const ALLOWED = new Set(["opportunity_discovery", "contract_tracker_freshness"]);
+
+function unauthorized() {
+  return { statusCode: 401, body: JSON.stringify({ error: "Unauthorized" }) };
+}
+
+exports.handler = async (event) => {
+  const headers = (event && event.headers) || {};
+  const qs = (event && event.queryStringParameters) || {};
+  const provided = headers["x-loop-secret"] || headers["X-Loop-Secret"] || qs.key;
+  const secret = process.env.LOOP_RUNNER_SECRET;
+  if (!secret || provided !== secret) return unauthorized();
+
+  let body = {};
+  try {
+    body = JSON.parse((event && event.body) || "{}");
+  } catch {
+    /* tolerate empty/non-JSON body; fall back to query params */
+  }
+  const loopName = body.loop_name || qs.loop;
+  if (!ALLOWED.has(loopName)) {
+    return { statusCode: 400, body: JSON.stringify({ error: "unknown loop", allowed: [...ALLOWED] }) };
+  }
+  const dryRun = body.dry_run === true || qs.dry_run === "1";
+
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
+    return { statusCode: 500, body: JSON.stringify({ error: "supabase env missing" }) };
+  }
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+
+  try {
+    const summary = await runLoop(loopName, { trigger: "manual", dryRun, supabase });
+    return { statusCode: 200, body: JSON.stringify(summary) };
+  } catch (e) {
+    return { statusCode: 500, body: JSON.stringify({ error: e.message, loop: loopName }) };
+  }
+};

--- a/netlify/functions/status.js
+++ b/netlify/functions/status.js
@@ -1,0 +1,42 @@
+// ============================================================
+// status.js — public data-freshness endpoint, served at /status.json.
+//
+// Reads the newest loop_status row per source (written hourly by the L3
+// contract_tracker_freshness loop) and returns a small JSON the site (or
+// an external uptime badge) can render. Read-only, 60s CDN cache, never
+// throws — if the table or env is missing it returns an honest "unknown".
+// ============================================================
+
+const { createClient } = require("@supabase/supabase-js");
+
+const HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "public, max-age=60",
+  "Access-Control-Allow-Origin": "*",
+};
+
+exports.handler = async () => {
+  const base = { generated_at: new Date().toISOString(), all_healthy: null, sources: [] };
+
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
+    return { statusCode: 200, headers: HEADERS, body: JSON.stringify({ ...base, note: "status store unavailable" }) };
+  }
+
+  try {
+    const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+    const { data } = await supabase
+      .from("loop_status")
+      .select("source, healthy, lag_hours, http_status, latency_ms, checked_at")
+      .order("checked_at", { ascending: false })
+      .limit(200);
+
+    const newest = new Map();
+    for (const r of data || []) if (!newest.has(r.source)) newest.set(r.source, r);
+    const sources = [...newest.values()];
+    const all_healthy = sources.length ? sources.every((s) => s.healthy !== false) : null;
+
+    return { statusCode: 200, headers: HEADERS, body: JSON.stringify({ ...base, all_healthy, sources }) };
+  } catch (e) {
+    return { statusCode: 200, headers: HEADERS, body: JSON.stringify({ ...base, note: `status error: ${e.message}` }) };
+  }
+};

--- a/tests/unit/loops.test.js
+++ b/tests/unit/loops.test.js
@@ -12,6 +12,7 @@ import scanPii from "../../netlify/functions/lib/loops/evals/scan_pii.js";
 import freshness from "../../netlify/functions/lib/loops/evals/freshness.js";
 import dupRate from "../../netlify/functions/lib/loops/evals/dup_rate.js";
 import lagThresholds from "../../netlify/functions/lib/loops/evals/lag_thresholds.js";
+import opportunityUpsert from "../../netlify/functions/lib/loops/publishers/opportunity_upsert.js";
 
 const hoursAgo = (h) => new Date(Date.now() - h * 3_600_000).toISOString();
 const daysAhead = (d) => new Date(Date.now() + d * 86_400_000).toISOString();
@@ -118,6 +119,36 @@ describe("evals", () => {
   it("dup_rate fails a runaway fetcher", async () => {
     const out = await dupRate.run({ data: { dedupe: { dupRate: 0.8, rawCount: 10, uniqueCount: 2 } } }, { max_dup_rate: 0.4 });
     expect(out.passed).toBe(false);
+  });
+
+  it("publisher never sends first_seen_at (DB default preserves it across runs)", async () => {
+    // Minimal Supabase stub capturing what the publisher would upsert.
+    let upserted = null;
+    const supabase = {
+      from() {
+        return {
+          select: () => ({ in: async () => ({ data: [{ notice_id: "A" }] }) }),
+          upsert: async (rows) => {
+            upserted = rows;
+            return { error: null };
+          },
+        };
+      },
+    };
+    const ctx = {
+      supabase,
+      runId: "run-1",
+      log: { warn() {} },
+      data: { score: { items: [
+        { notice_id: "A", title: "seen before", pursuit_score: 50 },
+        { notice_id: "B", title: "new", pursuit_score: 80 },
+      ] } },
+    };
+    const out = await opportunityUpsert.run(ctx);
+    expect(out.written).toBe(2);
+    expect(out.inserted).toBe(1); // B is new, A already existed
+    expect(upserted.every((r) => !("first_seen_at" in r))).toBe(true);
+    expect(upserted.every((r) => typeof r.last_seen_at === "string")).toBe(true);
   });
 
   it("lag_thresholds flags an unhealthy source as drift", async () => {

--- a/tests/unit/loops.test.js
+++ b/tests/unit/loops.test.js
@@ -1,0 +1,131 @@
+// Unit tests for the MMT Loop System v1 shared runner + L1/L3 modules.
+// Pure logic only — no network, no Supabase, no LLM. Guards the eval
+// gates and the quota-safe scorer against regression.
+
+import { describe, it, expect } from "vitest";
+import { runLoop, loadSpec } from "../../netlify/functions/lib/loops/runner.js";
+import { resolve } from "../../netlify/functions/lib/loops/registry.js";
+import dedupe from "../../netlify/functions/lib/loops/transforms/dedupe.js";
+import { scoreOne } from "../../netlify/functions/lib/loops/scorers/pursuit_score.js";
+import scoreSanity from "../../netlify/functions/lib/loops/evals/score_sanity.js";
+import scanPii from "../../netlify/functions/lib/loops/evals/scan_pii.js";
+import freshness from "../../netlify/functions/lib/loops/evals/freshness.js";
+import dupRate from "../../netlify/functions/lib/loops/evals/dup_rate.js";
+import lagThresholds from "../../netlify/functions/lib/loops/evals/lag_thresholds.js";
+
+const hoursAgo = (h) => new Date(Date.now() - h * 3_600_000).toISOString();
+const daysAhead = (d) => new Date(Date.now() + d * 86_400_000).toISOString();
+
+describe("spec + registry wiring", () => {
+  it("loads both v1 specs and every referenced fn resolves", () => {
+    for (const name of ["opportunity_discovery", "contract_tracker_freshness"]) {
+      const spec = loadSpec(name);
+      expect(spec.name).toBe(name);
+      for (const step of spec.steps) expect(typeof resolve(step.fn)).toBe("function");
+      for (const ev of spec.evals || []) expect(typeof resolve(ev.fn)).toBe("function");
+    }
+  });
+
+  it("loadSpec throws on unknown loop", () => {
+    expect(() => loadSpec("does_not_exist")).toThrow();
+  });
+});
+
+describe("runner dry-run", () => {
+  it("returns a skipped plan and runs no steps (no supabase)", async () => {
+    const logs = [];
+    const log = { info: (m) => logs.push(m), warn: () => {} };
+    const summary = await runLoop("opportunity_discovery", { dryRun: true, supabase: null, log });
+    expect(summary.status).toBe("skipped");
+    expect(summary.reason).toBe("dry-run");
+    expect(summary.plan).toContain("fetch");
+    expect(summary.plan).toContain("publish");
+  });
+});
+
+describe("transforms/dedupe", () => {
+  it("collapses by notice_id, computes dup rate, sets inputHash", async () => {
+    const ctx = {
+      data: {
+        fetch: {
+          items: [
+            { notice_id: "A", posted_date: hoursAgo(2) },
+            { notice_id: "A", posted_date: hoursAgo(1) },
+            { notice_id: "B", posted_date: hoursAgo(3) },
+          ],
+        },
+      },
+    };
+    const out = await dedupe.run(ctx);
+    expect(out.rawCount).toBe(3);
+    expect(out.uniqueCount).toBe(2);
+    expect(out.dupRate).toBeCloseTo(1 / 3, 5);
+    expect(ctx.inputHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe("scorers/pursuit_score (quota-safe heuristic)", () => {
+  it("scores a live, incumbent-heavy, health-IT solicitation high", () => {
+    const { score, verdict } = scoreOne({
+      title: "VA Electronic Health Record Modernization support",
+      type: "Combined Synopsis/Solicitation",
+      naics: "541512",
+      set_aside: "SDVOSB Set-Aside",
+      response_deadline: daysAhead(20),
+      incumbents: [{ value: "9000000" }, { value: "500000" }],
+    });
+    expect(score).toBeGreaterThanOrEqual(70);
+    expect(verdict).toBe("PURSUE");
+  });
+
+  it("keeps scores within 0..100 and downgrades closed solicitations", () => {
+    const { score } = scoreOne({ title: "x", response_deadline: hoursAgo(48), incumbents: [] });
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("evals", () => {
+  it("score_sanity passes a healthy spread, skips tiny batches", async () => {
+    const ok = await scoreSanity.run({ data: { score: { scores: [30, 45, 60, 72, 55] } } }, {});
+    expect(ok.passed).toBe(true);
+    const tiny = await scoreSanity.run({ data: { score: { scores: [50, 50] } } }, { min_items: 4 });
+    expect(tiny.passed).toBe(true); // too few to judge
+  });
+
+  it("score_sanity fails a stuck (zero-stdev) scorer", async () => {
+    const stuck = await scoreSanity.run({ data: { score: { scores: [50, 50, 50, 50, 50] } } }, { min_stdev: 6 });
+    expect(stuck.passed).toBe(false);
+  });
+
+  it("scan_pii allows gov POC emails, flags customer emails", async () => {
+    const clean = await scanPii.run({ data: { score: { items: [{ poc: "jane.doe@va.gov" }] } } });
+    expect(clean.passed).toBe(true);
+    const leak = await scanPii.run({ data: { score: { items: [{ poc: "someone@gmail.com" }] } } });
+    expect(leak.passed).toBe(false);
+    expect(leak.details.total).toBe(1);
+  });
+
+  it("freshness passes recent data, fails stale, passes empty vacuously", async () => {
+    const recent = await freshness.run({ data: { dedupe: { items: [{ posted_date: hoursAgo(5) }] } } }, { max_age_hours: 72 });
+    expect(recent.passed).toBe(true);
+    const stale = await freshness.run({ data: { dedupe: { items: [{ posted_date: hoursAgo(200) }] } } }, { max_age_hours: 72 });
+    expect(stale.passed).toBe(false);
+    const empty = await freshness.run({ data: { dedupe: { items: [] }, fetch: { errors: [] } } }, { max_age_hours: 72 });
+    expect(empty.passed).toBe(true);
+  });
+
+  it("dup_rate fails a runaway fetcher", async () => {
+    const out = await dupRate.run({ data: { dedupe: { dupRate: 0.8, rawCount: 10, uniqueCount: 2 } } }, { max_dup_rate: 0.4 });
+    expect(out.passed).toBe(false);
+  });
+
+  it("lag_thresholds flags an unhealthy source as drift", async () => {
+    const out = await lagThresholds.run({
+      data: { health: { sources: [{ source: "x", healthy: true }, { source: "y", healthy: false, lag_hours: 99, max_lag_hours: 25 }] } },
+    });
+    expect(out.passed).toBe(false);
+    expect(out.drift).toBe(true);
+    expect(out.details.unhealthy).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What this is

The first pass of the MMT Loop System (from Perplexity's `MMT_LOOP_SYSTEM_v1.md`), translated to this repo's reality and shipped as a focused, reviewable subset. Full doc: `docs/MMT-Loop-System.md`.

A loop is **trigger → fetch → reason → eval → write → alert**. Each loop is one declarative JSON spec; a single shared runner executes any spec. **Adding a loop = one JSON file + its small fn modules** — no new orchestration code.

## Editorial boundary (non-negotiable)

No loop writes to `content/newsletter`, `content/podcast`, `content/friday-briefs`, or `content/capture-corner`. **Loops stage DATA only; Mary owns all editorial output and all sends.** The runner has no path to a publishable directory.

## What shipped

- **Shared runner** (`netlify/functions/lib/loops/`): `runner.js` (load spec → run steps → run evals → **gated** publish → write `loop_runs` + `loop_evals` + `ops_ledger`), static-`require` `registry.js` (so Netlify's esbuild bundles every module), JSON `specs/`, and fetchers/transforms/enrichers/scorers/publishers/evals. CLI dry-run supported.
- **L1 Opportunity Discovery** (`loop-opportunity-discovery.js`, daily 12:00 UTC): SAM fetch → dedupe → USASpending incumbent enrich → quota-safe heuristic score → upsert to the **staged** `loop_opportunities` table. Evals: freshness, score-distribution sanity, PII scan, dup-rate.
- **L3 Contract Tracker Freshness** (`loop-contract-freshness.js`, hourly): ping unauthenticated upstreams + measure Supabase row-lag → `loop_status` → drift-alert Mary. Served publicly at **`/status.json`**.
- **On-demand entry** `loop-runner.js` (secret-gated by `LOOP_RUNNER_SECRET`).
- **Gated migration** `migrations/20260610000000_loop_infra.sql` — **NOT applied**, awaits Mary's approval (repo convention).
- 12 new unit tests; full suite **350/350 pass**.

## What I deliberately changed/dropped (and why)

Mary gave explicit authority to change/remove bad loops, and to **not** touch podcast or newsletter:

| Loop | Decision | Reason |
|---|---|---|
| L5 Newsletter QA, L7 Podcast | **Out** | Mary handles newsletter + podcast content independently |
| L6 Friday Brief integrity | **Out** | Pauses Mary's premium *send* pipeline — her sends, her call |
| L4 Agency drift | **Dropped** | `org-chart-monitor.js` already hashes agency pages + alerts Mary; a second detector double-notifies |
| L2 Pursuit Score QA, L8 Agent regression | **Deferred** | L2 needs Mary's 50-row hand-graded golden set (fabricating it breaks the no-fabricated-fixtures rule); L8 needs an agent registry + admin dashboard |

## Key repo-reality translations from the proposal

- **Netlify scheduled functions** (not GitHub Actions `curl` workflows) — repo convention.
- **`scorePursuit()` is NOT used per-item.** It hits SAM.gov on every call and SAM has a small **shared daily quota** (CLAUDE.md hard rule). L1's scorer works from already-fetched SAM metadata + unauthenticated USASpending data — zero extra SAM calls, $0, deterministic.
- Reuses existing `ops-ledger`, `scheduled-fn-wrapper` (dead-man switch), `sam-gov-opportunities`, `usaspending-client`.
- L1 output is **isolated** in `loop_opportunities` (separate from live `opportunity_radar`) so a loop bug can't corrupt the premium tracker.

## Verification

- `node build.js` clean (exit 0); `validate-dist` OK (489 pages); `validate-routes` ✓ (30 features).
- `npx vitest run tests/unit` → **350/350** (28 files).

## Before this can run in production (Mary's call)

1. Apply `migrations/20260610000000_loop_infra.sql` (gated).
2. Set `LOOP_RUNNER_SECRET` in Netlify.
3. Deploy — the two scheduled functions self-register from `netlify.toml`; verify `/status.json` after the first L3 run.

https://claude.ai/code/session_01UfEkVEJVGnwenskuXuyc6E

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfEkVEJVGnwenskuXuyc6E)_