### PR TITLE
fix(marketpulse): v4 report markdown mangled into tables; delivery state lied on failed/held sends

### DIFF
--- a/netlify/functions/generate-tactical-brief-background.js
+++ b/netlify/functions/generate-tactical-brief-background.js
@@ -1835,6 +1835,12 @@ CRITICAL: An honest "we found limited data" is infinitely more valuable than 18 
   </div>
 </div>`;
 
+    // Track whether the customer email actually went out. The workflow_state
+    // transition below MUST reflect this — a failed or held send must NOT be
+    // recorded as email_sent/delivered (the bug that left a customer's order
+    // stamped "delivered" while the report never reached them).
+    let emailSent = false;
+    let emailHeld = false;
     if (shouldHoldEmail()) {
       if (_supabase) {
         await holdEmail(_supabase, email, deliverySubject, deliveryHtml, {
@@ -1844,7 +1850,8 @@ CRITICAL: An honest "we found limited data" is infinitely more valuable than 18 
           attachment_size_kb: 0,
         });
       }
-      console.log(`[degraded] Delivery email held for ${email}`);
+      emailHeld = true;
+      console.log(`[degraded] Delivery email held for ${email} — order stays email_queued until the email worker sends it`);
     } else {
       const deliveryResult = await sendEmail({
         to: email,
@@ -1852,6 +1859,7 @@ CRITICAL: An honest "we found limited data" is infinitely more valuable than 18 
         html: deliveryHtml,
         from: "Mission Meets Tech <noreply@missionmeetstech.com>",
       });
+      emailSent = !!deliveryResult.success;
 
       if (!deliveryResult.success) {
         console.error("Delivery email failed:", deliveryResult.error);
@@ -1876,9 +1884,17 @@ CRITICAL: An honest "we found limited data" is infinitely more valuable than 18 
       from: "Mission Meets Tech <noreply@missionmeetstech.com>",
     });
 
-    // State: email_sent → delivered
-    await _transition("email_sent");
-    await _transition("delivered");
+    // State: advance only to reflect what actually happened.
+    //  - send succeeded → email_sent → delivered
+    //  - send failed     → email_failed (reconcile/replay can retry; never "delivered")
+    //  - held (degraded) → stay email_queued; the scheduled email worker owns
+    //    the real send. report_url is set, so reconcile skips re-replay.
+    if (emailSent) {
+      await _transition("email_sent");
+      await _transition("delivered");
+    } else if (!emailHeld) {
+      await _transition("email_failed", { reason: "customer_delivery_email_send_failed" });
+    }
 
     // Submit to customer approval queue for portal visibility
     try {

--- a/netlify/functions/generate-tactical-brief-background.js
+++ b/netlify/functions/generate-tactical-brief-background.js
@@ -1681,15 +1681,21 @@ CRITICAL: An honest "we found limited data" is infinitely more valuable than 18 
     }
 
     // === v4 STOP HANDLER ===
-    // If v4 self-audit triggered a stop condition, email the diagnostic
-    // to Mary (not the customer), log the event, and return without
-    // rendering/sending the report.
+    // Policy (2026-06-15, Mary): a quality-gate stop must NOT dead-end the
+    // order. Previously this path emailed the customer "you'll have it within
+    // 24 hours," transitioned to quality_fail, and returned WITHOUT delivering
+    // — but nothing ever fulfilled that promise, so orders stranded until a
+    // human manually replayed them. Now we DELIVER the report flagged with a
+    // prominent verification caveat (consistent with the soft-fail path). The
+    // stop is still logged for ops, and Mary still gets the diagnostic on
+    // catastrophic failures.
+    let v4DeliveredWithCaveat = false;
     if (V4_ON && v4Stop) {
       await logOpsEvent(_supabase, {
         event_type: "MARKETPULSE_V4_STOP",
         source_function: "generate-tactical-brief-background",
-        severity: "error",
-        signature: "v4_self_audit_stop",
+        severity: "warning",
+        signature: "v4_self_audit_stop_delivered_with_caveat",
         affected_entity: session_id,
         details: {
           email,
@@ -1697,14 +1703,13 @@ CRITICAL: An honest "we found limited data" is infinitely more valuable than 18 
           score: v4Score ? v4Score.total : null,
           band: v4Score ? v4Score.band : null,
           failed_checks: v4Audit ? v4Audit.checks.filter(c => !c.passed).map(c => `#${c.id} ${c.label}`) : [],
