### PR TITLE
Fix Netlify header-rules advisory: drop invalid bare-glob rules from _headers + stale CSP block

### DIFF
--- a/_headers
+++ b/_headers
@@ -26,25 +26,17 @@
 /js/*.js
   Cache-Control: public, max-age=3600, must-revalidate
 
-*.jpg
-  Cache-Control: public, max-age=2592000
-
-*.png
-  Cache-Control: public, max-age=2592000
-
-*.svg
-  Cache-Control: public, max-age=2592000
-
-*.webp
-  Cache-Control: public, max-age=2592000
-
-*.html
-  Cache-Control: public, max-age=0, must-revalidate
+# Extension-based cache rules (images / HTML / fonts) live in
+# netlify.toml [[headers]] (for = "*.jpg" etc.). Netlify's _headers
+# parser does NOT accept bare-extension globs — they were silently
+# rejected here as the "2 invalid header rules" advisory, and the
+# leading-slash form (/*.jpg) fails the deploy outright. netlify.toml's
+# `for` matcher is the supported home for extension-based rules.
 
 # Root path and extensionless pretty URLs. Netlify serves these by
-# rewriting to the corresponding .html file internally, which means
-# the *.html cache rule above does NOT apply to them. Set explicit
-# no-cache so edge caches always revalidate these routes.
+# rewriting to the corresponding .html file internally, so the HTML
+# cache rule (in netlify.toml) does NOT apply to them. Set explicit
+# no-cache here so edge caches always revalidate these routes.
 /
   Cache-Control: public, max-age=0, must-revalidate
 
@@ -58,9 +50,6 @@
 /deploy-id.txt
   Cache-Control: no-cache, no-store, must-revalidate
   Content-Type: text/plain; charset=utf-8
-
-*.woff2
-  Cache-Control: public, max-age=31536000, immutable
 
 /feed.xml
   Cache-Control: public, max-age=3600

--- a/netlify.toml
+++ b/netlify.toml
@@ -1118,14 +1118,15 @@
   to = "/rfp-shredder.html"
   status = 301
 
-[[headers]]
-  for = "/*"
-  [headers.values]
-    X-Frame-Options = "SAMEORIGIN"
-    X-Content-Type-Options = "nosniff"
-    Referrer-Policy = "strict-origin-when-cross-origin"
-    Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.io https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; frame-src https://checkout.stripe.com https://open.spotify.com; media-src 'self' https://api.riverside.fm https://hosting-media.rs-prod.riverside.fm; connect-src 'self' https://plausible.io https://*.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self' https://buttondown.com https://checkout.stripe.com"
+# Security headers are intentionally NOT defined here. Ownership (Sprint B
+# 2026-05-13, re-confirmed 2026-06-15): X-Frame-Options, X-Content-Type-Options,
+# and Referrer-Policy live in `_headers`; Content-Security-Policy,
+# Permissions-Policy, and Strict-Transport-Security live in the
+# `security-headers` edge function (path "/*", covers function routes too).
+# A duplicate `[[headers]] for="/*"` block used to live here with a STALE CSP
+# (old jsdelivr + *.stripe.com wildcard) that the edge function silently
+# overrode — dead weight and a divergence risk. Removed so the two owners
+# above are the single source of truth.
 
 # Cache headers
 [[headers]]


### PR DESCRIPTION
## What this is

Clears Netlify's **"2 invalid header rules"** advisory. Two files only: `_headers` and the header section of `netlify.toml`. Touches nothing else.

## Root cause (from the check's own output via the GitHub API)

`_headers` had bare-extension cache globs that don't start with `/`:

```
In /_headers:
- /js/*.js
    *.jpg *.png *.svg *.webp *.html   ← Netlify mis-reads these as malformed HEADER lines
- /deploy-id.txt
    *.woff2
```

Netlify's `_headers` parser only treats `/`-prefixed lines as path rules, so it attached the six bare globs to the *previous* rule as invalid headers → the advisory, and those cache rules weren't applying anyway.

## The fix (minimal, evidence-based)

1. **Delete the 6 invalid bare-glob rules from `_headers`.** Their valid equivalents already exist in `netlify.toml [[headers]]` via the `for = "*.jpg"` matcher (that's the supported home for extension rules, and they deploy fine there).
2. **Remove a stale, redundant security `[[headers]]` block from `netlify.toml`** — it carried a pre-Sprint-B CSP (old `jsdelivr` + `*.stripe.com` wildcard) that the `security-headers` edge function already overrode. Dead weight + divergence risk.

End state: `_headers` owns caching + X-Frame-Options/X-Content-Type-Options/Referrer-Policy; the edge function owns CSP/Permissions-Policy/HSTS; `netlify.toml` keeps the extension cache rules. **No effective caching or security-header change** (the `_headers` globs weren't applying).

## Verification

- `build-check` (GitHub Actions, full build) ✅; local `validate-dist` OK (500 pages); `validate-routes` ✓.
- An earlier `/*.ext` consolidation attempt was reverted because Netlify's `_headers` parser rejects that form; this minimal line-removal is what's in the branch.

## Note

This PR's deploy preview is blocked by a **separate, pre-existing issue unrelated to these changes**: the site's Netlify env vars exceed AWS Lambda's 4KB limit, failing function upload on every deploy. Once that's resolved (Netlify Functions runtime migration), this fix deploys and the Header-rules check goes green.

https://claude.ai/code/session_01UfEkVEJVGnwenskuXuyc6E