+          disposition: "delivered_with_caveat",
         },
       });
-      // Diagnostic email to Mary — silenced by default 2026-04-29 to stop the
-      // noise stream from Tier-B-only failures (e.g. score 84/100 with one
-      // unsourced row). The ops_events MARKETPULSE_V4_STOP entry above is the
-      // permanent durable signal; she can query it any time. Email fires only
-      // for catastrophic failures (score < 70 OR more than 3 failed checks)
-      // OR when MARKETPULSE_V4_DIAGNOSTIC_EMAIL=true is explicitly set.
+      // Diagnostic email to Mary — fires only for catastrophic failures
+      // (score < 70 OR more than 3 failed checks) OR when
+      // MARKETPULSE_V4_DIAGNOSTIC_EMAIL=true. The customer no longer receives a
+      // "still working" email; they get the report with a verification caveat.
       const v4FailedCheckCount = v4Audit ? v4Audit.checks.filter((c) => !c.passed).length : 0;
       const v4Critical = (v4Score && typeof v4Score.total === "number" && v4Score.total < 70) || v4FailedCheckCount > 3;
       const v4DiagnosticEnabled = String(process.env.MARKETPULSE_V4_DIAGNOSTIC_EMAIL || "").toLowerCase() === "true";
@@ -1712,24 +1717,13 @@ CRITICAL: An honest "we found limited data" is infinitely more valuable than 18 
         try {
           await sendEmail({
             to: "mary@missionmeetstech.com",
-            subject: `[MarketPulse v4] STOP — ${name} (${email}) — score ${v4Score ? v4Score.total : "?"}/100`,
+            subject: `[MarketPulse v4] STOP (delivered w/ caveat) — ${name} (${email}) — score ${v4Score ? v4Score.total : "?"}/100`,
             html: `<pre style="font-family:ui-monospace,monospace;white-space:pre-wrap;background:#f3f4f6;padding:16px;border-radius:8px;">${(v4Diagnostic || "").replace(/[<&>]/g, c => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]))}</pre>`,
             from: "Mission Meets Tech <noreply@missionmeetstech.com>",
           });
         } catch (_) { /* non-blocking */ }
       }
-
-      // Customer notification: a gentle "we need more time" rather than the raw diagnostic
-      try {
-        await sendEmail({
-          to: email,
-          subject: `We're still working on your MarketPulse Report — ${(topic || "").substring(0, 50)}`,
-          html: `<p>Hi ${(name || "there").split(" ")[0]},</p><p>Our audit flagged that your MarketPulse report needs additional primary-source verification before we deliver it. We don't ship reports that can't be fully grounded in Tier 1 federal sources.</p><p>Our team is working on closing the gaps. You'll have your report within 24 hours.</p><p>— Mission Meets Tech</p>`,
-          from: "Mission Meets Tech <noreply@missionmeetstech.com>",
-        });
-      } catch (_) { /* non-blocking */ }
-      await _transition("quality_fail");
-      return { statusCode: 200, body: JSON.stringify({ success: false, v4_stop: true, score: v4Score ? v4Score.total : null }) };
+      v4DeliveredWithCaveat = true;
     }
 
     await _transition("pdf_started");
@@ -1754,6 +1748,14 @@ CRITICAL: An honest "we found limited data" is infinitely more valuable than 18 
       reportScore: V4_ON ? undefined : reportScore,
     });
     console.log(`Report HTML generated: ${Math.round(reportHtmlContent.length / 1024)}KB`);
+
+    // If the v4 self-audit hit a stop condition, we still deliver (per policy)
+    // but prepend a prominent verification caveat so the customer knows to
+    // confirm flagged items against primary sources before acting.
+    if (v4DeliveredWithCaveat) {
+      const caveat = `<div style="background:#FFF4E5;border:1px solid #F0C36D;border-radius:8px;padding:14px 18px;margin:0 0 20px;font-size:13px;color:#8A5A00;line-height:1.55;"><strong>&#9888; Verification caveat.</strong> Our automated audit flagged one or more items in this report that warrant primary-source confirmation before you act on them. Treat figures, contract identifiers, and dates as directional and verify them against the cited .gov sources. Any specific items are listed under Verification Notes.</div>`;
+      reportHtmlContent = reportHtmlContent.replace(/(<div class="content">)/i, `$1\n${caveat}`);
+    }
 
     // === MarketPulse v2: subscriber-context post-generation validation ===
     // If no subscriber_context was loaded, prepend the no-context banner.

--- a/netlify/functions/lib/report-html-renderer.js
+++ b/netlify/functions/lib/report-html-renderer.js
@@ -5,6 +5,8 @@
 // print cleanly, and attach to emails. Replaces PDFKit.
 // ============================================================
 
+const { marked } = require("marked");
+
 function esc(str) {
   if (!str) return "";
   return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -37,8 +39,10 @@ const BASE_STYLES = `
   .header-title { font-size: 24px; font-weight: 700; color: #FFFFFF; letter-spacing: 0.5px; }
   .header-sub { font-size: 13px; color: rgba(255,255,255,0.6); margin-top: 4px; }
   .content { padding: 32px 40px; }
+  h1 { font-size: 22px; font-weight: 700; color: #0f172a; margin: 28px 0 12px; padding-bottom: 6px; border-bottom: 2px solid #457B9D; }
   h2 { font-size: 18px; font-weight: 700; color: #0f172a; margin: 28px 0 12px; padding-bottom: 6px; border-bottom: 2px solid #457B9D; }
   h3 { font-size: 15px; font-weight: 600; color: #334155; margin: 20px 0 8px; }
+  blockquote { border-left: 3px solid #457B9D; background: #f8fafc; margin: 12px 0; padding: 8px 16px; color: #334155; font-size: 14px; }
   p { margin: 0 0 12px; font-size: 14px; }
   ul, ol { margin: 0 0 12px; padding-left: 24px; font-size: 14px; }
   li { margin-bottom: 4px; }
@@ -331,69 +335,16 @@ function renderMarketPulseHTML(data) {
 
   body += `<hr style="border:none;border-top:1px solid #e2e8f0;margin:20px 0;">`;
 
-  // Render synthesis markdown-ish content
-  const lines = (synthesis || "").split("\n");
-  let inTable = false;
-  let tableRows = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
-    if (!trimmed) { body += "<br>"; continue; }
-
-    // Skip internal debug
-    if (/^Classification:/i.test(trimmed)) continue;
-    if (/^METHODOLOGY APPENDIX \(Auto-Generated\)/i.test(trimmed)) continue;
-
-    // Tables
-    if (/^\|.*\|$/.test(trimmed)) {
-      if (!inTable) { inTable = true; tableRows = []; }
-      tableRows.push(trimmed);
-      // Check if next line is not a table
-      if (i + 1 >= lines.length || !/^\|.*\|$/.test(lines[i + 1].trim())) {
-        body += renderMarkdownTable(tableRows);
-        inTable = false;
-        tableRows = [];
-      }
-      continue;
-    }
-
-    // Pipeline entries
-    if (trimmed.startsWith("CONTRACT/OPPORTUNITY:")) {
-      const entry = [trimmed];
-      while (i + 1 < lines.length && /^(Agency|Contract\s*#|NAICS|Set-Aside|Estimated Value|Incumbent|Status|Timeline|Source|SDVOSB Relevance):/.test(lines[i + 1].trim())) {
-        entry.push(lines[++i].trim());
-      }
-      body += renderPipelineEntry(entry);
-      continue;
-    }
-
-    // Section headers
-    if (/^#{1,3}\s/.test(trimmed)) {
-      const text = trimmed.replace(/^#+\s*/, "");
-      body += `<h2>${esc(text)}</h2>`;
-      continue;
-    }
-    if (/^[A-Z][A-Z &\/\-]+$/.test(trimmed) && trimmed.length > 3 && trimmed.length < 80) {
-      body += `<h2>${esc(trimmed)}</h2>`;
-      continue;
-    }
-
-    // Subheaders
-    if (/^###?\s/.test(trimmed)) {
-      body += `<h3>${esc(trimmed.replace(/^#+\s*/, ""))}</h3>`;
-      continue;
-    }
-
-    // Lists
-    if (/^\d+\.\s/.test(trimmed) || /^[-•]\s/.test(trimmed)) {
-      const text = trimmed.replace(/^[-•]\s*/, "").replace(/^\d+\.\s*/, "");
-      body += `<ul><li>${renderInlineBold(text)}</li></ul>`;
-      continue;
-    }
-
-    // Paragraphs
-    body += `<p>${renderInlineBold(trimmed)}</p>`;
-  }
+  // Render synthesis markdown → HTML via marked (GFM).
+  //
+  // The prior hand-rolled line loop mangled real model output: a leading
+  // markdown table with no |---| separator row promoted the first DATA row to
+  // <th>, then absorbed the entire report body into <td> cells, so headings
+  // (##) and bold (**) shipped to customers as literal text. marked handles
+  // headings, bold, lists, and tables correctly. We pre-extract the structured
+  // CONTRACT/OPPORTUNITY pipeline blocks into styled cards (which are not
+  // markdown) and inject any missing table separator rows first.
+  body += renderSynthesisBody(synthesis || "");
 
   // Citations
   if (citations && citations.length > 0) {
@@ -415,6 +366,86 @@ function renderMarketPulseHTML(data) {
 }
 
 // --- Helpers ---
+
+// Render the MarketPulse synthesis body (markdown) to HTML using marked (GFM),
+// after (1) dropping internal debug lines, (2) extracting structured
+// CONTRACT/OPPORTUNITY pipeline blocks into styled cards, and (3) repairing
+// markdown tables the model emitted without a |---| separator row.
+function renderSynthesisBody(synthesis) {
+  marked.setOptions({ gfm: true, breaks: false });
+
+  // 1. Drop internal-debug lines the old loop also skipped.
+  let text = String(synthesis || "")
+    .split("\n")
+    .filter((l) => !/^\s*Classification:/i.test(l) && !/^METHODOLOGY APPENDIX \(Auto-Generated\)/i.test(l))
+    .join("\n");
+
+  // 2. Extract CONTRACT/OPPORTUNITY pipeline blocks (plain label: value lines,
+  //    not markdown) into styled cards; leave a placeholder for marked.
+  const cards = [];
+  {
+    const lines = text.split("\n");
+    const out = [];
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].trim().startsWith("CONTRACT/OPPORTUNITY:")) {
+        const entry = [lines[i].trim()];
+        while (i + 1 < lines.length && /^(Agency|Contract\s*#|NAICS|Set-Aside|Estimated Value|Incumbent|Status|Timeline|Source|SDVOSB Relevance|Strategic Significance):/i.test(lines[i + 1].trim())) {
+          entry.push(lines[++i].trim());
+        }
+        const token = `@@PIPELINE_CARD_${cards.length}@@`;
+        cards.push(renderPipelineEntry(entry));
+        out.push("", token, "");
+      } else {
+        out.push(lines[i]);
+      }
+    }
+    text = out.join("\n");
+  }
+
+  // 3. Inject missing GFM table separator rows.
+  text = insertMissingTableSeparators(text);
+
+  // 4. Render markdown.
+  let html = marked.parse(text);
+
+  // 5. Defense-in-depth: marked passes raw HTML through, so strip script/iframe
+  //    and inline event handlers a crafted topic/model echo could introduce.
+  html = html
+    .replace(/<\/?(?:script|iframe|object|embed)\b[^>]*>/gi, "")
+    .replace(/\son\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+    .replace(/javascript:/gi, "");
+
+  // 6. Swap pipeline cards back (placeholder may be wrapped in <p>…</p>).
+  html = html
+    .replace(/<p>\s*@@PIPELINE_CARD_(\d+)@@\s*<\/p>/g, (_, n) => cards[Number(n)] || "")
+    .replace(/@@PIPELINE_CARD_(\d+)@@/g, (_, n) => cards[Number(n)] || "");
+
+  return html;
+}
+
+// A contiguous run of |…| lines whose second line is NOT a |---| separator is
+// not a valid GFM table — marked renders it as literal text. Treat the first
+// row as the header and inject a separator so it renders as a table (and the
+// first row stops being misread as data).
+function insertMissingTableSeparators(text) {
+  const lines = text.split("\n");
+  const isPipe = (l) => /^\s*\|.*\|\s*$/.test(l);
+  const isSep = (l) => /-/.test(l) && /^\s*\|?[\s:|-]+\|?\s*$/.test(l);
+  const out = [];
+  for (let i = 0; i < lines.length; i++) {
+    out.push(lines[i]);
+    if (isPipe(lines[i])) {
+      const prevWasPipe = i > 0 && isPipe(lines[i - 1]);
+      const next = lines[i + 1] || "";
+      if (!prevWasPipe && isPipe(next) && !isSep(next)) {
+        let n = lines[i].trim().replace(/^\|/, "").replace(/\|$/, "").split("|").length;
+        if (!Number.isFinite(n) || n < 1) n = 1;
+        out.push("|" + Array(n).fill("---").join("|") + "|");
+      }
+    }
+  }
+  return out.join("\n");
+}
 
 function renderMarkdownTable(rows) {
   const parsed = rows.map((r) => r.split("|").filter((c) => c.trim()).map((c) => c.trim()));

--- a/tests/unit/marketpulse-delivery-state.test.js
+++ b/tests/unit/marketpulse-delivery-state.test.js
@@ -11,7 +11,16 @@
 // is reachable from "email_queued".
 
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { MARKETPULSE_TRANSITIONS } from "../../netlify/functions/lib/workflow-state.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GENERATE_SRC = readFileSync(
+  resolve(HERE, "../../netlify/functions/generate-tactical-brief-background.js"),
+  "utf8",
+);
 
 describe("MarketPulse delivery state invariants", () => {
   it("email_queued can go to email_sent OR email_failed", () => {
@@ -33,5 +42,23 @@ describe("MarketPulse delivery state invariants", () => {
   it("email_failed routes to retry, not to delivered", () => {
     expect(MARKETPULSE_TRANSITIONS.email_failed).toContain("retry_pending");
     expect(MARKETPULSE_TRANSITIONS.email_failed).not.toContain("delivered");
+  });
+});
+
+describe("v4 quality-gate stop delivers with a caveat (no dead-end)", () => {
+  it("no longer sends the 'still working / 24 hours' dead-end customer email", () => {
+    expect(GENERATE_SRC).not.toContain("We're still working on your MarketPulse Report");
+    expect(GENERATE_SRC).not.toContain("You'll have your report within 24 hours");
+  });
+
+  it("flags the order for delivery-with-caveat instead of returning at the stop", () => {
+    expect(GENERATE_SRC).toContain("v4DeliveredWithCaveat = true");
+    expect(GENERATE_SRC).toContain("Verification caveat");
+    // the old hard-stop return inside the v4-stop block is gone
+    expect(GENERATE_SRC).not.toContain('success: false, v4_stop: true');
+  });
+
+  it("research_completed can advance to pdf_started (the deliver path the stop now falls through to)", () => {
+    expect(MARKETPULSE_TRANSITIONS.research_completed).toContain("pdf_started");
   });
 });

--- a/tests/unit/marketpulse-delivery-state.test.js
+++ b/tests/unit/marketpulse-delivery-state.test.js
@@ -1,0 +1,37 @@
+// Guard for the 2026-06-15 fix: a MarketPulse order must not be recorded as
+// email_sent/delivered unless the customer email actually went out.
+//
+// generate-tactical-brief-background now branches on the real send result:
+//   send ok   -> email_sent -> delivered
+//   send fail -> email_failed   (never delivered)
+//   held      -> stays email_queued (email worker owns the real send)
+//
+// This test pins the state-machine invariants that make that branching safe:
+// you cannot reach "delivered" except through "email_sent", and "email_failed"
+// is reachable from "email_queued".
+
+import { describe, it, expect } from "vitest";
+import { MARKETPULSE_TRANSITIONS } from "../../netlify/functions/lib/workflow-state.js";
+
+describe("MarketPulse delivery state invariants", () => {
+  it("email_queued can go to email_sent OR email_failed", () => {
+    expect(MARKETPULSE_TRANSITIONS.email_queued).toContain("email_sent");
+    expect(MARKETPULSE_TRANSITIONS.email_queued).toContain("email_failed");
+  });
+
+  it("delivered is reachable ONLY from email_sent", () => {
+    const canReachDelivered = Object.entries(MARKETPULSE_TRANSITIONS)
+      .filter(([, next]) => next.includes("delivered"))
+      .map(([from]) => from);
+    expect(canReachDelivered).toEqual(["email_sent"]);
+  });
+
+  it("email_queued cannot jump straight to delivered", () => {
+    expect(MARKETPULSE_TRANSITIONS.email_queued).not.toContain("delivered");
+  });
+
+  it("email_failed routes to retry, not to delivered", () => {
+    expect(MARKETPULSE_TRANSITIONS.email_failed).toContain("retry_pending");
+    expect(MARKETPULSE_TRANSITIONS.email_failed).not.toContain("delivered");
+  });
+});

--- a/tests/unit/report-renderer.test.js
+++ b/tests/unit/report-renderer.test.js
@@ -1,0 +1,98 @@
+// Unit tests for report-html-renderer MarketPulse markdown rendering.
+//
+// Regression guard for the 2026-06-15 defect: v4 synthesis whose body led
+// with a separator-less markdown table was swallowed into <td> cells by the
+// hand-rolled line loop, shipping literal "##" headings and "**bold**" markers
+// to customers. The renderer now uses marked (GFM) with table repair + a
+// pipeline-card carve-out.
+
+import { describe, it, expect } from "vitest";
+import { renderMarketPulseHTML, renderProposalPulseHTML } from "../../netlify/functions/lib/report-html-renderer.js";
+
+const V4_SYNTH = [
+  // leading "source table" the v4 model emits with NO |---| separator row
+  "| IHS Telehealth IDIQ | 75H70622D00023 | FY2022 | AVEL ECARE LLC |",
+  "| DHA MHS GENESIS | Multiple PIIDs | 2015 | Leidos |",
+  "",
+  "## Strategic Thesis",
+  "",
+  "The market is **shifting** to optimization; SB share grew to 28%.",
+  "",
+  "## Pipeline Intelligence",
+  "",
+  "CONTRACT/OPPORTUNITY: IHS Tele-Behavioral Health",
+  "Agency: Indian Health Service",
+  "Status: Recompete",
+  "Source: https://sam.gov/opp/123",
+  "",
+  "### Detail",
+  "",
+  "- first **bold** bullet",
+  "- second bullet",
+  "",
+  "| Vehicle | Ceiling |",
+  "|---|---|",
+  "| OASIS+ | $60B |",
+].join("\n");
+
+function render(synth) {
+  return renderMarketPulseHTML({
+    name: "Test User", company: "Acme", topic: "Test topic", audience: "Internal",
+    synthesis: synth, citations: ["https://ihs.gov"], generatedAt: "2026-06-15T00:00:00Z",
+  });
+}
+
+describe("renderMarketPulseHTML — markdown rendering", () => {
+  const html = render(V4_SYNTH);
+
+  it("ships no literal markdown heading or bold markers in the body", () => {
+    // Strip the cover topic / sources which legitimately echo user text.
+    const body = html.split("Research Topic")[1] || html;
+    expect(body).not.toMatch(/(^|>)\s*##\s/);
+    expect(/\*\*[^*]/.test(body)).toBe(false);
+  });
+
+  it("renders ## as <h2> and ### as <h3>", () => {
+    expect(html).toMatch(/<h2[^>]*>Strategic Thesis<\/h2>/);
+    expect(html).toMatch(/<h3[^>]*>Detail<\/h3>/);
+  });
+
+  it("renders **bold** as <strong>", () => {
+    expect(html).toContain("<strong>shifting</strong>");
+  });
+
+  it("repairs a separator-less leading table into a real <table> (no literal pipes leak)", () => {
+    expect(html).not.toContain("| IHS Telehealth");
+    expect((html.match(/<table>/g) || []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("preserves CONTRACT/OPPORTUNITY blocks as styled pipeline cards", () => {
+    expect(html).toContain("pipeline-card");
+    expect(html).toContain("IHS Tele-Behavioral Health");
+    // and does not leave the placeholder token behind
+    expect(html).not.toMatch(/@@PIPELINE_CARD_\d+@@/);
+  });
+
+  it("strips script/iframe and inline event handlers (defense-in-depth)", () => {
+    const evil = render("## Hi\n\n<script>alert(1)</script>\n\n<img src=x onerror=alert(2)>\n\n[x](javascript:alert(3))");
+    expect(evil.toLowerCase()).not.toContain("<script");
+    expect(evil).not.toMatch(/onerror\s*=/i);
+    expect(evil.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("renders a well-formed GFM table normally", () => {
+    expect(html).toMatch(/<th>Vehicle<\/th>/);
+    expect(html).toContain("<td>OASIS+</td>");
+  });
+});
+
+describe("renderProposalPulseHTML — unaffected by the MarketPulse change", () => {
+  it("still renders a basic scorecard", () => {
+    const h = renderProposalPulseHTML({
+      scorecard: { verdict: "PASS", scores: [{ title: "Mission Relevance", grade: "B+", assessment: "ok" }] },
+      overallGrade: "B+", documentLabel: "Proposal", fileName: "x.docx",
+    });
+    expect(h).toContain(">PASS<");
+    expect(h).toContain("Mission Relevance");
+  });
+});


### PR DESCRIPTION
## Why

Triggered by recovering a customer MarketPulse order (Avel eCare / Mark Johnston) that the system recorded as **delivered** but the customer never received. Investigation surfaced three defects affecting MarketPulse reliability platform-wide.

## What was wrong + fix

**1. Report render (customer-facing quality).** `renderMarketPulseHTML` used a hand-rolled line loop. The v4 synthesis body leads with a markdown "Source Table" the model emits **without** a `|---|` separator row. The loop promoted the first *data* row to `<th>` and swallowed the entire body — `##` headings, `**bold**`, prose — into `<td>` cells where markdown is never converted. Recent v4 reports shipped with 100+ literal `**` and raw `##`. → Render via **marked (GFM)**; pre-extract `CONTRACT/OPPORTUNITY` pipeline cards; repair separator-less tables; strip script/iframe/event handlers. ProposalPulse untouched.

**2. Delivery state lied.** `email_sent → delivered` ran **unconditionally**, even on send failure or held/degraded mode — orders stamped `delivered` while the customer got nothing. → Branch on the real result: success → `delivered`; failure → `email_failed` (+`DELIVERY_FAILURE`, never "delivered"); held → stays `email_queued`.

**3. Quality-gate stop dead-ended orders (the recurring issue).** The v4 self-audit STOP emailed the customer "you'll have your report within 24 hours," went to `quality_fail`, and returned **without delivering** — with no process to ever fulfill that promise. Orders stranded until a human manually replayed (exactly what happened to the Avel order). → Per product decision: **deliver with a verification caveat** instead. Log the stop as `warning`/`delivered_with_caveat`, keep Mary's diagnostic on catastrophic failures, drop the dead-end customer email, fall through to normal delivery, and prepend a caveat banner to the report.

## Tests / verification

- `report-renderer.test.js` (8): no raw markdown, heading/bold/list/table rendering, separator-less table repair, pipeline-card carve-out, XSS stripping, ProposalPulse unaffected.
- `marketpulse-delivery-state.test.js` (7): `delivered` reachable only via `email_sent`; dead-end email/return removed; deliver-with-caveat path wired.
- Full suite **366/366 pass**. `build.js` clean, `validate-dist` OK (500 pages). generate fn syntax-checks clean.

## Operational notes (not code in this PR)

- The customer's order was regenerated with a clean render, re-stored (hosted link serves corrected report), and **re-sent through the standard delivery email** — Resend confirms accepted by the recipient mail server.
- `MARKETPULSE_V4` is currently **off**, so fixes #1 and #3 are dormant until V4 is re-enabled; #2 is always live.
- ProposalPulse verified healthy out-of-band: functions load, full scorecard renders, last 30 days 4/4 assessments complete, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)