### PR TITLE
feat(agent-api): read-only Agent Access API (Sprints 1+2+2.5) — preview, gated migration

### DIFF
--- a/build.js
+++ b/build.js
@@ -3058,7 +3058,8 @@ function injectDashShell(html, activePage) {
     { href: '/glossary.html', label: 'Glossary', id: 'glossary', group: 'Reference' },
     { href: '/newswire.html', label: 'Newswire', id: 'newswire' },
     { href: '/agency-sources.html', label: 'Agency Sources', id: 'agency-sources' },
-    { href: '/premium/settings/', label: 'Settings', id: 'settings', group: 'Account' },
+    { href: '/premium/ai-integrations/', label: 'AI & Integrations', id: 'ai-integrations', group: 'Account' },
+    { href: '/premium/settings/', label: 'Settings', id: 'settings' },
   ];
 
   let navHtml = '<nav class="dash-nav">\n';
@@ -3542,6 +3543,8 @@ ${innerHtml}
     'premium/key-people.html': 'key-people',
     'premium/forecast-delta.html': 'forecast-delta',
     'premium/cr-exposure.html': 'cr-exposure',
+    // Agent Access (2026-06-16) — AI & Integrations setup UX
+    'premium/ai-integrations.html': 'ai-integrations',
   };
 
   // Copy premium and agency subdirectory pages
@@ -3564,6 +3567,7 @@ ${innerHtml}
     { src: 'premium/key-people.html', dest: 'premium/key-people/index.html' },
     { src: 'premium/forecast-delta.html', dest: 'premium/forecast-delta/index.html' },
     { src: 'premium/cr-exposure.html', dest: 'premium/cr-exposure/index.html' },
+    { src: 'premium/ai-integrations.html', dest: 'premium/ai-integrations/index.html' },
     // Sprint 6 Phase 3 (2026-05-15) follow-up — the page exists at
     // premium/api-health.html but Sprint 6 missed adding it here, so it
     // never shipped to dist and /admin/api-health redirected to a 404.

--- a/docs/agent-access-go-live.md
+++ b/docs/agent-access-go-live.md
@@ -1,0 +1,67 @@
+# Agent Access API — Go-Live Runbook
+
+Everything you need to take `feat/agent-api` ([PR #103](https://github.com/maryadawson-code/mmt-site/pull/103)) live, in order. The **critical path is 3 steps** — the rest is optional and can wait.
+
+> **Why these are yours, not mine:** they need your Supabase access, your merge/promote authority, and (optionally) your provider logins. I can't do them for you, but I've made each one copy-paste.
+
+---
+
+## ✅ Critical path — makes the read API live (15 min)
+
+### Step 1 — Apply the database migration
+The endpoints need 5 new tables. The migration only **adds** tables — it touches nothing that already exists, so it's safe.
+
+1. Open Supabase → project **missionpulse-prod** (`djuviwarqdvlbgcfuupa`) → **SQL Editor** → **New query**.
+2. Open `migrations/20260616000000_agent_api_infra.sql` in the repo, copy the whole file, paste it in, click **Run**.
+3. Confirm it worked — paste this in the same editor and Run:
+
+```sql
+-- Expect 5 rows, rowsecurity = true on every one
+select relname, relrowsecurity
+from pg_class
+where relname in ('api_tokens','api_audit_log','api_cost_ledger','recommended_cache','idempotency_keys')
+order by relname;
+
+-- Expect: token_hash + token_prefix only (NO plaintext "token" column)
+select column_name from information_schema.columns
+where table_name = 'api_tokens' and column_name like '%token%';
+```
+
+> Do **not** run `supabase db push` — it would also apply other migrations you've intentionally gated. The SQL editor is the safe path.
+
+### Step 2 — Merge the PR
+Only after Step 1 (merging first would ship endpoints that error against missing tables).
+
+- GitHub → [PR #103](https://github.com/maryadawson-code/mmt-site/pull/103) → **Squash and merge**. The push to `main` auto-deploys.
+
+### Step 3 — Smoke-test production
+After the deploy finishes (~2 min):
+
+```bash
+node scripts/verify-agent-api.js https://missionmeetstech.com
+```
+
+Expect **6/6 passed**. Then, as a logged-in premium member, visit **/ai-integrations**, click **Connect your AI**, request the email sign-in link, and create a test connection. That exercises the full path end-to-end.
+
+**That's it — the read API is live.**
+
+---
+
+## 🔭 Optional — later, only when you want AI scoring (Phase 4)
+
+None of this is needed for the read API. The LLM router ships **fail-closed**, so nothing breaks while it's off.
+
+| When you want… | Do this |
+|---|---|
+| AI fit-scores in `/recommended` | Add provider keys to Netlify env (`GEMINI_API_KEY` / `OPENAI_API_KEY` / AWS GovCloud), set monthly spend caps in each console, then set `AGENT_SCORING_ENABLED=true`. (SDK wiring is a follow-up — `chub get` first.) |
+| The sensitive/CUI path | Attorney-review the §11 + UX §8 data-handling copy, then set `CUI_PATH_CLEARED=true`. **Leave unset until legal clears.** |
+| Abuse alerts | Set `AGENT_ALERT_WEBHOOK_URL` + `AGENT_ALERTS_ENABLED=true`. |
+
+Tuning knobs (all have safe defaults) live in `netlify/functions/lib/agent-config.js`.
+
+---
+
+## 🧹 Minor follow-ups (no rush)
+- **Primary-nav placement** — "AI & Integrations" is in the premium dashboard's Account group. Promoting it to top-level nav touches governed nav copy across the site; your call.
+- **Advanced-view toggle persistence** — currently localStorage; the UX spec wants server-side. Needs a `mmt_preferences` column (another gated migration), so deferred.
+- **SAM.gov source data** — confirm it carries no CUI before enabling `intel:read` broadly.

--- a/docs/agent-access-schema.sql
+++ b/docs/agent-access-schema.sql
@@ -1,0 +1,166 @@
+-- ============================================================================
+-- CANONICAL SCHEMA — AI Agent Access for Mission Meets Tech
+-- Owner: Mary Womack · Companion to mmt_agent_access_spec.md + _hardening.md
+-- This is the AUTHORITATIVE data model. Claude Code: COPY this. Do NOT invent
+-- columns, types, or policies. If something here conflicts with the prose specs,
+-- THIS FILE WINS. Apply via `supabase db push`.
+--
+-- Tables: api_tokens, api_audit_log, api_cost_ledger, recommended_cache,
+--         idempotency_keys. RLS ON all five. Owner reads via user_id = auth.uid().
+--         audit/ledger/cache/idempotency: writes via service_role only.
+--
+-- ⚠️ REPO-REALITY NOTE (added 2026-06-16, feat/agent-api):
+-- mmt-site does NOT use Supabase Auth. Subscribers are keyed by EMAIL in
+-- mp_users; there is no auth.users session and auth.uid() is always NULL on an
+-- agent request. The `references auth.users(id)` FK + `auth.uid()` RLS below are
+-- therefore NOT directly buildable here without a decision (bridge to Supabase
+-- Auth vs. adapt identity to mp_users). The authored migration in migrations/
+-- reflects Mary's chosen path; this file is preserved AS DELIVERED for the record.
+-- ============================================================================
+
+-- Required for gen_random_uuid()
+create extension if not exists "pgcrypto";
+
+-- ----------------------------------------------------------------------------
+-- 1. api_tokens  (spec §6 — full canonical form)
+-- ----------------------------------------------------------------------------
+create table if not exists public.api_tokens (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  name          text not null,
+  token_hash    text not null unique,                 -- SHA-256 hex; NEVER raw token
+  token_prefix  text not null,                         -- first 8 chars, display only
+  scopes        text[] not null default '{opportunities:read}',
+  last_used_at  timestamptz,
+  expires_at    timestamptz,                           -- nullable = no expiry
+  revoked_at    timestamptz,                           -- non-null = instant kill
+  created_at    timestamptz not null default now(),
+  constraint api_tokens_scopes_not_empty check (array_length(scopes, 1) >= 1)
+);
+create index if not exists api_tokens_user_id_idx    on public.api_tokens(user_id);
+create index if not exists api_tokens_token_hash_idx on public.api_tokens(token_hash);
+
+-- ----------------------------------------------------------------------------
+-- 2. api_audit_log  (spec §6 base + hardening §5 cost/attribution columns)
+--    Immutable, append-only. No client update/delete.
+-- ----------------------------------------------------------------------------
+create table if not exists public.api_audit_log (
+  id             uuid primary key default gen_random_uuid(),
+  token_id       uuid references public.api_tokens(id) on delete set null,
+  user_id        uuid not null references auth.users(id) on delete cascade,
+  endpoint       text not null,
+  method         text not null,
+  status_code    integer not null,
+  ip             inet,
+  user_agent     text,
+  session_id     uuid,                                 -- hardening §2b / §5
+  llm_model      text,                                  -- model the router picked, null if no LLM call
+  cache_hit      boolean not null default false,        -- hardening §5
+  cost_usd       numeric(12,6) not null default 0,      -- USD, not cents — hardening §2a/§5
+  response_bytes bigint not null default 0,             -- hardening §5 (harvest detection)
+  created_at     timestamptz not null default now()
+);
+create index if not exists api_audit_log_token_id_idx   on public.api_audit_log(token_id);
+create index if not exists api_audit_log_user_id_idx     on public.api_audit_log(user_id);
+create index if not exists api_audit_log_created_at_idx  on public.api_audit_log(created_at);
+create index if not exists api_audit_log_session_id_idx  on public.api_audit_log(session_id);
+
+-- ----------------------------------------------------------------------------
+-- 3. api_cost_ledger  (hardening §2a — per-key budget gate, pre-call)
+--    One row per token per sliding window bucket. Read BEFORE any LLM call.
+-- ----------------------------------------------------------------------------
+create table if not exists public.api_cost_ledger (
+  id             uuid primary key default gen_random_uuid(),
+  token_id       uuid not null references public.api_tokens(id) on delete cascade,
+  user_id        uuid not null references auth.users(id) on delete cascade,
+  window_kind    text not null check (window_kind in ('day','month')),  -- 24h sliding + month
+  window_start   timestamptz not null,                 -- bucket start (sliding window anchor)
+  spend_usd      numeric(12,6) not null default 0,      -- running USD this window
+  budget_usd     numeric(12,6) not null,                -- cap for this window/tier
+  call_count     integer not null default 0,
+  updated_at     timestamptz not null default now(),
+  unique (token_id, window_kind, window_start)
+);
+create index if not exists api_cost_ledger_token_idx on public.api_cost_ledger(token_id, window_kind, window_start);
+
+-- ----------------------------------------------------------------------------
+-- 4. recommended_cache  (hardening §2e — pre-computed go/no-go scores)
+--    Written by nightly Batch job. /api/v1/recommended READS this; NO live LLM.
+-- ----------------------------------------------------------------------------
+create table if not exists public.recommended_cache (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references auth.users(id) on delete cascade,
+  opportunity_id  text not null,                        -- source opp identifier (SAM.gov etc.)
+  fit_score       numeric(5,2) not null,                -- 0.00–100.00, higher = better fit
+  rationale       text,                                  -- short model-generated justification
+  data_class      text not null default 'public' check (data_class in ('public','sensitive')),
+  scored_model    text,                                  -- which model produced the score
+  scored_at       timestamptz not null default now(),
+  expires_at      timestamptz,                           -- re-score after this; nullable
+  unique (user_id, opportunity_id)
+);
+create index if not exists recommended_cache_user_score_idx on public.recommended_cache(user_id, fit_score desc);
+create index if not exists recommended_cache_expires_idx     on public.recommended_cache(expires_at);
+
+-- ----------------------------------------------------------------------------
+-- 5. idempotency_keys  (hardening §4 — build now, used by Phase 2 writes)
+-- ----------------------------------------------------------------------------
+create table if not exists public.idempotency_keys (
+  id              uuid primary key default gen_random_uuid(),
+  token_id        uuid not null references public.api_tokens(id) on delete cascade,
+  user_id         uuid not null references auth.users(id) on delete cascade,
+  idempotency_key text not null,
+  response_body   jsonb,
+  status_code     integer,
+  created_at      timestamptz not null default now(),
+  expires_at      timestamptz not null default (now() + interval '24 hours'),
+  unique (token_id, idempotency_key)
+);
+create index if not exists idempotency_keys_expires_idx on public.idempotency_keys(expires_at);
+
+-- ============================================================================
+-- ROW LEVEL SECURITY — enable on all five tables
+-- ============================================================================
+alter table public.api_tokens        enable row level security;
+alter table public.api_audit_log      enable row level security;
+alter table public.api_cost_ledger    enable row level security;
+alter table public.recommended_cache  enable row level security;
+alter table public.idempotency_keys   enable row level security;
+
+-- api_tokens: owner full self-service (the settings UI runs as the user session)
+create policy api_tokens_owner_select on public.api_tokens
+  for select using (user_id = auth.uid());
+create policy api_tokens_owner_insert on public.api_tokens
+  for insert with check (user_id = auth.uid());
+create policy api_tokens_owner_update on public.api_tokens
+  for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+create policy api_tokens_owner_delete on public.api_tokens
+  for delete using (user_id = auth.uid());
+
+-- api_audit_log: owner may READ own rows; inserts/updates/deletes via service_role only
+-- (no client INSERT/UPDATE/DELETE policy = append happens server-side with service key,
+--  which bypasses RLS; clients get read-only of their own rows). Immutable to clients.
+create policy api_audit_log_owner_select on public.api_audit_log
+  for select using (user_id = auth.uid());
+
+-- api_cost_ledger: owner READ-ONLY (so UI can show usage); writes via service_role only
+create policy api_cost_ledger_owner_select on public.api_cost_ledger
+  for select using (user_id = auth.uid());
+
+-- recommended_cache: owner READ-ONLY; nightly Batch job writes via service_role
+create policy recommended_cache_owner_select on public.recommended_cache
+  for select using (user_id = auth.uid());
+
+-- idempotency_keys: NO client policy — service_role only (internal write-dedup table).
+-- RLS enabled with zero policies = clients see nothing; server uses service key.
+
+-- ============================================================================
+-- NOTES FOR THE BUILD AGENT
+-- - Agent read API (lib/agent-auth.js) sets request context to the token's user_id
+--   so the owner_select policies scope every read. NEVER use service_role for agent reads.
+-- - service_role is used ONLY for: writing audit rows, updating the cost ledger,
+--   writing recommended_cache (nightly Batch), and idempotency dedup. Never on a read path.
+-- - cost_usd / spend_usd / budget_usd are NUMERIC USD (dollars), never cents.
+-- - Verify after push: every table has rowsecurity = true in pg_tables; no plaintext
+--   token column exists; api_tokens.token_hash is unique.
+-- ============================================================================

--- a/docs/agent-access-spec-sections.md
+++ b/docs/agent-access-spec-sections.md
@@ -1,0 +1,44 @@
+# Agent Access — Core Spec + Hardening Section Map
+
+Status: reference · Added 2026-06-16 on `feat/agent-api`.
+
+The two prose specs (`mmt_agent_access_spec.md`, `mmt_agent_access_hardening.md`)
+were authored by Mary but did not arrive as files in the prompt export — only
+the two build prompts (`claude_code_prompt_master_autonomous.md`,
+`claude_code_prompt_sprint2.md`), the UX spec, and the canonical schema
+(`agent-access-schema.sql`) were delivered. Mary read both prose specs
+end-to-end (148 + 96 lines) and provided the section-by-section content below.
+This file preserves that content in-repo so the build has a durable reference.
+Where the schema and prose disagree, **`docs/agent-access-schema.sql` wins**.
+
+## `mmt_agent_access_spec.md` (148 lines)
+
+| § | Title | Content |
+|---|---|---|
+| §6 | Data model | Full column table for `api_tokens` (id, user_id, name, token_hash, token_prefix, scopes, last_used_at, expires_at, revoked_at, created_at + types/notes); `api_audit_log` column list; RLS rule stated. (Schema SQL closes the prose gap for `api_cost_ledger`, `recommended_cache`, `idempotency_keys`.) |
+| §7 | Endpoints | `POST/GET/DELETE /api/tokens` + `GET /api/v1/opportunities`, `/opportunities/:id`, `/tracker`, `/recommended` with filters + paywall-aware note |
+| §8 | Auth middleware | 7-step: bearer → hash → revoked/expired → scope → rate-limit → RLS context → audit |
+| §9 | Security requirements | HTTPS-only, hash-only compare, limits **60/min · 5k/day · 10/min-LLM**, RLS, instant revoke, generic errors |
+| §10 | Settings UI | The bare settings panel the UX spec replaces |
+| §11 | Compliance gate | **FedRAMP Moderate / IL5**, CUI/PII sanitization, attorney-review trigger — the posture the `503 COMPLIANCE_HOLD` copy must match |
+
+## `mmt_agent_access_hardening.md` (96 lines)
+
+| § | Title | Content |
+|---|---|---|
+| §2a | Budget gate | Per-token day/month ledger; zones **green <80% / yellow 80–100% / red >100%**; 24h sliding window |
+| §2b | Session gate | Hard stop at **100 calls/session**; `X-Session-Limit-Reached` header |
+| §2c | max_tokens | `count_tokens` pre-count, reject oversized, `max_tokens` on every call |
+| §2d | Model router | Classify `public` vs `sensitive` FIRST; routing table (Gemini 3 Flash / GPT-5.4 nano / Llama 4 / Bedrock-GovCloud); **no Chinese-origin models** (DeepSeek/Qwen/GLM/MiniMax) |
+| §2e/§2f | Spend caps | Batch pre-computation; per-provider console caps; optional Cloudflare AI Gateway |
+| §3 | Rate limits | **Global 1,000/min** (canonical here, NOT in prompt body); per-key 60/min; 10/min LLM; 5/min bulk |
+| §4 | Circuit breaker | Error-rate > X% rolling window → stop forwarding T sec; pagination max 100; backoff + jitter |
+| §5 | Alert thresholds | >50 401s/key/60s; >100 403s; >10 429s; response_bytes > X MB/hr; cost-spike auto-pause |
+
+### Parameters left as `X` / `T` in the specs (need values before Phase 4/5 ship)
+- §4 circuit-breaker error-rate threshold (`X%`) and cooldown (`T sec`)
+- §5 `response_bytes > X MB/hr` harvest-detection threshold
+- §2e/§2f per-provider monthly USD caps (set in each provider console — manual)
+
+These will be wired as named config constants with conservative defaults and
+surfaced in the final report for Mary to confirm.

--- a/docs/agent-access-ux-spec.md
+++ b/docs/agent-access-ux-spec.md
@@ -1,0 +1,110 @@
+<!--
+REPO-ADAPTATION NOTE (added 2026-06-16, feat/agent-api):
+This spec is the canonical UX source of truth for the Agent Access feature.
+It is authored against a React + Tailwind + shadcn/ui stack (see §11). This
+repo (mmt-site) is STATIC HTML built by `node build.js` with inline-CSS-var /
+build-time Tailwind and `mmt_premium` localStorage auth gates — there is no
+React runtime. Per the HHS-sprint precedent ("a Mary-delivered spec's path
+conventions are spec hypothesis, not repo reality"), the build TRANSLATES this
+spec to the repo's flat-HTML + vanilla-JS pattern: the wizard/list/dialog
+become server-rendered pages + progressive-enhancement JS, not shadcn
+components. UX requirements (the fork, plain-language scopes, one-time key,
+activity view, a11y AA, error microcopy) are honored verbatim; only the
+implementation substrate changes. Companion data-model + hardening specs:
+docs/agent-access-spec.md + docs/agent-access-hardening-spec.md (added when
+provided). Build branch: feat/agent-api.
+-->
+
+# SPEC: Agent Access — UX / Setup Experience
+Owner: Mary Womack · Companion to `mmt_agent_access_spec.md` + `_hardening.md` · Status: DRAFT FOR REVIEW
+Goal: A setup experience anyone can complete — capture/BD/small-biz owners who are NOT engineers — while power users like Eric move fast. Lead with INTEL (71% poll winner), agent-connection secondary.
+
+## 1. Design principles
+- Non-technical-first floor, expert fast-path ceiling. Never make a non-engineer read the word "token" before they understand the value.
+- Plain language over jargon. "Connect your AI assistant" not "Generate a PAT." Explain scopes as what the AI can SEE, not as permission strings.
+- Trust before action. A nervous federal user must see read-only, revoke-anytime, audit-visible BEFORE they click generate.
+- One clear next step per screen. Progressive disclosure — advanced controls hidden until asked for.
+- WCAG AA throughout (4.5:1 body, 3:1 large text, keyboard nav, visible focus, no color-only signals).
+
+## 2. Design system (Nexus, GovCon-sober)
+- Palette: Nexus neutrals + Hydra Teal `#01696F` primary (CTAs/links only). Semantic: success `#437A22`, warning `#964219`, error `#A12C7B`. Dark mode first-class.
+- Type: one distinctive sans (e.g. Satoshi/General Sans via CDN) — display via weight, not size. `text-xl` max heading in-app. 16px body floor.
+- Tone: precise, calm, trustworthy. No marketing fluff inside the setup flow.
+
+## 3. The fork (two paths, one product)
+Default = Guided. A persistent "Advanced / Developer view" toggle (top-right of the API Access page) switches to the dense expert panel. Choice is remembered in user profile (server-side, never localStorage).
+
+### 3a. Guided path (default — non-technical)
+A wizard, not a form. Stepper with 3 steps + a success state.
+
+### 3b. Advanced path (Eric & devs)
+Single dense page: token table + create form + raw scopes + curl/MCP snippets + rate-limit/budget readout. No wizard chrome. Skips all explanatory copy.
+
+## 4. Information architecture
+Entry point: a top-level "AI & Integrations" nav item (NOT buried in Settings). Lead card = INTEL.
+1. **Hero card — "Pull intel on your market"** (the 71% winner): plain pitch + "Connect your AI" primary CTA. This is the front door.
+2. Secondary cards: "Let your AI pick your bids" (Eric's case), "Score bids before you chase them."
+3. Below: "Your connected assistants" (token list, empty by default).
+
+## 5. Guided wizard — screen by screen
+
+### Screen 0 — Value + trust (before any setup)
+- Headline: "Connect your AI assistant to Mission Meets Tech."
+- Subhead: "Let the AI you already use read your live opportunities and market intel — so it tells you what to chase before you open your laptop."
+- Trust row (3 chips, icon + label): 🔒 Read-only (it can't change anything) · ↩ Revoke anytime · 👁 Every access logged.
+- Primary CTA: "Get started." Secondary: "How does this work?" (opens explainer drawer).
+
+### Screen 1 — Pick what your AI can see (scopes in plain language)
+- Three toggle cards, NOT checkboxes-with-jargon. Each: plain title + one-line "what this lets your AI do" + a "for example" line.
+  - "My market intel" → opportunities + trend data. (maps `intel:read`) — pre-selected, labeled "Most popular."
+  - "My live opportunities" → the open bids in your tracker. (maps `opportunities:read`)
+  - "My pipeline" → what you're already tracking. (maps `tracker:read`)
+- Reassurance under cards: "You can change this anytime. Your AI can only read — never edit, delete, or spend."
+
+### Screen 2 — Name it + expiry (with smart defaults)
+- "Give this connection a name" (placeholder: "My ChatGPT", "Eric's Ops Assistant"). Required.
+- Expiry: friendly dropdown — "90 days (recommended)" default; 30 / 365 / "Never (not recommended)". Each option has a one-line consequence.
+- Primary CTA: "Create connection."
+
+### Screen 3 — Success + one-time key (the critical moment)
+- Big success check. "Your connection is ready."
+- The key shown ONCE in a copy-box with a giant Copy button. Plain warning: "Copy this now — for your security we can't show it again. Lost it? Just make a new one."
+- Then: "Now paste it into your AI" — a tool picker (Claude Desktop · ChatGPT · Other) that reveals copy-paste setup steps for THAT tool, including the base URL and a ready curl/MCP snippet.
+- "I've connected it" → returns to the list showing the new live connection with a green "Active" badge.
+
+## 6. The connection list (both paths)
+Each row: name · what it can see (plain chips) · created · last used ("2h ago" / "Never yet") · status badge (Active/Expired/Revoked) · Revoke button. Revoke = one click + a plain confirm ("Your AI will lose access immediately. You can reconnect anytime.").
+
+## 7. States & microcopy (the polish that makes it feel "perfect")
+- Empty state: friendly, not a void. "No AI assistants connected yet. Connect one to let it work your pipeline for you."
+- Loading: skeletons, never spinners-on-blank.
+- Errors in human language, never codes. Examples:
+  - 401 from a bad key → "That key didn't work. It may have been revoked or expired — try making a new one."
+  - 429 budget → "You've reached this month's usage. It resets on [date], or upgrade for more."
+  - 503 COMPLIANCE_HOLD (CUI path) → "This data isn't available for AI access yet while we finish security review."
+- Success confirmations on every action (toast: "Connection revoked.").
+
+## 8. Trust & safety surfacing (federal buyers need this)
+- Persistent "How your data is protected" link → drawer: read-only, scoped, per-connection, audit-logged, revoke-anytime, where data is/isn't sent.
+- On the CUI/sensitive note: plainly state that protected data stays inside the secure boundary and isn't sent to outside AI.
+- A visible "Activity" view per connection: last 20 reads (time, what was read) — turns the audit log into a user-facing trust feature.
+
+## 9. Accessibility (non-negotiable)
+- Full keyboard path through the wizard; visible focus rings; logical tab order.
+- Every status uses icon + text + color (never color alone).
+- Copy-box and toggles have ARIA labels; success/error announced via live region.
+- Test at 375px (mobile) and 1280px+; 200% zoom must not break layout.
+
+## 10. Acceptance criteria
+- A non-technical user can connect an AI assistant end-to-end without seeing the words "token", "scope", or "bearer" until the advanced view.
+- Intel is the visible front door; agent-connect is reachable but secondary.
+- Advanced toggle gives Eric the dense panel in one click; choice persists.
+- One-time key screen: copy works, warning is clear, tool-specific paste steps shown for Claude + ChatGPT.
+- Every error renders human copy, never a raw status code.
+- WCAG AA passes (contrast, keyboard, focus, live-region announcements) at mobile + desktop.
+- Activity view shows real audit rows per connection.
+
+## 11. Reference
+- Design system: Nexus palette + Satoshi/General Sans (design-foundations).
+- Build target: React + Tailwind + shadcn/ui (webapp template); wizard via shadcn Stepper/Tabs; toggles via Switch; key reveal via Dialog; list via Table.
+- ⚖️ The §8 "where data is sent" copy must match the §11 compliance posture — keep wording aligned with legal before launch.

--- a/docs/member-features.json
+++ b/docs/member-features.json
@@ -3,6 +3,21 @@
   "comment": "Canonical registry for marketed member tools. Drives validate-dist + smoke tests + docs. Update this file BEFORE adding a new tool. If a marketed route is missing from built dist/, validate-dist fails the build.",
   "features": [
     {
+      "feature_name": "AI & Integrations",
+      "public_marketing_urls": [
+        "/ai-integrations"
+      ],
+      "member_url": "/premium/ai-integrations.html",
+      "backing_function": "netlify/functions/tokens-create.js",
+      "entitlement_required": "premium|founding|institutional|admin",
+      "public_locked_preview_behavior": "premium gate card → /pricing.html; token CRUD requires a verified magic-link session",
+      "expected_data_source": "Supabase api_tokens + api_audit_log (Agent Access API)",
+      "freshness_sla_hours": null,
+      "title_signature": "AI &amp; Integrations",
+      "smoke_test_url": "/premium/ai-integrations.html",
+      "noindex": true
+    },
+    {
       "feature_name": "Ask MMT",
       "public_marketing_urls": [
         "/ask-mmt",

--- a/migrations/20260616000000_agent_api_infra.sql
+++ b/migrations/20260616000000_agent_api_infra.sql
@@ -1,0 +1,165 @@
+-- ============================================================================
+-- Agent API infrastructure (Phase 1 — data model + RLS)
+-- Branch: feat/agent-api · Authored 2026-06-16
+--
+-- Source of truth: docs/agent-access-schema.sql ("THIS FILE WINS"), ADAPTED to
+-- mmt-site's real identity model per Mary's decision 2026-06-16:
+--   - mmt-site has NO Supabase Auth. Subscribers are email-keyed in mp_users
+--     (id uuid PK, email text unique). There is no auth.uid() session.
+--   - Therefore: user_id FK targets mp_users(id), NOT auth.users(id).
+--   - Therefore: RLS is ON for defense-in-depth but carries NO permissive
+--     policy. All access is via the service-role client inside Netlify
+--     functions (lib/), which bypasses RLS and enforces per-owner scoping in
+--     code with explicit .eq() filters — identical to every existing paid tool
+--     (entitlement.js, score-deck.js, etc.). The anon/PostgREST path sees
+--     NOTHING (fail-closed), which is exactly what we want for token_hash.
+--
+-- GATED: do NOT `supabase db push` this. Mary applies it manually after review
+-- (repo convention — every prior sprint gates migrations on her approval).
+-- ============================================================================
+
+create extension if not exists "pgcrypto";
+
+-- ----------------------------------------------------------------------------
+-- 1. api_tokens  (spec §6) — one row per personal access token (PAT)
+--    Raw token is NEVER stored. token_hash = SHA-256 hex; token_prefix = first
+--    8 chars for display. Revoke = set revoked_at (instant kill).
+-- ----------------------------------------------------------------------------
+create table if not exists public.api_tokens (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references public.mp_users(id) on delete cascade,
+  name          text not null,
+  token_hash    text not null unique,                  -- SHA-256 hex; NEVER raw token
+  token_prefix  text not null,                          -- first 8 chars, display only
+  scopes        text[] not null default '{opportunities:read}',
+  last_used_at  timestamptz,
+  expires_at    timestamptz,                            -- nullable = no expiry
+  revoked_at    timestamptz,                            -- non-null = instant kill
+  created_at    timestamptz not null default now(),
+  constraint api_tokens_scopes_not_empty check (array_length(scopes, 1) >= 1)
+);
+create index if not exists api_tokens_user_id_idx    on public.api_tokens(user_id);
+create index if not exists api_tokens_token_hash_idx on public.api_tokens(token_hash);
+-- Partial index: the hot path is "active tokens for this user" (CRUD list +
+-- max-5 enforcement). revoked_at IS NULL = live.
+create index if not exists api_tokens_user_active_idx
+  on public.api_tokens(user_id) where revoked_at is null;
+
+-- ----------------------------------------------------------------------------
+-- 2. api_audit_log  (spec §6 + hardening §5) — immutable, append-only.
+--    Written server-side via service role on EVERY agent request.
+-- ----------------------------------------------------------------------------
+create table if not exists public.api_audit_log (
+  id             uuid primary key default gen_random_uuid(),
+  token_id       uuid references public.api_tokens(id) on delete set null,
+  user_id        uuid not null references public.mp_users(id) on delete cascade,
+  endpoint       text not null,
+  method         text not null,
+  status_code    integer not null,
+  ip             inet,
+  user_agent     text,
+  session_id     uuid,                                  -- hardening §2b / §5
+  llm_model      text,                                   -- model the router picked, null if no LLM
+  cache_hit      boolean not null default false,         -- hardening §5
+  cost_usd       numeric(12,6) not null default 0,       -- USD dollars — hardening §2a/§5
+  response_bytes bigint not null default 0,              -- hardening §5 (harvest detection)
+  created_at     timestamptz not null default now()
+);
+create index if not exists api_audit_log_token_id_idx  on public.api_audit_log(token_id);
+create index if not exists api_audit_log_user_id_idx    on public.api_audit_log(user_id);
+create index if not exists api_audit_log_created_at_idx on public.api_audit_log(created_at);
+create index if not exists api_audit_log_session_id_idx on public.api_audit_log(session_id);
+
+-- ----------------------------------------------------------------------------
+-- 3. api_cost_ledger  (hardening §2a) — per-token budget gate, read pre-call.
+--    One row per (token, window_kind, window_start) bucket.
+-- ----------------------------------------------------------------------------
+create table if not exists public.api_cost_ledger (
+  id             uuid primary key default gen_random_uuid(),
+  token_id       uuid not null references public.api_tokens(id) on delete cascade,
+  user_id        uuid not null references public.mp_users(id) on delete cascade,
+  window_kind    text not null check (window_kind in ('day','month')),
+  window_start   timestamptz not null,
+  spend_usd      numeric(12,6) not null default 0,
+  budget_usd     numeric(12,6) not null,
+  call_count     integer not null default 0,
+  updated_at     timestamptz not null default now(),
+  unique (token_id, window_kind, window_start)
+);
+create index if not exists api_cost_ledger_token_idx
+  on public.api_cost_ledger(token_id, window_kind, window_start);
+
+-- ----------------------------------------------------------------------------
+-- 4. recommended_cache  (hardening §2e) — pre-computed go/no-go scores.
+--    Written by the nightly batch job; /api/v1/recommended only READS this.
+-- ----------------------------------------------------------------------------
+create table if not exists public.recommended_cache (
+  id              uuid primary key default gen_random_uuid(),
+  user_id         uuid not null references public.mp_users(id) on delete cascade,
+  opportunity_id  text not null,
+  fit_score       numeric(5,2) not null,
+  rationale       text,
+  data_class      text not null default 'public' check (data_class in ('public','sensitive')),
+  scored_model    text,
+  scored_at       timestamptz not null default now(),
+  expires_at      timestamptz,
+  unique (user_id, opportunity_id)
+);
+create index if not exists recommended_cache_user_score_idx
+  on public.recommended_cache(user_id, fit_score desc);
+create index if not exists recommended_cache_expires_idx
+  on public.recommended_cache(expires_at);
+
+-- ----------------------------------------------------------------------------
+-- 5. idempotency_keys  (hardening §4) — built now; used by Phase 2+ writes.
+-- ----------------------------------------------------------------------------
+create table if not exists public.idempotency_keys (
+  id              uuid primary key default gen_random_uuid(),
+  token_id        uuid not null references public.api_tokens(id) on delete cascade,
+  user_id         uuid not null references public.mp_users(id) on delete cascade,
+  idempotency_key text not null,
+  response_body   jsonb,
+  status_code     integer,
+  created_at      timestamptz not null default now(),
+  expires_at      timestamptz not null default (now() + interval '24 hours'),
+  unique (token_id, idempotency_key)
+);
+create index if not exists idempotency_keys_expires_idx on public.idempotency_keys(expires_at);
+
+-- ============================================================================
+-- ROW LEVEL SECURITY — ON for all five, fail-closed (no permissive policy).
+-- Rationale (adaptation): no Supabase Auth = no auth.uid() to scope by, and
+-- no anon/authenticated client ever touches these tables. Enabling RLS with
+-- zero policies means PostgREST (anon/authenticated keys) returns nothing,
+-- while the service-role client used by Netlify functions bypasses RLS. Owner
+-- scoping is enforced in lib/agent-auth.js with explicit user_id filters.
+-- This is strictly MORE restrictive than the as-delivered owner_select(auth.uid())
+-- policies, which on this stack would always evaluate false anyway.
+-- ============================================================================
+alter table public.api_tokens        enable row level security;
+alter table public.api_audit_log      enable row level security;
+alter table public.api_cost_ledger    enable row level security;
+alter table public.recommended_cache  enable row level security;
+alter table public.idempotency_keys   enable row level security;
+
+-- Belt-and-suspenders: explicitly revoke the PostgREST roles so even if a
+-- future permissive policy is added by mistake, these roles have no table
+-- privilege. service_role (used by our functions) is unaffected.
+revoke all on public.api_tokens,
+              public.api_audit_log,
+              public.api_cost_ledger,
+              public.recommended_cache,
+              public.idempotency_keys
+  from anon, authenticated;
+
+-- ============================================================================
+-- VERIFY AFTER PUSH (Mary, manual):
+--   select relname, relrowsecurity from pg_class
+--     where relname in ('api_tokens','api_audit_log','api_cost_ledger',
+--                        'recommended_cache','idempotency_keys');   -- all true
+--   -- no plaintext token column:
+--   select column_name from information_schema.columns
+--     where table_name='api_tokens';   -- token_hash + token_prefix only, no 'token'
+--   -- uniqueness:
+--   \d public.api_tokens   -- token_hash UNIQUE present
+-- ============================================================================

--- a/netlify.toml
+++ b/netlify.toml
@@ -692,6 +692,27 @@
   status = 200
   force = true
 
+# ── Agent Access — token management (Phase 2) ───────────────────────────────
+# Auth: verified magic-link session in the POST body (lib/agent-session.js).
+# Raw token shown once on create; only SHA-256 hash + 8-char prefix stored.
+[[redirects]]
+  from = "/api/tokens"
+  to = "/.netlify/functions/tokens-create"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/tokens/list"
+  to = "/.netlify/functions/tokens-list"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/tokens/revoke"
+  to = "/.netlify/functions/tokens-revoke"
+  status = 200
+  force = true
+
 # Capture Corner Premium portal — dynamic markdown renderer
 # Serves premium_deliverables rows when publish_at <= now AND published=true
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -752,6 +752,13 @@
   status = 200
   force = true
 
+# Agent Access — marketed clean URL for the setup UX (Phase 5.5)
+[[redirects]]
+  from = "/ai-integrations"
+  to = "/premium/ai-integrations/"
+  status = 301
+  force = true
+
 # Capture Corner Premium portal — dynamic markdown renderer
 # Serves premium_deliverables rows when publish_at <= now AND published=true
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -50,6 +50,18 @@
 [functions."weekly-report"]
   schedule = "0 14 * * 1"
 
+# Agent Access — nightly recommendation scoring (Phase 4). Feeds
+# recommended_cache. No-op until AGENT_SCORING_ENABLED=true AND provider keys
+# land (the router is fail-closed), so the cron is safe to register now.
+[functions."agent-score-batch"]
+  schedule = "0 7 * * *"
+
+# Agent Access — abuse/harvest alert sweep (Phase 5, §5). No-op until
+# AGENT_ALERTS_ENABLED=true. Hourly (Netlify's smallest reliable cadence here);
+# tighten if real-time §5 detection is needed once traffic exists.
+[functions."agent-alert-sweep"]
+  schedule = "0 * * * *"
+
 # Feature-vote Day-7 tally — hourly; the fn checks now >= deadline and
 # exits no-op until the 7-day window closes, then runs once (idempotent).
 [functions."feature-vote-tally"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -713,6 +713,33 @@
   status = 200
   force = true
 
+# ── Agent Access — read API v1 (Phase 3) ────────────────────────────────────
+# Bearer-token auth + budget/session/rate gates live in lib/agent-auth.js.
+# Order matters: the :id rule must precede the bare collection rule.
+[[redirects]]
+  from = "/api/v1/opportunities/:id"
+  to = "/.netlify/functions/agent-opportunities?id=:id"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/v1/opportunities"
+  to = "/.netlify/functions/agent-opportunities"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/v1/tracker"
+  to = "/.netlify/functions/agent-tracker"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/v1/recommended"
+  to = "/.netlify/functions/agent-recommended"
+  status = 200
+  force = true
+
 # Capture Corner Premium portal — dynamic markdown renderer
 # Serves premium_deliverables rows when publish_at <= now AND published=true
 [[redirects]]

--- a/netlify/functions/agent-alert-sweep.js
+++ b/netlify/functions/agent-alert-sweep.js
@@ -1,0 +1,30 @@
+// ============================================================================
+// agent-alert-sweep.js — scheduled abuse/harvest alert sweep (Phase 5, §5)
+// Reads recent api_audit_log, fires AGENT_ALERT_WEBHOOK_URL (or logs) for any
+// key over the §5 thresholds. Flag-gated by AGENT_ALERTS_ENABLED. Schedule in
+// netlify.toml. Cheap: one bounded audit query per run.
+// ============================================================================
+
+const { getServiceClient } = require("./lib/agent-auth");
+const { sweepAlerts } = require("./lib/agent-observability");
+
+async function postWebhook(payload) {
+  const url = process.env.AGENT_ALERT_WEBHOOK_URL;
+  if (!url) { console.warn("AGENT_ALERT (no webhook configured)", JSON.stringify(payload)); return; }
+  try {
+    await fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+  } catch (e) { console.error("agent-alert webhook failed:", e.message); }
+}
+
+exports.handler = async () => {
+  if (process.env.AGENT_ALERTS_ENABLED !== "true") {
+    return { statusCode: 200, body: "disabled" };
+  }
+  try {
+    const fired = await sweepAlerts(getServiceClient(), { notify: postWebhook });
+    return { statusCode: 200, body: JSON.stringify({ fired: fired.length }) };
+  } catch (e) {
+    console.error("agent-alert-sweep error:", e.message);
+    return { statusCode: 500, body: "error" };
+  }
+};

--- a/netlify/functions/agent-opportunities.js
+++ b/netlify/functions/agent-opportunities.js
@@ -1,0 +1,52 @@
+// ============================================================================
+// agent-opportunities.js — GET /api/v1/opportunities  +  /opportunities/:id
+// Scope: opportunities:read. Global premium opportunity data (opportunity_radar).
+// The :id form is routed here with ?id=<n> by netlify.toml. id is a bigint.
+// No service-role client in this file — all DB access via lib/agent-auth + data.
+// ============================================================================
+
+const { authenticateAgent, finalizeAudit, resp, CORS } = require("./lib/agent-auth");
+const { parsePaging, listOpportunities, getOpportunity } = require("./lib/agent-data");
+
+const SCOPE = "opportunities:read";
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return { statusCode: 204, headers: CORS, body: "" };
+  if (event.httpMethod !== "GET") return resp(405, { error: "METHOD_NOT_ALLOWED", message: "Use GET." });
+
+  const qs = event.queryStringParameters || {};
+  const id = qs.id;
+
+  // Pagination validation happens BEFORE auth for the list form so limit=500
+  // returns a clean 400 (it's a client error, not an auth problem).
+  let paging;
+  if (!id) {
+    paging = parsePaging(qs);
+    if (paging.error) return resp(400, { error: "BAD_REQUEST", message: paging.error });
+  }
+
+  const auth = await authenticateAgent(event, SCOPE);
+  if (!auth.ok) return auth.response;
+  const { ctx } = auth;
+
+  let statusCode = 200, body;
+  try {
+    if (id) {
+      const opp = await getOpportunity(ctx.db, id);
+      if (!opp) { statusCode = 404; body = { error: "NOT_FOUND", message: "No opportunity with that id." }; }
+      else body = { data: opp };
+    } else {
+      body = await listOpportunities(ctx.db, {
+        naics: qs.naics, agency: qs.agency, set_aside: qs.set_aside,
+        posted_from: qs.posted_from, deadline: qs.deadline,
+      }, paging);
+    }
+  } catch (e) {
+    console.error("agent-opportunities:", e.message);
+    statusCode = 500; body = { error: "SERVER_ERROR", message: "Could not load opportunities. Try again." };
+  }
+
+  const payload = JSON.stringify(body);
+  await finalizeAudit(ctx, { statusCode, responseBytes: Buffer.byteLength(payload), endpoint: "/api/v1/opportunities" + (id ? "/:id" : ""), method: "GET" });
+  return { statusCode, headers: { ...CORS, "Content-Type": "application/json", ...ctx.rateHeaders }, body: payload };
+};

--- a/netlify/functions/agent-recommended.js
+++ b/netlify/functions/agent-recommended.js
@@ -1,0 +1,36 @@
+// ============================================================================
+// agent-recommended.js — GET /api/v1/recommended
+// Scope: intel:read. Reads PRE-COMPUTED rows from recommended_cache ONLY.
+// NEVER makes a live LLM call (spec §7, hardening §2e). Empty until the nightly
+// batch (lib/score-batch.js) populates the cache — returns an honest empty set.
+// ============================================================================
+
+const { authenticateAgent, finalizeAudit, resp, CORS } = require("./lib/agent-auth");
+const { parsePaging, listRecommended } = require("./lib/agent-data");
+
+const SCOPE = "intel:read";
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return { statusCode: 204, headers: CORS, body: "" };
+  if (event.httpMethod !== "GET") return resp(405, { error: "METHOD_NOT_ALLOWED", message: "Use GET." });
+
+  const paging = parsePaging(event.queryStringParameters);
+  if (paging.error) return resp(400, { error: "BAD_REQUEST", message: paging.error });
+
+  const auth = await authenticateAgent(event, SCOPE);
+  if (!auth.ok) return auth.response;
+  const { ctx } = auth;
+
+  let statusCode = 200, body;
+  try {
+    body = await listRecommended(ctx.db, ctx.userId, paging);
+  } catch (e) {
+    console.error("agent-recommended:", e.message);
+    statusCode = 500; body = { error: "SERVER_ERROR", message: "Could not load recommendations. Try again." };
+  }
+
+  // llm_model stays null — this endpoint never calls a model (audit proves it).
+  const payload = JSON.stringify(body);
+  await finalizeAudit(ctx, { statusCode, responseBytes: Buffer.byteLength(payload), endpoint: "/api/v1/recommended", method: "GET", llmModel: null });
+  return { statusCode, headers: { ...CORS, "Content-Type": "application/json", ...ctx.rateHeaders }, body: payload };
+};

--- a/netlify/functions/agent-score-batch.js
+++ b/netlify/functions/agent-score-batch.js
@@ -1,0 +1,24 @@
+// ============================================================================
+// agent-score-batch.js — nightly scheduled function (Phase 4, sprint2)
+// Scores public opportunities → recommended_cache. Flag-gated + fail-closed:
+// no-ops until AGENT_SCORING_ENABLED=true AND provider keys land (router wired).
+// Schedule block in netlify.toml.
+// ============================================================================
+
+const { getServiceClient } = require("./lib/agent-auth");
+const { runBatch } = require("./lib/agent-score-batch");
+
+exports.handler = async () => {
+  if (process.env.AGENT_SCORING_ENABLED !== "true") {
+    console.log("agent-score-batch: disabled (AGENT_SCORING_ENABLED!=true) — no-op");
+    return { statusCode: 200, body: "disabled" };
+  }
+  try {
+    const stats = await runBatch(getServiceClient(), { limit: Number(process.env.AGENT_SCORING_LIMIT) || 200 });
+    console.log("agent-score-batch:", JSON.stringify(stats));
+    return { statusCode: 200, body: JSON.stringify(stats) };
+  } catch (e) {
+    console.error("agent-score-batch error:", e.message);
+    return { statusCode: 500, body: "error" };
+  }
+};

--- a/netlify/functions/agent-tracker.js
+++ b/netlify/functions/agent-tracker.js
@@ -1,0 +1,33 @@
+// ============================================================================
+// agent-tracker.js — GET /api/v1/tracker
+// Scope: tracker:read. The OWNER's pipeline (mmt_watchlist, scoped by email).
+// ============================================================================
+
+const { authenticateAgent, finalizeAudit, resp, CORS } = require("./lib/agent-auth");
+const { parsePaging, listTracker } = require("./lib/agent-data");
+
+const SCOPE = "tracker:read";
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return { statusCode: 204, headers: CORS, body: "" };
+  if (event.httpMethod !== "GET") return resp(405, { error: "METHOD_NOT_ALLOWED", message: "Use GET." });
+
+  const paging = parsePaging(event.queryStringParameters);
+  if (paging.error) return resp(400, { error: "BAD_REQUEST", message: paging.error });
+
+  const auth = await authenticateAgent(event, SCOPE);
+  if (!auth.ok) return auth.response;
+  const { ctx } = auth;
+
+  let statusCode = 200, body;
+  try {
+    body = await listTracker(ctx.db, ctx.email, paging);
+  } catch (e) {
+    console.error("agent-tracker:", e.message);
+    statusCode = 500; body = { error: "SERVER_ERROR", message: "Could not load your pipeline. Try again." };
+  }
+
+  const payload = JSON.stringify(body);
+  await finalizeAudit(ctx, { statusCode, responseBytes: Buffer.byteLength(payload), endpoint: "/api/v1/tracker", method: "GET" });
+  return { statusCode, headers: { ...CORS, "Content-Type": "application/json", ...ctx.rateHeaders }, body: payload };
+};

--- a/netlify/functions/lib/agent-auth.js
+++ b/netlify/functions/lib/agent-auth.js
@@ -1,0 +1,224 @@
+// ============================================================================
+// lib/agent-auth.js — Agent Access auth middleware (spec §8, hardening §2,§3)
+//
+// Runs on EVERY /api/v1/* request, in order:
+//   1. Bearer token present + structurally valid     → else 401 (generic)
+//   2. SHA-256 lookup in api_tokens                    → not found → 401
+//   3. revoked_at set OR expires_at past               → 401
+//   4. required scope ∈ token.scopes                   → else 403
+//   5. resolve owner email (mp_users) for owner-scoping
+//   6. BUDGET GATE (api_cost_ledger, pre-call)         → red → 429 + Retry-After
+//   7. SESSION GATE (>100 calls/session)               → 429 + X-Session-Limit-Reached
+//   8. RATE LIMIT (per-key 60/min, 5k/day; global 1k/min) → 429 + Retry-After + X-RateLimit-*
+// then the handler runs and calls finalizeAudit() to:
+//   - bump api_tokens.last_used_at
+//   - write the api_audit_log row (cost_usd, response_bytes, session_id, status)
+//   - upsert the api_cost_ledger day+month buckets
+//
+// IDENTITY-MODEL ADAPTATION (Mary, 2026-06-16): mmt-site has no Supabase Auth,
+// so the spec's "set RLS context to user_id" step is realized as explicit
+// owner-scoped filters in lib/agent-data.js. The service client lives HERE and
+// in agent-data.js ONLY — never in a netlify/functions/agent-*.js read handler,
+// so the GATE-3 "no service_role in read handlers" intent holds.
+// ============================================================================
+
+const crypto = require("crypto");
+const { createClient } = require("@supabase/supabase-js");
+const { hashToken, looksLikeToken } = require("./agent-tokens");
+const { RATE, SESSION_MAX_CALLS, BUDGET } = require("./agent-config");
+
+let _client = null;
+/** Memoized service-role client. Used only inside lib/ (auth + data layers). */
+function getServiceClient() {
+  if (!_client) _client = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  return _client;
+}
+
+const CORS = {
+  "Access-Control-Allow-Origin": "https://missionmeetstech.com",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Session-Id, Idempotency-Key",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Vary": "Origin",
+};
+
+function resp(statusCode, body, extra) {
+  return { statusCode, headers: { ...CORS, "Content-Type": "application/json", ...(extra || {}) }, body: JSON.stringify(body) };
+}
+
+// Generic, non-enumerating auth failure (spec §9 — no "expired" vs "not found" leak).
+function unauthorized() {
+  return resp(401, { error: "UNAUTHORIZED", message: "Invalid or missing API key." });
+}
+function forbidden() {
+  return resp(403, { error: "FORBIDDEN", message: "This key isn't allowed to read that." });
+}
+
+function bearerFrom(event) {
+  const h = (event.headers && (event.headers.authorization || event.headers.Authorization)) || "";
+  const m = /^Bearer\s+(.+)$/i.exec(h.trim());
+  return m ? m[1].trim() : null;
+}
+
+function clientIp(event) {
+  const h = event.headers || {};
+  return (h["x-nf-client-connection-ip"] || h["x-forwarded-for"] || "").split(",")[0].trim() || null;
+}
+
+function isUuid(s) {
+  return typeof s === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
+}
+
+/** Count audit rows for a token since `sinceIso` (rate + session windows). */
+async function countAudit(db, filter, sinceIso) {
+  let q = db.from("api_audit_log").select("id", { count: "exact", head: true }).gte("created_at", sinceIso);
+  for (const [k, v] of Object.entries(filter)) q = q.eq(k, v);
+  const { count } = await q;
+  return count || 0;
+}
+
+const nextUtcMidnightSec = () => {
+  const now = new Date();
+  const next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+  return Math.max(1, Math.ceil((next.getTime() - now.getTime()) / 1000));
+};
+
+/**
+ * Authenticate + gate an agent request.
+ * @returns {Promise<{ok:true, ctx} | {ok:false, response}>}
+ */
+async function authenticateAgent(event, requiredScope, dbOverride) {
+  const db = dbOverride || getServiceClient();
+
+  // 1. Bearer present + structurally valid
+  const raw = bearerFrom(event);
+  if (!raw || !looksLikeToken(raw)) return { ok: false, response: unauthorized() };
+
+  // 2. Lookup by hash
+  let token;
+  try {
+    const { data, error } = await db
+      .from("api_tokens")
+      .select("id, user_id, scopes, expires_at, revoked_at")
+      .eq("token_hash", hashToken(raw))
+      .limit(1)
+      .single();
+    if (error || !data) return { ok: false, response: unauthorized() };
+    token = data;
+  } catch {
+    return { ok: false, response: unauthorized() };
+  }
+
+  // 3. Revoked or expired (known key → audit the 401 so §5 alerts can count)
+  const now = new Date();
+  if (token.revoked_at || (token.expires_at && new Date(token.expires_at) <= now)) {
+    await safeAuditFailure(db, token, 401, event, requiredScope);
+    return { ok: false, response: unauthorized() };
+  }
+
+  // 4. Scope
+  if (!Array.isArray(token.scopes) || !token.scopes.includes(requiredScope)) {
+    await safeAuditFailure(db, token, 403, event, requiredScope);
+    return { ok: false, response: forbidden() };
+  }
+
+  // 5. Owner email (for owner-scoped tracker reads)
+  let email = null;
+  try {
+    const { data: u } = await db.from("mp_users").select("email").eq("id", token.user_id).limit(1).single();
+    email = u ? String(u.email || "").toLowerCase() : null;
+  } catch { /* email optional for global endpoints */ }
+
+  // 6. BUDGET GATE (pre-call) — red (>100% daily cap) blocks BEFORE any work
+  const dayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())).toISOString();
+  try {
+    const { data: ledger } = await db
+      .from("api_cost_ledger")
+      .select("spend_usd, budget_usd")
+      .eq("token_id", token.id).eq("window_kind", "day").eq("window_start", dayStart)
+      .limit(1).single();
+    if (ledger && Number(ledger.spend_usd) >= Number(ledger.budget_usd)) {
+      await safeAuditFailure(db, token, 429, event, requiredScope);
+      return { ok: false, response: resp(429, { error: "BUDGET_EXCEEDED", message: "You've reached this period's usage." }, { "Retry-After": String(nextUtcMidnightSec()) }) };
+    }
+  } catch { /* no ledger row yet = $0 spent = pass */ }
+
+  // 7. SESSION GATE — >100 calls per session
+  const sessionId = isUuid(event.headers && (event.headers["x-session-id"] || event.headers["X-Session-Id"]))
+    ? (event.headers["x-session-id"] || event.headers["X-Session-Id"])
+    : crypto.randomUUID(); // no session header = fresh session each call (never trips, by design)
+  const sessSince = new Date(now.getTime() - 24 * 3600 * 1000).toISOString();
+  const sessCount = await countAudit(db, { session_id: sessionId }, sessSince);
+  if (sessCount >= SESSION_MAX_CALLS) {
+    await safeAuditFailure(db, token, 429, event, requiredScope, sessionId);
+    return { ok: false, response: resp(429, { error: "SESSION_LIMIT", message: "This session hit its call limit. Start a new session." }, { "X-Session-Limit-Reached": "true", "Retry-After": "60" }) };
+  }
+
+  // 8. RATE LIMIT — per-key 60/min + 5k/day, global 1k/min
+  const minAgo = new Date(now.getTime() - 60 * 1000).toISOString();
+  const [perMin, perDay, globalMin] = await Promise.all([
+    countAudit(db, { token_id: token.id }, minAgo),
+    countAudit(db, { token_id: token.id }, dayStart),
+    countAudit(db, {}, minAgo),
+  ]);
+  const rateHeaders = {
+    "X-RateLimit-Limit": String(RATE.PER_KEY_PER_MIN),
+    "X-RateLimit-Remaining": String(Math.max(0, RATE.PER_KEY_PER_MIN - perMin - 1)),
+  };
+  if (perMin >= RATE.PER_KEY_PER_MIN || globalMin >= RATE.GLOBAL_PER_MIN) {
+    await safeAuditFailure(db, token, 429, event, requiredScope, sessionId);
+    return { ok: false, response: resp(429, { error: "RATE_LIMITED", message: "Too many requests. Slow down a moment." }, { ...rateHeaders, "Retry-After": "60" }) };
+  }
+  if (perDay >= RATE.PER_KEY_PER_DAY) {
+    await safeAuditFailure(db, token, 429, event, requiredScope, sessionId);
+    return { ok: false, response: resp(429, { error: "DAILY_LIMIT", message: "You've reached today's request limit." }, { ...rateHeaders, "Retry-After": String(nextUtcMidnightSec()) }) };
+  }
+
+  return {
+    ok: true,
+    ctx: { db, token, userId: token.user_id, email, sessionId, rateHeaders, dayStart, startedAt: Date.now(), ip: clientIp(event), userAgent: (event.headers && event.headers["user-agent"]) || null },
+  };
+}
+
+/** Write the success/whatever audit row + bump last_used_at + ledger. Never throws. */
+async function finalizeAudit(ctx, { statusCode, responseBytes = 0, llmModel = null, costUsd = 0, cacheHit = false, endpoint, method = "GET" }) {
+  const { db, token, userId, sessionId } = ctx;
+  try {
+    await db.from("api_tokens").update({ last_used_at: new Date().toISOString() }).eq("id", token.id);
+  } catch (e) { console.error("finalizeAudit last_used_at:", e.message); }
+  try {
+    const { error } = await db.from("api_audit_log").insert({
+      token_id: token.id, user_id: userId, endpoint, method, status_code: statusCode,
+      ip: ctx.ip, user_agent: ctx.userAgent, session_id: sessionId, llm_model: llmModel,
+      cache_hit: cacheHit, cost_usd: costUsd, response_bytes: responseBytes,
+    });
+    if (error) console.error("finalizeAudit insert:", error.message);
+  } catch (e) { console.error("finalizeAudit insert threw:", e.message); }
+  if (costUsd > 0) await bumpLedger(ctx, costUsd).catch((e) => console.error("ledger:", e.message));
+}
+
+async function bumpLedger(ctx, costUsd) {
+  const { db, token, userId, dayStart } = ctx;
+  const monthStart = (() => { const d = new Date(); return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)).toISOString(); })();
+  for (const [window_kind, window_start, budget_usd] of [["day", dayStart, BUDGET.DAILY_USD], ["month", monthStart, BUDGET.MONTHLY_USD]]) {
+    const { data: row } = await db.from("api_cost_ledger").select("id, spend_usd, call_count")
+      .eq("token_id", token.id).eq("window_kind", window_kind).eq("window_start", window_start).limit(1).single();
+    if (row) {
+      await db.from("api_cost_ledger").update({ spend_usd: Number(row.spend_usd) + costUsd, call_count: row.call_count + 1, updated_at: new Date().toISOString() }).eq("id", row.id);
+    } else {
+      await db.from("api_cost_ledger").insert({ token_id: token.id, user_id: userId, window_kind, window_start, spend_usd: costUsd, budget_usd, call_count: 1 });
+    }
+  }
+}
+
+/** Best-effort audit of a rejected request (known token only). Never throws. */
+async function safeAuditFailure(db, token, statusCode, event, endpoint, sessionId) {
+  try {
+    await db.from("api_audit_log").insert({
+      token_id: token.id, user_id: token.user_id, endpoint: endpoint || (event.path || ""), method: event.httpMethod || "GET",
+      status_code: statusCode, ip: clientIp(event), user_agent: (event.headers && event.headers["user-agent"]) || null,
+      session_id: sessionId || null, response_bytes: 0, cost_usd: 0,
+    });
+  } catch (e) { console.error("safeAuditFailure:", e.message); }
+}
+
+module.exports = { authenticateAgent, finalizeAudit, getServiceClient, resp, CORS };

--- a/netlify/functions/lib/agent-config.js
+++ b/netlify/functions/lib/agent-config.js
@@ -1,0 +1,61 @@
+// ============================================================================
+// lib/agent-config.js — single source of truth for Agent Access limits.
+//
+// Centralizes the hardening §2–§5 thresholds, including the params the prose
+// specs left as `X` / `T`. Defaults are conservative; override per-env via the
+// listed environment variables. All values surfaced in the build report so
+// Mary can confirm/tune before promoting to prod.
+// ============================================================================
+
+function num(envName, fallback) {
+  const v = process.env[envName];
+  if (v == null || v === "") return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+// hardening §3 — rate limits (per-key + global)
+const RATE = Object.freeze({
+  PER_KEY_PER_MIN: num("AGENT_RATE_PER_KEY_MIN", 60),
+  PER_KEY_PER_DAY: num("AGENT_RATE_PER_KEY_DAY", 5000),
+  LLM_PER_MIN: num("AGENT_RATE_LLM_MIN", 10),     // Claude-backed endpoints
+  BULK_PER_MIN: num("AGENT_RATE_BULK_MIN", 5),
+  GLOBAL_PER_MIN: num("AGENT_RATE_GLOBAL_MIN", 1000), // canonical in hardening §3; NOT in prompt body
+});
+
+// hardening §2b — session gate
+const SESSION_MAX_CALLS = num("AGENT_SESSION_MAX_CALLS", 100);
+
+// hardening §2a — per-token budget (USD dollars). Reads cost ~0; LLM endpoints spend.
+const BUDGET = Object.freeze({
+  DAILY_USD: num("AGENT_BUDGET_DAILY_USD", 5.0),
+  MONTHLY_USD: num("AGENT_BUDGET_MONTHLY_USD", 50.0),
+});
+
+// hardening §4 — circuit breaker (the `X%` / `T sec` the spec left open)
+const BREAKER = Object.freeze({
+  ERROR_RATE_THRESHOLD: num("AGENT_BREAKER_ERROR_RATE", 0.5), // 50% over the sample window
+  SAMPLE_MIN_CALLS: num("AGENT_BREAKER_SAMPLE_MIN", 20),       // need this many calls before tripping
+  WINDOW_SEC: num("AGENT_BREAKER_WINDOW_SEC", 60),
+  COOLDOWN_SEC: num("AGENT_BREAKER_COOLDOWN_SEC", 60),         // T — stop forwarding this long
+});
+
+// hardening §5 — abuse/harvest alert thresholds (the `X MB/hr` left open)
+const ALERTS = Object.freeze({
+  UNAUTHED_PER_KEY_MIN: num("AGENT_ALERT_401_MIN", 50),   // >50 401/key/60s
+  FORBIDDEN_PER_KEY_MIN: num("AGENT_ALERT_403_MIN", 100), // >100 403/key/60s
+  THROTTLED_PER_KEY_MIN: num("AGENT_ALERT_429_MIN", 10),  // >10 429/key/60s
+  RESPONSE_MB_PER_HR: num("AGENT_ALERT_MB_PER_HR", 50),   // harvest detection
+});
+
+// hardening §4 — pagination
+const PAGINATION = Object.freeze({
+  DEFAULT_LIMIT: 25,
+  MAX_LIMIT: 100,
+});
+
+// CUI/compliance gate (spec §11) — sensitive LLM path stays fail-closed
+// until legal clears AND this env flag is explicitly set to "true".
+const CUI_PATH_CLEARED = process.env.CUI_PATH_CLEARED === "true";
+
+module.exports = { RATE, SESSION_MAX_CALLS, BUDGET, BREAKER, ALERTS, PAGINATION, CUI_PATH_CLEARED };

--- a/netlify/functions/lib/agent-data.js
+++ b/netlify/functions/lib/agent-data.js
@@ -1,0 +1,123 @@
+// ============================================================================
+// lib/agent-data.js — owner-scoped read accessors for the Agent Access API.
+//
+// Every query that returns user-specific rows is hard-filtered by the token
+// owner (this is how the "RLS context = user_id" intent is realized on a stack
+// with no Supabase Auth). Opportunities are global premium data; tracker +
+// recommended are per-owner. The Supabase client is passed in via ctx.db so
+// this module never constructs a service-role client itself.
+// ============================================================================
+
+const { PAGINATION } = require("./agent-config");
+
+/** Parse + clamp pagination. limit>MAX → { error } so the handler returns 400. */
+function parsePaging(qs) {
+  const q = qs || {};
+  let limit = PAGINATION.DEFAULT_LIMIT;
+  if (q.limit != null && q.limit !== "") {
+    const n = Number(q.limit);
+    if (!Number.isInteger(n) || n < 1) return { error: "limit must be a positive integer." };
+    if (n > PAGINATION.MAX_LIMIT) return { error: `limit cannot exceed ${PAGINATION.MAX_LIMIT}.` };
+    limit = n;
+  }
+  let offset = 0;
+  if (q.offset != null && q.offset !== "") {
+    const n = Number(q.offset);
+    if (!Number.isInteger(n) || n < 0) return { error: "offset must be a non-negative integer." };
+    offset = n;
+  }
+  return { limit, offset };
+}
+
+function envelope(rows, total, limit, offset) {
+  return { data: rows, total_count: total, has_more: offset + rows.length < total, limit, offset };
+}
+
+// ---- opportunities (global) ------------------------------------------------
+
+function serializeOpp(r) {
+  return {
+    id: r.id,
+    title: r.title,
+    solicitation_number: r.solicitation_number,
+    agency: r.agency,
+    description: r.description,
+    value_estimate: r.value_estimate,
+    response_deadline: r.response_deadline,
+    set_aside_type: r.set_aside_type,
+    naics_codes: Array.isArray(r.naics_codes) ? r.naics_codes : [],
+    source_url: r.source_url,
+    relevance_score: r.relevance_score,
+    opportunity_type: r.opportunity_type,
+    small_business_eligible: r.small_business_eligible,
+    ai_summary: r.ai_summary,
+    scan_date: r.scan_date,
+  };
+}
+
+const OPP_COLS = "id, title, solicitation_number, agency, description, value_estimate, response_deadline, set_aside_type, naics_codes, source_url, relevance_score, opportunity_type, small_business_eligible, ai_summary, scan_date";
+
+function applyOppFilters(query, f) {
+  if (f.naics) query = query.contains("naics_codes", [String(f.naics)]);
+  if (f.agency) query = query.ilike("agency", `%${f.agency}%`);
+  if (f.set_aside) query = query.ilike("set_aside_type", `%${f.set_aside}%`);
+  if (f.posted_from) query = query.gte("scan_date", f.posted_from);
+  if (f.deadline) query = query.lte("response_deadline", f.deadline);
+  return query;
+}
+
+async function listOpportunities(db, filters, paging) {
+  const { limit, offset } = paging;
+  let countQ = applyOppFilters(db.from("opportunity_radar").select("id", { count: "exact", head: true }), filters);
+  const { count } = await countQ;
+  let q = applyOppFilters(db.from("opportunity_radar").select(OPP_COLS), filters)
+    .order("scan_date", { ascending: false })
+    .order("relevance_score", { ascending: false })
+    .range(offset, offset + limit - 1);
+  const { data, error } = await q;
+  if (error) throw new Error(`opportunities: ${error.message}`);
+  return envelope((data || []).map(serializeOpp), count || 0, limit, offset);
+}
+
+async function getOpportunity(db, id) {
+  if (!/^\d+$/.test(String(id))) return null; // opportunity_radar.id is bigint identity
+  const { data, error } = await db.from("opportunity_radar").select(OPP_COLS).eq("id", id).limit(1).single();
+  if (error || !data) return null;
+  return serializeOpp(data);
+}
+
+// ---- tracker (per-owner: mmt_watchlist by email) ---------------------------
+
+async function listTracker(db, email, paging) {
+  const { limit, offset } = paging;
+  if (!email) return envelope([], 0, limit, offset);
+  const { count } = await db.from("mmt_watchlist").select("entry_id", { count: "exact", head: true }).eq("email", email);
+  const { data, error } = await db.from("mmt_watchlist")
+    .select("entry_id, entry_title, entry_url, saved_at")
+    .eq("email", email)
+    .order("saved_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+  if (error) throw new Error(`tracker: ${error.message}`);
+  const rows = (data || []).map((r) => ({ id: r.entry_id, title: r.entry_title, url: r.entry_url, saved_at: r.saved_at }));
+  return envelope(rows, count || 0, limit, offset);
+}
+
+// ---- recommended (per-owner: recommended_cache, READ ONLY, no LLM) ---------
+
+async function listRecommended(db, userId, paging) {
+  const { limit, offset } = paging;
+  const { count } = await db.from("recommended_cache").select("id", { count: "exact", head: true }).eq("user_id", userId);
+  const { data, error } = await db.from("recommended_cache")
+    .select("opportunity_id, fit_score, rationale, scored_model, scored_at")
+    .eq("user_id", userId)
+    .order("fit_score", { ascending: false })
+    .range(offset, offset + limit - 1);
+  if (error) throw new Error(`recommended: ${error.message}`);
+  const rows = (data || []).map((r) => ({
+    opportunity_id: r.opportunity_id, fit_score: Number(r.fit_score),
+    rationale: r.rationale, scored_model: r.scored_model, scored_at: r.scored_at,
+  }));
+  return envelope(rows, count || 0, limit, offset);
+}
+
+module.exports = { parsePaging, listOpportunities, getOpportunity, listTracker, listRecommended };

--- a/netlify/functions/lib/agent-http.js
+++ b/netlify/functions/lib/agent-http.js
@@ -1,0 +1,45 @@
+// ============================================================================
+// lib/agent-http.js — shared HTTP helpers for Agent Access functions
+// CORS, JSON responses, body parsing, and token masking for logs.
+// ============================================================================
+
+const ALLOWED_ORIGIN = "https://missionmeetstech.com";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, Idempotency-Key",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Vary": "Origin",
+};
+
+/** JSON response with CORS + optional extra headers (e.g. Retry-After). */
+function json(statusCode, body, extraHeaders) {
+  return {
+    statusCode,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json", ...(extraHeaders || {}) },
+    body: JSON.stringify(body),
+  };
+}
+
+/** Preflight short-circuit. Returns a response or null. */
+function preflight(event) {
+  if (event.httpMethod === "OPTIONS") return { statusCode: 204, headers: CORS_HEADERS, body: "" };
+  return null;
+}
+
+/** Parse a JSON body safely. Returns {} on empty/invalid. */
+function parseBody(event) {
+  try {
+    return JSON.parse(event.body || "{}");
+  } catch {
+    return {};
+  }
+}
+
+/** Never log a raw token. mmt_pat_9f3a...c1 -> mmt_pat_9f3a…(masked) */
+function maskToken(raw) {
+  if (typeof raw !== "string" || raw.length < 12) return "(masked)";
+  return raw.slice(0, 12) + "…(masked)";
+}
+
+module.exports = { ALLOWED_ORIGIN, CORS_HEADERS, json, preflight, parseBody, maskToken };

--- a/netlify/functions/lib/agent-model-router.js
+++ b/netlify/functions/lib/agent-model-router.js
@@ -1,0 +1,82 @@
+// ============================================================================
+// lib/agent-model-router.js — US/allied model router for Agent Access
+// (hardening §2c, §2d, spec §11). Distinct from the existing ProposalPulse
+// lib/model-router.js — do not conflate.
+//
+// CLASSIFY FIRST, then route. Built per spec, shipped FAIL-CLOSED per Mary's
+// 2026-06-16 decision ("defer router, build read-API"):
+//   - sensitive (CUI/PII) → Bedrock GovCloud, but 503 COMPLIANCE_HOLD unless
+//     CUI_PATH_CLEARED === 'true' (legal must clear §11 first).
+//   - public → Gemini 3 Flash (default) / GPT-5.4 nano (batch) / Llama 4
+//     (self-host); low-confidence escalates Haiku 4.5 → Sonnet 4.6.
+//   - NO Chinese-origin models anywhere (DeepSeek/Qwen/GLM/MiniMax). The
+//     PROVIDERS registry is the allow-list; a deny-list is the safety net.
+//   - Every routing decision carries max_tokens (§2c); oversized input rejected.
+//
+// Provider SDK invocation is intentionally NOT wired (keys absent; the read API
+// needs no live model). invoke() returns PROVIDER_NOT_CONFIGURED until keys
+// land — fail-closed surface, fully testable routing logic now.
+// ============================================================================
+
+const PROVIDERS = Object.freeze({
+  "gemini-3-flash": { vendor: "google", envKey: "GEMINI_API_KEY", boundary: "public" },
+  "gpt-5.4-nano": { vendor: "openai", envKey: "OPENAI_API_KEY", boundary: "public" },
+  "llama-4": { vendor: "meta-selfhost", envKey: "LLAMA_ENDPOINT_URL", boundary: "public" },
+  "claude-haiku-4-5": { vendor: "anthropic", envKey: "ANTHROPIC_API_KEY", boundary: "public" },
+  "claude-sonnet-4-6": { vendor: "anthropic", envKey: "ANTHROPIC_API_KEY", boundary: "public" },
+  "bedrock-claude-govcloud": { vendor: "aws-bedrock-govcloud", envKey: "AWS_ACCESS_KEY_ID", boundary: "sensitive" },
+});
+
+const BANNED_SUBSTRINGS = ["deepseek", "qwen", "glm", "minimax"];
+
+const DEFAULT_MAX_TOKENS = 1024;
+const MAX_INPUT_CHARS = 24000; // ~6k tokens; reject oversized before any call (§2c)
+
+const SENSITIVE_PATTERNS = [
+  /\bCUI\b/, /\bFOUO\b/, /controlled unclassified/i, /\bPII\b/,
+  /\b\d{3}-\d{2}-\d{4}\b/,            // SSN
+  /\bclassified\b/i, /\bclearance\b/i, /\bITAR\b/, /\bnoforn\b/i,
+];
+
+/** Classify a payload's sensitivity. Returns 'public' | 'sensitive'. */
+function classifyPayload(payload) {
+  const text = typeof payload === "string" ? payload : JSON.stringify(payload || "");
+  return SENSITIVE_PATTERNS.some((re) => re.test(text)) ? "sensitive" : "public";
+}
+
+/** Pure routing decision (no side effects, no calls). */
+function route(payload, opts = {}) {
+  const dataClass = classifyPayload(payload);
+  let model;
+  if (dataClass === "sensitive") model = "bedrock-claude-govcloud";
+  else if (opts.escalate) model = "claude-haiku-4-5";
+  else if (opts.selfHost) model = "llama-4";
+  else if (opts.batch) model = "gpt-5.4-nano";
+  else model = "gemini-3-flash";
+  const meta = PROVIDERS[model];
+  return {
+    dataClass, model, vendor: meta.vendor, boundary: meta.boundary,
+    maxTokens: Number(opts.maxTokens) > 0 ? Number(opts.maxTokens) : DEFAULT_MAX_TOKENS,
+    reason: dataClass === "sensitive" ? "CUI/PII → GovCloud boundary" : `public → ${model}`,
+  };
+}
+
+/** Fail-closed call attempt (no SDKs wired yet). */
+async function invoke(payload, opts = {}) {
+  const text = typeof payload === "string" ? payload : JSON.stringify(payload || "");
+  if (text.length > MAX_INPUT_CHARS) return { ok: false, status: 413, code: "INPUT_TOO_LARGE", decision: null };
+
+  const decision = route(payload, opts);
+  if (BANNED_SUBSTRINGS.some((b) => decision.model.toLowerCase().includes(b))) {
+    return { ok: false, status: 500, code: "BANNED_MODEL_BLOCKED", decision };
+  }
+  if (decision.dataClass === "sensitive" && process.env.CUI_PATH_CLEARED !== "true") {
+    return { ok: false, status: 503, code: "COMPLIANCE_HOLD", decision };
+  }
+  const meta = PROVIDERS[decision.model];
+  if (!process.env[meta.envKey]) return { ok: false, status: 503, code: "PROVIDER_NOT_CONFIGURED", decision };
+  // Keys present + cleared: wire SDKs here (run `chub get` first). Until then, fail closed.
+  return { ok: false, status: 503, code: "ROUTER_NOT_WIRED", decision };
+}
+
+module.exports = { PROVIDERS, BANNED_SUBSTRINGS, DEFAULT_MAX_TOKENS, MAX_INPUT_CHARS, classifyPayload, route, invoke };

--- a/netlify/functions/lib/agent-observability.js
+++ b/netlify/functions/lib/agent-observability.js
@@ -1,0 +1,89 @@
+// ============================================================================
+// lib/agent-observability.js — alerts (§5) + circuit breaker (§4)
+//
+// Both are driven by api_audit_log so they need no extra state store (serverless
+// has no durable in-memory state). Pure evaluators are exported for testing; the
+// sweep + breaker-check do the IO via an injected db client.
+// ============================================================================
+
+const { ALERTS, BREAKER } = require("./agent-config");
+
+// ---- §5 abuse / harvest alerts ---------------------------------------------
+
+/**
+ * Given per-key counts over the last 60s and bytes/hr, return the alerts that
+ * should fire. Pure — the sweep feeds it real numbers.
+ * @param {object} m { unauthedPerMin, forbiddenPerMin, throttledPerMin, mbPerHr } per key
+ */
+function evaluateAlerts(m) {
+  const fired = [];
+  if (m.unauthedPerMin > ALERTS.UNAUTHED_PER_KEY_MIN) fired.push({ kind: "AUTH_SPIKE", detail: `${m.unauthedPerMin} 401s/min` });
+  if (m.forbiddenPerMin > ALERTS.FORBIDDEN_PER_KEY_MIN) fired.push({ kind: "SCOPE_SPIKE", detail: `${m.forbiddenPerMin} 403s/min` });
+  if (m.throttledPerMin > ALERTS.THROTTLED_PER_KEY_MIN) fired.push({ kind: "THROTTLE_SPIKE", detail: `${m.throttledPerMin} 429s/min` });
+  if (m.mbPerHr > ALERTS.RESPONSE_MB_PER_HR) fired.push({ kind: "HARVEST", detail: `${m.mbPerHr.toFixed(1)} MB/hr` });
+  return fired;
+}
+
+/** Sweep recent audit rows per token and fire a webhook/log for any over-threshold key. */
+async function sweepAlerts(db, { now = Date.now(), notify } = {}) {
+  const minAgo = new Date(now - 60000).toISOString();
+  const hrAgo = new Date(now - 3600000).toISOString();
+
+  const { data: recent } = await db
+    .from("api_audit_log")
+    .select("token_id, status_code, response_bytes, created_at")
+    .gte("created_at", hrAgo);
+  if (!recent || recent.length === 0) return [];
+
+  const byKey = new Map();
+  for (const r of recent) {
+    const k = r.token_id || "anon";
+    const e = byKey.get(k) || { unauthedPerMin: 0, forbiddenPerMin: 0, throttledPerMin: 0, mbPerHr: 0 };
+    e.mbPerHr += (r.response_bytes || 0) / 1e6;
+    if (r.created_at >= minAgo) {
+      if (r.status_code === 401) e.unauthedPerMin++;
+      else if (r.status_code === 403) e.forbiddenPerMin++;
+      else if (r.status_code === 429) e.throttledPerMin++;
+    }
+    byKey.set(k, e);
+  }
+
+  const allFired = [];
+  for (const [token_id, m] of byKey) {
+    const fired = evaluateAlerts(m);
+    for (const f of fired) {
+      allFired.push({ token_id, ...f });
+      if (typeof notify === "function") await notify({ token_id, ...f });
+      else console.warn("AGENT_ALERT", JSON.stringify({ token_id, ...f }));
+    }
+  }
+  return allFired;
+}
+
+// ---- §4 circuit breaker (LLM calls) ----------------------------------------
+
+/**
+ * Decide whether the breaker should be OPEN given a sample window.
+ * Open only once we have a meaningful sample (SAMPLE_MIN_CALLS) AND the error
+ * rate exceeds the threshold. Pure.
+ */
+function evaluateBreaker(total, errors) {
+  if (total < BREAKER.SAMPLE_MIN_CALLS) return { open: false, rate: total ? errors / total : 0, reason: "sample too small" };
+  const rate = errors / total;
+  return { open: rate > BREAKER.ERROR_RATE_THRESHOLD, rate, reason: rate > BREAKER.ERROR_RATE_THRESHOLD ? "error rate exceeded" : "healthy" };
+}
+
+/** DB-backed breaker check for a given model over the rolling window. */
+async function breakerOpenForModel(db, model, { now = Date.now() } = {}) {
+  const since = new Date(now - BREAKER.WINDOW_SEC * 1000).toISOString();
+  const { data } = await db
+    .from("api_audit_log")
+    .select("status_code")
+    .eq("llm_model", model)
+    .gte("created_at", since);
+  const rows = data || [];
+  const errors = rows.filter((r) => r.status_code >= 500).length;
+  return evaluateBreaker(rows.length, errors);
+}
+
+module.exports = { evaluateAlerts, sweepAlerts, evaluateBreaker, breakerOpenForModel };

--- a/netlify/functions/lib/agent-score-batch.js
+++ b/netlify/functions/lib/agent-score-batch.js
@@ -1,0 +1,67 @@
+// ============================================================================
+// lib/agent-score-batch.js — nightly pre-computation that feeds /api/v1/recommended
+// (sprint2 §pre-computation, hardening §2d/§2e). Scores PUBLIC opportunities
+// per user and writes recommended_cache. /recommended only ever READS that table.
+//
+// Deferred-build state: routes through agent-model-router.invoke(), which is
+// fail-closed until provider keys land — so this scores nothing yet and logs a
+// clean no-op. Gated behind AGENT_SCORING_ENABLED so the cron never errors
+// before keys/migration exist (mirrors the LOOPS_ENABLED pattern).
+// ============================================================================
+
+const { invoke } = require("./agent-model-router");
+
+const SCORE_RE_TTL_DAYS = 7;
+
+/** Build the (public-only) scoring payload for one opportunity. */
+function buildScorePayload(opp) {
+  return [
+    `Opportunity: ${opp.title || ""}`,
+    `Agency: ${opp.agency || ""}`,
+    `NAICS: ${(opp.naics_codes || []).join(", ")}`,
+    `Set-aside: ${opp.set_aside_type || ""}`,
+    `Summary: ${opp.ai_summary || opp.description || ""}`,
+  ].join("\n");
+}
+
+/**
+ * Score a batch. Pure-ish: all IO via injected `db`; model via the router.
+ * @returns {Promise<{scanned, scored, skipped, holds}>}
+ */
+async function runBatch(db, { limit = 200 } = {}) {
+  const stats = { scanned: 0, scored: 0, skipped: 0, holds: 0 };
+
+  // Users to score for: paid mp_users. (Recommended is intel:read / premium.)
+  const { data: users } = await db.from("mp_users").select("id").limit(5000);
+  const { data: opps } = await db
+    .from("opportunity_radar")
+    .select("id, title, agency, naics_codes, set_aside_type, ai_summary, description")
+    .order("scan_date", { ascending: false })
+    .limit(limit);
+
+  if (!users || !opps) return stats;
+  const expiresAt = new Date(Date.now() + SCORE_RE_TTL_DAYS * 864e5).toISOString();
+
+  for (const opp of opps) {
+    stats.scanned++;
+    const result = await invoke(buildScorePayload(opp), { batch: true });
+    if (!result.ok) {
+      // Fail-closed router (no keys / compliance hold) → skip, don't fabricate.
+      if (result.code === "COMPLIANCE_HOLD") stats.holds++;
+      stats.skipped++;
+      continue;
+    }
+    // When the router is wired, result carries { fitScore, rationale, model }.
+    const rows = users.map((u) => ({
+      user_id: u.id, opportunity_id: String(opp.id),
+      fit_score: result.fitScore, rationale: result.rationale,
+      data_class: "public", scored_model: result.decision && result.decision.model,
+      expires_at: expiresAt,
+    }));
+    const { error } = await db.from("recommended_cache").upsert(rows, { onConflict: "user_id,opportunity_id" });
+    if (!error) stats.scored += rows.length;
+  }
+  return stats;
+}
+
+module.exports = { buildScorePayload, runBatch, SCORE_RE_TTL_DAYS };

--- a/netlify/functions/lib/agent-session.js
+++ b/netlify/functions/lib/agent-session.js
@@ -1,0 +1,92 @@
+// ============================================================================
+// lib/agent-session.js — resolve the VERIFIED owner of a token-management request
+//
+// Minting / listing / revoking an API token is far higher-stakes than the
+// existing read-gated pages, so it must NOT trust a caller-supplied email
+// (member-auth.js does that — fine for read-gating, unacceptable for credential
+// minting). Instead it requires a verified magic-link session token from the
+// existing customer-auth.js flow (customer_sessions: token_hash + email + 7d
+// expiry). Holding a valid session proves the caller controls that email.
+//
+// Flow:  sessionToken --(customer_sessions)--> email --(mp_users)--> user_id
+//        then loadEntitlement() gates the agent API behind a paid tier.
+//
+// Returns a discriminated result so callers never have to guess:
+//   { ok:true,  userId, email, entitlement }
+//   { ok:false, status, code, message }   (generic — no enumeration leak)
+// ============================================================================
+
+const crypto = require("crypto");
+const { loadEntitlement } = require("./entitlement");
+
+function hashSessionToken(token) {
+  return crypto.createHash("sha256").update(String(token)).digest("hex");
+}
+
+const GENERIC_AUTH = {
+  ok: false,
+  status: 401,
+  code: "NOT_SIGNED_IN",
+  // Human copy lives in the UI (UX §7); the API stays generic + non-enumerating.
+  message: "Sign in to manage your AI connections.",
+};
+
+/**
+ * @param {object} supabase  service-role client
+ * @param {string} sessionToken  the magic-link session token from customer-auth
+ * @returns {Promise<object>} resolved owner or a generic auth failure
+ */
+async function resolveAgentOwner(supabase, sessionToken) {
+  if (!sessionToken || typeof sessionToken !== "string") return { ...GENERIC_AUTH };
+
+  // 1. Verify the magic-link session (same lookup customer-auth.js uses).
+  let session;
+  try {
+    const { data, error } = await supabase
+      .from("customer_sessions")
+      .select("email, expires_at")
+      .eq("token_hash", hashSessionToken(sessionToken))
+      .eq("is_valid", true)
+      .gt("expires_at", new Date().toISOString())
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .single();
+    if (error || !data) return { ...GENERIC_AUTH };
+    session = data;
+  } catch {
+    return { ...GENERIC_AUTH };
+  }
+
+  const email = String(session.email || "").toLowerCase().trim();
+  if (!email) return { ...GENERIC_AUTH };
+
+  // 2. Gate on a paid tier — the agent API is a premium feature.
+  const entitlement = await loadEntitlement(supabase, email);
+  if (!entitlement.ok) {
+    return {
+      ok: false,
+      status: 403,
+      code: "SUBSCRIPTION_REQUIRED",
+      message: "API access is a premium feature. See /pricing.",
+    };
+  }
+
+  // 3. Resolve the owning mp_users row (the FK target for api_tokens.user_id).
+  let userId;
+  try {
+    const { data: user, error } = await supabase
+      .from("mp_users")
+      .select("id")
+      .ilike("email", email)
+      .limit(1)
+      .single();
+    if (error || !user) return { ...GENERIC_AUTH };
+    userId = user.id;
+  } catch {
+    return { ...GENERIC_AUTH };
+  }
+
+  return { ok: true, userId, email, entitlement };
+}
+
+module.exports = { resolveAgentOwner, hashSessionToken };

--- a/netlify/functions/lib/agent-tokens.js
+++ b/netlify/functions/lib/agent-tokens.js
@@ -1,0 +1,90 @@
+// ============================================================================
+// lib/agent-tokens.js — token crypto + scope helpers for the Agent Access API
+//
+// A raw personal access token (PAT) is shown to the user EXACTLY ONCE. We store
+// only its SHA-256 hash + an 8-char display prefix. There is no way to recover
+// the raw token from the database — lost = make a new one (UX spec §5 Screen 3).
+//
+// Token shape:  mmt_pat_<48 hex chars>   (e.g. mmt_pat_9f3a...c1)
+//   - the "mmt_pat_" literal lets middleware reject obviously-wrong tokens fast
+//   - 24 random bytes (48 hex) = 192 bits of entropy
+//   - token_prefix = first 8 hex chars of the random part (display-only,
+//     so the advanced token table can disambiguate without revealing anything)
+// ============================================================================
+
+const crypto = require("crypto");
+
+const TOKEN_LITERAL = "mmt_pat_";
+
+// Canonical scopes. These are the ONLY scopes a token may carry. The UX maps
+// each to plain language (spec §5 Screen 1) but the stored value is the raw form.
+const VALID_SCOPES = Object.freeze([
+  "opportunities:read", // GET /api/v1/opportunities(/:id)
+  "tracker:read",       // GET /api/v1/tracker
+  "intel:read",         // GET /api/v1/recommended
+]);
+
+const DEFAULT_SCOPES = Object.freeze(["opportunities:read"]);
+
+// Token CRUD policy (spec §6 / §9):
+const MAX_ACTIVE_TOKENS_PER_USER = 5;
+const DEFAULT_EXPIRY_DAYS = 90;
+// Friendly expiry options the UX offers (spec §5 Screen 2). null = never.
+const ALLOWED_EXPIRY_DAYS = Object.freeze([30, 90, 365, null]);
+
+/** Generate a fresh PAT. Returns the raw token (show once), its hash, and prefix. */
+function generateToken() {
+  const random = crypto.randomBytes(24).toString("hex"); // 48 hex chars
+  const raw = TOKEN_LITERAL + random;
+  return {
+    raw,
+    hash: hashToken(raw),
+    prefix: random.slice(0, 8), // display-only, never the whole token
+  };
+}
+
+/** SHA-256 hex of the raw token. Used for storage + constant-time lookup. */
+function hashToken(raw) {
+  return crypto.createHash("sha256").update(String(raw)).digest("hex");
+}
+
+/** Cheap structural check before hitting the DB. Does NOT prove validity. */
+function looksLikeToken(raw) {
+  return typeof raw === "string" && /^mmt_pat_[0-9a-f]{48}$/.test(raw.trim());
+}
+
+/**
+ * Validate + normalize a requested scope list.
+ * Returns { ok, scopes, error }. Unknown scope = reject (no silent drop).
+ */
+function normalizeScopes(requested) {
+  if (requested == null) return { ok: true, scopes: [...DEFAULT_SCOPES] };
+  const list = Array.isArray(requested) ? requested : [requested];
+  const cleaned = [...new Set(list.map((s) => String(s).trim()).filter(Boolean))];
+  if (cleaned.length === 0) return { ok: true, scopes: [...DEFAULT_SCOPES] };
+  const bad = cleaned.filter((s) => !VALID_SCOPES.includes(s));
+  if (bad.length) return { ok: false, error: `Unknown scope(s): ${bad.join(", ")}` };
+  return { ok: true, scopes: cleaned };
+}
+
+/** Resolve a friendly expiry (days) to an ISO timestamp, or null for never. */
+function expiryToIso(days) {
+  if (days == null) return null;
+  const n = Number(days);
+  if (!ALLOWED_EXPIRY_DAYS.includes(n)) return undefined; // signal: invalid
+  return new Date(Date.now() + n * 24 * 3600 * 1000).toISOString();
+}
+
+module.exports = {
+  TOKEN_LITERAL,
+  VALID_SCOPES,
+  DEFAULT_SCOPES,
+  MAX_ACTIVE_TOKENS_PER_USER,
+  DEFAULT_EXPIRY_DAYS,
+  ALLOWED_EXPIRY_DAYS,
+  generateToken,
+  hashToken,
+  looksLikeToken,
+  normalizeScopes,
+  expiryToIso,
+};

--- a/netlify/functions/tokens-activity.js
+++ b/netlify/functions/tokens-activity.js
@@ -1,0 +1,51 @@
+// ============================================================================
+// tokens-activity.js — POST /api/tokens/activity (UX §8 trust feature)
+// Returns the last 20 audit reads for one of the caller's connections, so the
+// member can SEE what their AI assistant accessed. Owner-scoped via the
+// verified magic-link session; never exposes another user's activity.
+// Body: { sessionToken, tokenId }
+// ============================================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { json, preflight, parseBody } = require("./lib/agent-http");
+const { resolveAgentOwner } = require("./lib/agent-session");
+
+exports.handler = async (event) => {
+  const pf = preflight(event);
+  if (pf) return pf;
+  if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
+
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  const body = parseBody(event);
+  const owner = await resolveAgentOwner(supabase, body.sessionToken);
+  if (!owner.ok) return json(owner.status, { error: owner.code, message: owner.message });
+
+  const tokenId = String(body.tokenId || "").trim();
+  if (!tokenId) return json(400, { error: "TOKEN_ID_REQUIRED", message: "Which connection?" });
+
+  // Confirm the connection belongs to the caller before reading its activity.
+  const { data: owned } = await supabase
+    .from("api_tokens").select("id").eq("id", tokenId).eq("user_id", owner.userId).limit(1);
+  if (!owned || owned.length === 0) {
+    return json(404, { error: "NOT_FOUND", message: "That connection no longer exists." });
+  }
+
+  const { data, error } = await supabase
+    .from("api_audit_log")
+    .select("endpoint, method, status_code, created_at, response_bytes")
+    .eq("token_id", tokenId)
+    .eq("user_id", owner.userId)
+    .order("created_at", { ascending: false })
+    .limit(20);
+
+  if (error) {
+    console.error("tokens-activity error:", error.message);
+    return json(500, { error: "SERVER_ERROR", message: "Could not load activity. Try again." });
+  }
+
+  const reads = (data || []).map((r) => ({
+    endpoint: r.endpoint, method: r.method, status: r.status_code,
+    at: r.created_at, bytes: r.response_bytes,
+  }));
+  return json(200, { reads });
+};

--- a/netlify/functions/tokens-create.js
+++ b/netlify/functions/tokens-create.js
@@ -1,0 +1,93 @@
+// ============================================================================
+// tokens-create.js — POST /api/tokens (spec §7)
+// Create a personal access token. Returns the raw token EXACTLY ONCE.
+//
+// Body: { sessionToken, name, scopes?, expiryDays? }
+//   sessionToken — verified magic-link session (proves email ownership)
+//   name         — required, the friendly connection name (UX §5 Screen 2)
+//   scopes       — optional, defaults to opportunities:read
+//   expiryDays   — optional, one of 30/90/365/null; defaults to 90
+//
+// Enforces: max 5 active tokens/user. Stores SHA-256 hash + 8-char prefix only.
+// ============================================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { json, preflight, parseBody, maskToken } = require("./lib/agent-http");
+const { resolveAgentOwner } = require("./lib/agent-session");
+const {
+  generateToken, normalizeScopes, expiryToIso,
+  MAX_ACTIVE_TOKENS_PER_USER, DEFAULT_EXPIRY_DAYS,
+} = require("./lib/agent-tokens");
+
+exports.handler = async (event) => {
+  const pf = preflight(event);
+  if (pf) return pf;
+  if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
+
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  const body = parseBody(event);
+
+  // 1. Verified owner (magic-link session -> email -> mp_users.id + premium gate)
+  const owner = await resolveAgentOwner(supabase, body.sessionToken);
+  if (!owner.ok) return json(owner.status, { error: owner.code, message: owner.message });
+
+  // 2. Validate inputs
+  const name = String(body.name || "").trim();
+  if (!name) return json(400, { error: "NAME_REQUIRED", message: "Give this connection a name." });
+  if (name.length > 80) return json(400, { error: "NAME_TOO_LONG", message: "Name must be 80 characters or fewer." });
+
+  const scopeResult = normalizeScopes(body.scopes);
+  if (!scopeResult.ok) return json(400, { error: "INVALID_SCOPE", message: scopeResult.error });
+
+  const expiryDays = body.expiryDays === undefined ? DEFAULT_EXPIRY_DAYS : body.expiryDays;
+  const expiresAt = expiryToIso(expiryDays);
+  if (expiresAt === undefined) return json(400, { error: "INVALID_EXPIRY", message: "Expiry must be 30, 90, 365 days, or never." });
+
+  // 3. Enforce max active tokens (revoked_at IS NULL = active)
+  const { count, error: countErr } = await supabase
+    .from("api_tokens")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", owner.userId)
+    .is("revoked_at", null);
+  if (countErr) {
+    console.error("tokens-create count error:", countErr.message);
+    return json(500, { error: "SERVER_ERROR", message: "Could not create the connection. Try again." });
+  }
+  if ((count || 0) >= MAX_ACTIVE_TOKENS_PER_USER) {
+    return json(400, {
+      error: "TOO_MANY_TOKENS",
+      message: `You can have up to ${MAX_ACTIVE_TOKENS_PER_USER} active connections. Revoke one to add another.`,
+    });
+  }
+
+  // 4. Mint + store (hash + prefix only — never the raw token)
+  const tok = generateToken();
+  const { data: inserted, error: insErr } = await supabase
+    .from("api_tokens")
+    .insert({
+      user_id: owner.userId,
+      name,
+      token_hash: tok.hash,
+      token_prefix: tok.prefix,
+      scopes: scopeResult.scopes,
+      expires_at: expiresAt,
+    })
+    .select("id, name, token_prefix, scopes, expires_at, created_at")
+    .single();
+
+  if (insErr || !inserted) {
+    console.error("tokens-create insert error:", insErr && insErr.message, "token:", maskToken(tok.raw));
+    return json(500, { error: "SERVER_ERROR", message: "Could not create the connection. Try again." });
+  }
+
+  // 5. Return the raw token ONCE. It is never retrievable again.
+  return json(201, {
+    id: inserted.id,
+    name: inserted.name,
+    token: tok.raw, // shown once (UX §5 Screen 3)
+    token_prefix: inserted.token_prefix,
+    scopes: inserted.scopes,
+    expires_at: inserted.expires_at,
+    created_at: inserted.created_at,
+  });
+};

--- a/netlify/functions/tokens-list.js
+++ b/netlify/functions/tokens-list.js
@@ -1,0 +1,53 @@
+// ============================================================================
+// tokens-list.js — POST /api/tokens (action=list) (spec §7)
+// List the caller's tokens. NEVER returns token_hash or the raw token.
+// Body: { sessionToken }
+// Returns connection rows with a derived status (Active/Expired/Revoked) so the
+// UI doesn't have to recompute it (UX §6).
+// ============================================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { json, preflight, parseBody } = require("./lib/agent-http");
+const { resolveAgentOwner } = require("./lib/agent-session");
+
+function statusOf(row, now) {
+  if (row.revoked_at) return "revoked";
+  if (row.expires_at && new Date(row.expires_at) <= now) return "expired";
+  return "active";
+}
+
+exports.handler = async (event) => {
+  const pf = preflight(event);
+  if (pf) return pf;
+  if (event.httpMethod !== "POST") return json(405, { error: "Method not allowed" });
+
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  const owner = await resolveAgentOwner(supabase, parseBody(event).sessionToken);
+  if (!owner.ok) return json(owner.status, { error: owner.code, message: owner.message });
+
+  // Explicit column list — token_hash is intentionally excluded.
+  const { data, error } = await supabase
+    .from("api_tokens")
+    .select("id, name, token_prefix, scopes, last_used_at, expires_at, revoked_at, created_at")
+    .eq("user_id", owner.userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("tokens-list error:", error.message);
+    return json(500, { error: "SERVER_ERROR", message: "Could not load your connections. Try again." });
+  }
+
+  const now = new Date();
+  const connections = (data || []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    token_prefix: row.token_prefix,
+    scopes: row.scopes,
+    last_used_at: row.last_used_at,
+    expires_at: row.expires_at,
+    created_at: row.created_at,
+    status: statusOf(row, now),
+  }));
+
+  return json(200, { connections });
+};

--- a/netlify/functions/tokens-revoke.js
+++ b/netlify/functions/tokens-revoke.js
@@ -1,0 +1,59 @@
+// ============================================================================
+// tokens-revoke.js — DELETE/POST /api/tokens (action=revoke) (spec §7)
+// Instant kill: sets revoked_at. The token stops working on the next request
+// (middleware rejects any token with revoked_at set).
+// Body: { sessionToken, tokenId }
+// Idempotent: revoking an already-revoked token returns success.
+// ============================================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { json, preflight, parseBody } = require("./lib/agent-http");
+const { resolveAgentOwner } = require("./lib/agent-session");
+
+exports.handler = async (event) => {
+  const pf = preflight(event);
+  if (pf) return pf;
+  if (event.httpMethod !== "POST" && event.httpMethod !== "DELETE") {
+    return json(405, { error: "Method not allowed" });
+  }
+
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  const body = parseBody(event);
+  const owner = await resolveAgentOwner(supabase, body.sessionToken);
+  if (!owner.ok) return json(owner.status, { error: owner.code, message: owner.message });
+
+  const tokenId = String(body.tokenId || "").trim();
+  if (!tokenId) return json(400, { error: "TOKEN_ID_REQUIRED", message: "Which connection do you want to revoke?" });
+
+  // Scope the update to the OWNER's rows — a caller can never revoke another
+  // user's token even with a guessed id (user_id filter + RLS fail-closed).
+  const { data, error } = await supabase
+    .from("api_tokens")
+    .update({ revoked_at: new Date().toISOString() })
+    .eq("id", tokenId)
+    .eq("user_id", owner.userId)
+    .is("revoked_at", null) // idempotent: no-op if already revoked
+    .select("id");
+
+  if (error) {
+    console.error("tokens-revoke error:", error.message);
+    return json(500, { error: "SERVER_ERROR", message: "Could not revoke the connection. Try again." });
+  }
+
+  // If nothing was updated it was either already revoked or not the caller's —
+  // confirm the row exists for this owner so we return an honest 404 vs 200.
+  if (!data || data.length === 0) {
+    const { data: existing } = await supabase
+      .from("api_tokens")
+      .select("id")
+      .eq("id", tokenId)
+      .eq("user_id", owner.userId)
+      .limit(1);
+    if (!existing || existing.length === 0) {
+      return json(404, { error: "NOT_FOUND", message: "That connection no longer exists." });
+    }
+    // Already revoked — idempotent success.
+  }
+
+  return json(200, { revoked: true, id: tokenId });
+};

--- a/premium/ai-integrations.html
+++ b/premium/ai-integrations.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI &amp; Integrations — Connect your AI assistant — MMT Premium</title>
+  <meta name="robots" content="noindex">
+  <meta name="description" content="Connect the AI assistant you already use to your live opportunities and market intel. Read-only, revoke anytime, every access logged.">
+  <link rel="stylesheet" href="/styles/tailwind.css">
+  <link rel="icon" href="/favicon-v3.png" type="image/png">
+  <style>
+    /* Scoped component styles only — NO dash-shell/dash-nav/dash-main here.
+       injectDashShell() owns the layout (repo hard rule: mapped pages are
+       content-only). MMT tokens; no dark mode; AA contrast; visible focus. */
+    :root { --mmt-navy:#0A192F; --mmt-teal:#457B9D; --mmt-white:#FFFFFF; --mmt-surface:#F3F4F6; --mmt-text-secondary:#5C6B7A; --mmt-border:#E5E7EB; --ok:#437A22; --warn:#964219; --err:#A12C7B; }
+    .ai-wrap { max-width:860px; }
+    .ai-h1 { font-size:22px; font-weight:800; color:var(--mmt-navy); margin:0 0 4px; }
+    .ai-sub { font-size:15px; color:var(--mmt-text-secondary); margin:0 0 24px; line-height:1.5; }
+    .ai-card { background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:12px; padding:20px 22px; margin-bottom:16px; }
+    .ai-hero { background:linear-gradient(180deg,#fff, #fbfcfd); border:1px solid var(--mmt-border); border-left:4px solid var(--mmt-teal); }
+    .ai-hero h2 { font-size:18px; font-weight:800; margin:0 0 6px; color:var(--mmt-navy); }
+    .ai-hero p { font-size:14px; color:var(--mmt-text-secondary); margin:0 0 14px; line-height:1.55; }
+    .ai-secondary-grid { display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-bottom:16px; }
+    .ai-mini { background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:10px; padding:14px 16px; }
+    .ai-mini h3 { font-size:13px; font-weight:700; margin:0 0 4px; color:var(--mmt-navy); }
+    .ai-mini p { font-size:12px; color:var(--mmt-text-secondary); margin:0; }
+    .ai-trust { display:flex; flex-wrap:wrap; gap:10px; margin:14px 0 0; padding:0; list-style:none; }
+    .ai-trust li { display:flex; align-items:center; gap:6px; font-size:12px; font-weight:600; color:var(--mmt-navy); background:var(--mmt-surface); border:1px solid var(--mmt-border); border-radius:999px; padding:6px 12px; }
+    .ai-btn { display:inline-flex; align-items:center; gap:8px; background:var(--mmt-navy); color:#fff; border:none; padding:11px 18px; border-radius:8px; font-size:14px; font-weight:600; cursor:pointer; text-decoration:none; }
+    .ai-btn:hover { background:#13294a; }
+    .ai-btn[disabled] { opacity:.5; cursor:not-allowed; }
+    .ai-btn-ghost { background:transparent; color:var(--mmt-teal); border:1px solid var(--mmt-border); }
+    .ai-btn-danger { background:var(--err); }
+    .ai-btn:focus-visible, .ai-toggle:focus-visible, .ai-scope:focus-within, input:focus-visible, select:focus-visible, a:focus-visible { outline:3px solid var(--mmt-teal); outline-offset:2px; }
+    .ai-field { display:block; margin:0 0 14px; }
+    .ai-field label { display:block; font-size:13px; font-weight:700; color:var(--mmt-navy); margin-bottom:6px; }
+    .ai-field input, .ai-field select { width:100%; box-sizing:border-box; padding:10px 12px; font-size:14px; border:1px solid var(--mmt-border); border-radius:8px; font-family:inherit; }
+    .ai-scope { display:flex; gap:12px; align-items:flex-start; border:1px solid var(--mmt-border); border-radius:10px; padding:12px 14px; margin-bottom:10px; cursor:pointer; }
+    .ai-scope[data-on="true"] { border-color:var(--mmt-teal); background:rgba(69,123,157,.06); }
+    .ai-scope input { margin-top:3px; }
+    .ai-scope .t { font-size:14px; font-weight:700; color:var(--mmt-navy); }
+    .ai-scope .d { font-size:12px; color:var(--mmt-text-secondary); margin-top:2px; }
+    .ai-scope .ex { font-size:12px; color:var(--mmt-teal); margin-top:4px; }
+    .ai-tag { display:inline-block; font-size:11px; font-weight:700; color:var(--mmt-teal); background:rgba(69,123,157,.1); border-radius:6px; padding:2px 8px; margin-left:8px; }
+    .ai-steps { display:flex; gap:8px; margin-bottom:18px; list-style:none; padding:0; }
+    .ai-steps li { flex:1; text-align:center; font-size:11px; font-weight:700; color:var(--mmt-text-secondary); border-top:3px solid var(--mmt-border); padding-top:8px; }
+    .ai-steps li[aria-current="step"] { color:var(--mmt-navy); border-top-color:var(--mmt-teal); }
+    .ai-keybox { display:flex; gap:8px; align-items:stretch; margin:12px 0; }
+    .ai-keybox code { flex:1; font-family:ui-monospace,Menlo,monospace; font-size:13px; background:var(--mmt-surface); border:1px solid var(--mmt-border); border-radius:8px; padding:12px; word-break:break-all; }
+    .ai-warn { font-size:13px; color:var(--warn); font-weight:600; }
+    .ai-conn { display:grid; grid-template-columns:1fr auto; gap:8px 16px; align-items:center; padding:14px 0; border-bottom:1px solid var(--mmt-border); }
+    .ai-conn:last-child { border-bottom:none; }
+    .ai-conn .name { font-size:14px; font-weight:700; color:var(--mmt-navy); }
+    .ai-conn .meta { font-size:12px; color:var(--mmt-text-secondary); margin-top:2px; }
+    .ai-chip { display:inline-block; font-size:11px; font-weight:600; border-radius:6px; padding:2px 8px; margin:2px 4px 0 0; background:var(--mmt-surface); color:var(--mmt-navy); border:1px solid var(--mmt-border); }
+    .ai-badge { font-size:11px; font-weight:700; border-radius:999px; padding:3px 10px; }
+    .ai-badge[data-s="active"] { background:rgba(67,122,34,.12); color:var(--ok); }
+    .ai-badge[data-s="expired"], .ai-badge[data-s="revoked"] { background:rgba(150,66,25,.12); color:var(--warn); }
+    .ai-empty { text-align:center; color:var(--mmt-text-secondary); font-size:14px; padding:24px 0; }
+    .ai-skel { height:48px; border-radius:8px; background:linear-gradient(90deg,#eef1f4,#f6f8fa,#eef1f4); background-size:200% 100%; animation:sk 1.2s infinite; margin-bottom:8px; }
+    @keyframes sk { 0%{background-position:200% 0} 100%{background-position:-200% 0} }
+    .ai-msg { font-size:13px; border-radius:8px; padding:10px 12px; margin:10px 0; }
+    .ai-msg[data-k="err"] { background:rgba(161,44,123,.08); color:var(--err); border:1px solid rgba(161,44,123,.25); }
+    .ai-msg[data-k="ok"] { background:rgba(67,122,34,.08); color:var(--ok); border:1px solid rgba(67,122,34,.25); }
+    .ai-link { color:var(--mmt-teal); font-weight:600; cursor:pointer; background:none; border:none; padding:0; font-size:inherit; text-decoration:underline; }
+    .ai-activity { font-size:12px; color:var(--mmt-text-secondary); border-top:1px dashed var(--mmt-border); margin-top:8px; padding-top:8px; }
+    .ai-activity div { padding:3px 0; font-family:ui-monospace,monospace; }
+    .ai-toprow { display:flex; justify-content:space-between; align-items:center; gap:12px; margin-bottom:18px; }
+    .ai-toggle { font-size:13px; font-weight:600; color:var(--mmt-teal); background:none; border:1px solid var(--mmt-border); border-radius:8px; padding:6px 12px; cursor:pointer; }
+    .ai-hidden { display:none !important; }
+    .ai-table { width:100%; border-collapse:collapse; font-size:13px; }
+    .ai-table th, .ai-table td { text-align:left; padding:8px 10px; border-bottom:1px solid var(--mmt-border); }
+    .ai-table th { font-size:11px; text-transform:uppercase; letter-spacing:.05em; color:var(--mmt-text-secondary); }
+    .ai-snippet { font-family:ui-monospace,monospace; font-size:12px; background:var(--mmt-surface); border:1px solid var(--mmt-border); border-radius:8px; padding:12px; white-space:pre-wrap; word-break:break-all; }
+    .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0; }
+    @media (max-width:640px) { .ai-secondary-grid { grid-template-columns:1fr; } .ai-conn { grid-template-columns:1fr; } }
+  </style>
+</head>
+<body>
+  <nav class="nav-editorial"></nav>
+
+  <div class="ai-wrap" id="ai-root">
+    <h1 class="ai-h1">AI &amp; Integrations</h1>
+    <p class="ai-sub">Connect the AI you already use to your live opportunities and market intel — so it tells you what to chase before you open your laptop.</p>
+
+    <!-- Live region for screen-reader announcements -->
+    <div class="sr-only" role="status" aria-live="polite" id="ai-live"></div>
+
+    <!-- Premium gate (shown if not a premium member) -->
+    <div class="ai-card ai-hidden" id="ai-gate">
+      <h2 style="font-size:17px;font-weight:800;margin:0 0 8px;">This is a premium feature</h2>
+      <p class="ai-sub" style="margin-bottom:14px;">Connecting an AI assistant is included with MMT Premium.</p>
+      <a class="ai-btn" href="/pricing.html">See premium plans</a>
+    </div>
+
+    <div id="ai-app" class="ai-hidden">
+      <!-- Hero: INTEL front door (71% poll winner) -->
+      <div class="ai-card ai-hero">
+        <h2>Pull intel on your market</h2>
+        <p>Let your assistant read your live federal opportunities and market intel on demand. You stay in control — it can read, never change.</p>
+        <button class="ai-btn" id="ai-start" type="button">Connect your AI</button>
+        <button class="ai-link" id="ai-how" type="button" style="margin-left:14px;">How does this work?</button>
+        <ul class="ai-trust">
+          <li>🔒 Read-only — it can't change anything</li>
+          <li>↩ Revoke anytime</li>
+          <li>👁 Every access logged</li>
+        </ul>
+      </div>
+
+      <div class="ai-secondary-grid">
+        <div class="ai-mini"><h3>Let your AI pick your bids</h3><p>Point your assistant at your pipeline and recommended opportunities.</p></div>
+        <div class="ai-mini"><h3>Score bids before you chase them</h3><p>Pull fit scores into the tools you already work in.</p></div>
+      </div>
+
+      <!-- Sign-in (verified email ownership required to manage connections) -->
+      <div class="ai-card ai-hidden" id="ai-signin">
+        <h2 style="font-size:16px;font-weight:800;margin:0 0 6px;">First, confirm it's you</h2>
+        <p class="ai-sub" style="margin-bottom:12px;">For your security we email you a one-time sign-in link before you can create or remove a connection.</p>
+        <div class="ai-field"><label for="ai-email">Your account email</label><input type="email" id="ai-email" autocomplete="email" placeholder="you@agency.com"></div>
+        <button class="ai-btn" id="ai-sendlink" type="button">Email me a sign-in link</button>
+        <div class="ai-msg ai-hidden" id="ai-signin-msg" data-k="ok"></div>
+        <p class="ai-sub" style="margin-top:12px;font-size:12px;">Already have a link? Open it and you'll come back here signed in.</p>
+      </div>
+
+      <!-- Connected assistants list -->
+      <div class="ai-card ai-hidden" id="ai-list-card">
+        <div class="ai-toprow">
+          <h2 style="font-size:16px;font-weight:800;margin:0;">Your connected assistants</h2>
+          <button class="ai-toggle" id="ai-adv-toggle" type="button" aria-pressed="false">Advanced view</button>
+        </div>
+        <div id="ai-list" aria-busy="true">
+          <div class="ai-skel"></div><div class="ai-skel"></div>
+        </div>
+        <div style="margin-top:14px;"><button class="ai-btn" id="ai-add" type="button">+ Connect an assistant</button></div>
+        <button class="ai-link" id="ai-protect" type="button" style="margin-top:14px;display:inline-block;">How your data is protected</button>
+      </div>
+
+      <!-- Guided wizard -->
+      <div class="ai-card ai-hidden" id="ai-wizard" role="region" aria-label="Connect your AI assistant">
+        <ol class="ai-steps" id="ai-stepper">
+          <li data-step="1" aria-current="step">What it can see</li>
+          <li data-step="2">Name &amp; expiry</li>
+          <li data-step="3">Your key</li>
+        </ol>
+
+        <!-- Step 1: scopes in plain language -->
+        <div data-screen="1">
+          <h2 style="font-size:16px;font-weight:800;margin:0 0 10px;">Pick what your AI can see</h2>
+          <label class="ai-scope" data-on="true">
+            <input type="checkbox" value="intel:read" checked aria-describedby="d-intel">
+            <span><span class="t">My market intel<span class="ai-tag">Most popular</span></span><span class="d" id="d-intel">Opportunities and trend data.</span><span class="ex">For example: "What should I be watching at VA this month?"</span></span>
+          </label>
+          <label class="ai-scope" data-on="false">
+            <input type="checkbox" value="opportunities:read" aria-describedby="d-opp">
+            <span><span class="t">My live opportunities</span><span class="d" id="d-opp">The open bids in your tracker.</span><span class="ex">For example: "Show me open DHA solicitations under NAICS 541512."</span></span>
+          </label>
+          <label class="ai-scope" data-on="false">
+            <input type="checkbox" value="tracker:read" aria-describedby="d-trk">
+            <span><span class="t">My pipeline</span><span class="d" id="d-trk">What you're already tracking.</span><span class="ex">For example: "Summarize everything in my pipeline."</span></span>
+          </label>
+          <p class="ai-sub" style="font-size:12px;margin:6px 0 14px;">You can change this anytime. Your AI can only read — never edit, delete, or spend.</p>
+          <button class="ai-btn" id="ai-s1-next" type="button">Continue</button>
+        </div>
+
+        <!-- Step 2: name + expiry -->
+        <div data-screen="2" class="ai-hidden">
+          <h2 style="font-size:16px;font-weight:800;margin:0 0 10px;">Name it</h2>
+          <div class="ai-field"><label for="ai-name">Give this connection a name</label><input type="text" id="ai-name" maxlength="80" placeholder="My ChatGPT"></div>
+          <div class="ai-field"><label for="ai-expiry">When should it expire?</label>
+            <select id="ai-expiry">
+              <option value="90">90 days (recommended)</option>
+              <option value="30">30 days — tightest</option>
+              <option value="365">1 year — fewer renewals</option>
+              <option value="">Never — not recommended</option>
+            </select>
+          </div>
+          <button class="ai-btn ai-btn-ghost" id="ai-s2-back" type="button">Back</button>
+          <button class="ai-btn" id="ai-s2-create" type="button">Create connection</button>
+          <div class="ai-msg ai-hidden" id="ai-create-msg" data-k="err"></div>
+        </div>
+
+        <!-- Step 3: one-time key + tool picker -->
+        <div data-screen="3" class="ai-hidden">
+          <h2 style="font-size:16px;font-weight:800;margin:0 0 8px;">✓ Your connection is ready</h2>
+          <p class="ai-sub" style="margin-bottom:6px;">Copy your key now.</p>
+          <div class="ai-keybox"><code id="ai-key" tabindex="0" aria-label="Your new connection key"></code><button class="ai-btn" id="ai-copy" type="button">Copy</button></div>
+          <p class="ai-warn">Copy this now — for your security we can't show it again. Lost it? Just make a new one.</p>
+          <div class="ai-field" style="margin-top:16px;"><label for="ai-tool">Now paste it into your AI</label>
+            <select id="ai-tool"><option value="claude">Claude Desktop</option><option value="chatgpt">ChatGPT</option><option value="other">Other</option></select>
+          </div>
+          <div class="ai-snippet" id="ai-setup"></div>
+          <div style="margin-top:14px;"><button class="ai-btn" id="ai-done" type="button">I've connected it</button></div>
+        </div>
+      </div>
+
+      <!-- Drawer: how data is protected (UX §8) -->
+      <div class="ai-card ai-hidden" id="ai-drawer">
+        <h2 style="font-size:16px;font-weight:800;margin:0 0 8px;">How your data is protected</h2>
+        <ul class="ai-sub" style="margin:0;padding-left:18px;line-height:1.7;">
+          <li>Connections are <strong>read-only</strong> and scoped to what you pick.</li>
+          <li>Every read is logged — open any connection's <strong>Activity</strong> to see the last 20.</li>
+          <li>Revoke a connection and your AI loses access immediately.</li>
+          <li>Protected/sensitive data stays inside our secure boundary and is <strong>not</strong> sent to outside AI while security review is underway.</li>
+        </ul>
+        <button class="ai-link" id="ai-drawer-close" type="button" style="margin-top:10px;">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+  (function () {
+    "use strict";
+    var $ = function (id) { return document.getElementById(id); };
+    var announce = function (m) { $("ai-live").textContent = m; };
+    var BASE = location.origin;
+    var SESS_KEY = "mmt_agent_session";
+
+    // Map raw status codes to human copy (UX §7) — never show a raw code.
+    function humanError(code, status) {
+      if (status === 401) return "That didn't work. Your sign-in may have expired — try sending a new link.";
+      if (status === 403) return "API access is part of MMT Premium. See /pricing to upgrade.";
+      if (status === 429) return "You've hit this period's usage. It resets soon, or upgrade for more.";
+      if (status === 503) return "This isn't available for AI access yet while we finish a security review.";
+      return "Something went wrong. Please try again.";
+    }
+
+    function isPremium() {
+      if (localStorage.getItem("mmt_premium") === "true") {
+        var ts = localStorage.getItem("mmt_premium_ts");
+        return !ts || (Date.now() - parseInt(ts, 10)) < 30 * 864e5;
+      }
+      return document.cookie.indexOf("mmt_premium=true") !== -1;
+    }
+    function session() { return localStorage.getItem(SESS_KEY); }
+
+    async function api(path, body) {
+      var r = await fetch(BASE + path, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+      var data = {}; try { data = await r.json(); } catch (e) {}
+      return { status: r.status, ok: r.ok, data: data };
+    }
+
+    // ---- bootstrap --------------------------------------------------------
+    function show(id, on) { $(id).classList.toggle("ai-hidden", !on); }
+
+    function boot() {
+      if (!isPremium()) { show("ai-gate", true); return; }
+      show("ai-app", true);
+      // Accept a returning magic-link token (?session=… from the email link).
+      var qp = new URLSearchParams(location.search);
+      if (qp.get("session")) { verifyAndStore(qp.get("session")); return; }
+      if (session()) { showList(); } // already signed in
+    }
+
+    // ---- sign-in (verified email ownership) -------------------------------
+    $("ai-start").onclick = $("ai-add") ? null : null;
+    function gotoSignInOrList() { if (session()) { showWizard(); } else { show("ai-signin", true); $("ai-email").focus(); } }
+    $("ai-start").addEventListener("click", gotoSignInOrList);
+
+    $("ai-sendlink").addEventListener("click", async function () {
+      var email = ($("ai-email").value || "").trim();
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { msg("ai-signin-msg", "err", "Enter a valid email."); return; }
+      this.disabled = true;
+      var r = await api("/.netlify/functions/customer-auth", { action: "request_link", email: email });
+      this.disabled = false;
+      if (r.ok) { msg("ai-signin-msg", "ok", "Check your email for a sign-in link, then come back here."); announce("Sign-in link sent."); }
+      else { msg("ai-signin-msg", "err", humanError(r.data.error, r.status)); }
+    });
+
+    async function verifyAndStore(token) {
+      var r = await api("/.netlify/functions/customer-auth", { action: "verify", token: token });
+      if (r.ok) { localStorage.setItem(SESS_KEY, token); history.replaceState({}, "", location.pathname); showList(); }
+      else { show("ai-signin", true); msg("ai-signin-msg", "err", humanError(r.data.error, r.status)); }
+    }
+
+    function msg(id, kind, text) { var el = $(id); el.dataset.k = kind; el.textContent = text; show(id, true); }
+
+    // ---- connection list --------------------------------------------------
+    async function showList() {
+      ["ai-signin", "ai-wizard"].forEach(function (i) { show(i, false); });
+      show("ai-list-card", true);
+      var box = $("ai-list"); box.setAttribute("aria-busy", "true");
+      var r = await api("/api/tokens/list", { sessionToken: session() });
+      box.setAttribute("aria-busy", "false");
+      if (!r.ok) {
+        if (r.status === 401) { localStorage.removeItem(SESS_KEY); show("ai-list-card", false); show("ai-signin", true); return; }
+        box.innerHTML = '<div class="ai-msg" data-k="err">' + humanError(r.data.error, r.status) + "</div>"; return;
+      }
+      renderList(r.data.connections || []);
+    }
+
+    var _lastConns = [];
+    function renderList(conns) {
+      _lastConns = conns;
+      var box = $("ai-list");
+      if (conns.length === 0) { box.innerHTML = '<div class="ai-empty">No AI assistants connected yet. Connect one to let it work your pipeline for you.</div>'; return; }
+      if (localStorage.getItem(ADV_KEY) === "advanced") { renderAdvanced(conns); return; }
+      box.innerHTML = conns.map(function (c) {
+        var chips = (c.scopes || []).map(function (s) { return '<span class="ai-chip">' + scopeLabel(s) + "</span>"; }).join("");
+        var last = c.last_used_at ? timeAgo(c.last_used_at) : "Never yet";
+        return '<div class="ai-conn" data-id="' + c.id + '">' +
+          '<div><div class="name">' + esc(c.name) + ' <span class="ai-badge" data-s="' + c.status + '">' + c.status + "</span></div>" +
+          '<div class="meta">' + chips + " · last used " + last + " · " + (c.token_prefix ? "key …" + c.token_prefix : "") + "</div>" +
+          '<div class="ai-activity ai-hidden" data-activity></div></div>' +
+          '<div style="display:flex;gap:8px;align-items:center;"><button class="ai-link" data-act="activity">Activity</button>' +
+          (c.status === "active" ? '<button class="ai-btn ai-btn-danger" data-act="revoke" style="padding:6px 12px;">Revoke</button>' : "") +
+          "</div></div>";
+      }).join("");
+      box.querySelectorAll("[data-act=revoke]").forEach(function (b) { b.addEventListener("click", onRevoke); });
+      box.querySelectorAll("[data-act=activity]").forEach(function (b) { b.addEventListener("click", onActivity); });
+    }
+
+    // Advanced/developer view (UX §3b): dense table, raw scope strings, a ready
+    // curl snippet per connection. No explanatory chrome.
+    function renderAdvanced(conns) {
+      var base = BASE + "/api/v1";
+      var rows = conns.map(function (c) {
+        return "<tr data-id=\"" + c.id + "\"><td>" + esc(c.name) + "</td>" +
+          "<td><code>" + (c.scopes || []).join(" ") + "</code></td>" +
+          "<td><code>…" + esc(c.token_prefix || "") + "</code></td>" +
+          "<td><span class=\"ai-badge\" data-s=\"" + c.status + "\">" + c.status + "</span></td>" +
+          "<td>" + (c.last_used_at ? timeAgo(c.last_used_at) : "never") + "</td>" +
+          "<td>" + (c.status === "active" ? "<button class=\"ai-link\" data-act=\"revoke\">revoke</button>" : "") + "</td></tr>";
+      }).join("");
+      $("ai-list").innerHTML =
+        "<table class=\"ai-table\"><thead><tr><th>Name</th><th>Scopes</th><th>Prefix</th><th>Status</th><th>Last used</th><th></th></tr></thead><tbody>" + rows + "</tbody></table>" +
+        "<div class=\"ai-snippet\" style=\"margin-top:12px;\">curl -H \"Authorization: Bearer &lt;your_token&gt;\" " + base + "/opportunities?limit=25\n# MCP base URL: " + base + " · scopes: opportunities:read tracker:read intel:read</div>";
+      $("ai-list").querySelectorAll("[data-act=revoke]").forEach(function (b) { b.addEventListener("click", onRevoke); });
+    }
+
+    async function onRevoke(e) {
+      var host = e.target.closest(".ai-conn") || e.target.closest("[data-id]");
+      var id = host.dataset.id;
+      if (!confirm("Your AI will lose access immediately. You can reconnect anytime.")) return;
+      var r = await api("/api/tokens/revoke", { sessionToken: session(), tokenId: id });
+      if (r.ok) { announce("Connection revoked."); showList(); }
+      else { alert(humanError(r.data.error, r.status)); }
+    }
+
+    async function onActivity(e) {
+      var row = e.target.closest(".ai-conn"); var panel = row.querySelector("[data-activity]");
+      if (!panel.classList.contains("ai-hidden")) { panel.classList.add("ai-hidden"); return; }
+      panel.classList.remove("ai-hidden"); panel.textContent = "Loading…";
+      var r = await api("/api/tokens/activity", { sessionToken: session(), tokenId: row.dataset.id });
+      if (!r.ok) { panel.textContent = humanError(r.data.error, r.status); return; }
+      var reads = r.data.reads || [];
+      panel.innerHTML = reads.length ? reads.map(function (x) { return "<div>" + timeAgo(x.at) + " · " + x.method + " " + esc(x.endpoint) + " · " + x.status + "</div>"; }).join("") : "<div>No reads yet.</div>";
+    }
+
+    // ---- wizard -----------------------------------------------------------
+    function showWizard() { ["ai-list-card", "ai-signin"].forEach(function (i) { show(i, false); }); show("ai-wizard", true); gotoScreen(1); }
+    $("ai-add") && $("ai-add").addEventListener("click", function () { if (session()) showWizard(); else { show("ai-list-card", false); show("ai-signin", true); } });
+
+    function gotoScreen(n) {
+      [1, 2, 3].forEach(function (s) { document.querySelector('[data-screen="' + s + '"]').classList.toggle("ai-hidden", s !== n); });
+      $("ai-stepper").querySelectorAll("li").forEach(function (li) { if (+li.dataset.step === n) li.setAttribute("aria-current", "step"); else li.removeAttribute("aria-current"); });
+    }
+
+    document.querySelectorAll(".ai-scope").forEach(function (lab) {
+      var cb = lab.querySelector("input");
+      var sync = function () { lab.dataset.on = cb.checked ? "true" : "false"; };
+      cb.addEventListener("change", sync); sync();
+    });
+    function pickedScopes() { return Array.prototype.map.call(document.querySelectorAll(".ai-scope input:checked"), function (i) { return i.value; }); }
+    function scopeLabel(s) { return { "intel:read": "Market intel", "opportunities:read": "Live opportunities", "tracker:read": "Pipeline" }[s] || s; }
+
+    $("ai-s1-next").addEventListener("click", function () { if (pickedScopes().length === 0) { announce("Pick at least one thing your AI can see."); return; } gotoScreen(2); $("ai-name").focus(); });
+    $("ai-s2-back").addEventListener("click", function () { gotoScreen(1); });
+
+    $("ai-s2-create").addEventListener("click", async function () {
+      var name = ($("ai-name").value || "").trim();
+      if (!name) { msg("ai-create-msg", "err", "Give this connection a name."); return; }
+      this.disabled = true;
+      var expiry = $("ai-expiry").value;
+      var body = { sessionToken: session(), name: name, scopes: pickedScopes(), expiryDays: expiry === "" ? null : Number(expiry) };
+      var r = await api("/api/tokens", body);
+      this.disabled = false;
+      if (!r.ok) { msg("ai-create-msg", "err", r.data.message || humanError(r.data.error, r.status)); return; }
+      $("ai-key").textContent = r.data.token; renderSetup(); gotoScreen(3); $("ai-key").focus(); announce("Connection created. Copy your key now.");
+    });
+
+    $("ai-copy").addEventListener("click", function () {
+      navigator.clipboard.writeText($("ai-key").textContent).then(function () { announce("Key copied to clipboard."); $("ai-copy").textContent = "Copied"; });
+    });
+    $("ai-tool").addEventListener("change", renderSetup);
+    function renderSetup() {
+      var key = $("ai-key").textContent, tool = $("ai-tool").value;
+      var base = BASE + "/api/v1";
+      if (tool === "claude") $("ai-setup").textContent = "In Claude Desktop → Settings → Connectors, add a custom HTTP header:\n  Authorization: Bearer " + key + "\nBase URL: " + base;
+      else if (tool === "chatgpt") $("ai-setup").textContent = "In ChatGPT → custom action / GPT, set the auth header:\n  Authorization: Bearer " + key + "\nBase URL: " + base;
+      else $("ai-setup").textContent = "curl -H \"Authorization: Bearer " + key + "\" " + base + "/opportunities";
+    }
+    $("ai-done").addEventListener("click", showList);
+
+    // ---- advanced view, drawer, how-it-works ------------------------------
+    var ADV_KEY = "mmt_agent_view"; // NOTE: spec §3 wants server-side persistence
+    $("ai-adv-toggle").addEventListener("click", function () {
+      var on = localStorage.getItem(ADV_KEY) === "advanced";
+      localStorage.setItem(ADV_KEY, on ? "guided" : "advanced");
+      this.setAttribute("aria-pressed", String(!on));
+      this.textContent = on ? "Advanced view" : "Guided view";
+      announce(on ? "Guided view" : "Advanced view");
+      if (_lastConns.length) renderList(_lastConns); // re-render in the new mode
+    });
+    if (localStorage.getItem(ADV_KEY) === "advanced") { var t = $("ai-adv-toggle"); if (t) { t.setAttribute("aria-pressed", "true"); t.textContent = "Guided view"; } }
+
+    function toggleDrawer() { var d = $("ai-drawer"); d.classList.toggle("ai-hidden"); if (!d.classList.contains("ai-hidden")) d.scrollIntoView({ behavior: "smooth" }); }
+    $("ai-how").addEventListener("click", toggleDrawer);
+    $("ai-protect") && $("ai-protect").addEventListener("click", toggleDrawer);
+    $("ai-drawer-close").addEventListener("click", toggleDrawer);
+
+    function esc(s) { return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) { return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]; }); }
+    function timeAgo(iso) { var d = (Date.now() - new Date(iso).getTime()) / 1000; if (d < 60) return "just now"; if (d < 3600) return Math.floor(d / 60) + "m ago"; if (d < 86400) return Math.floor(d / 3600) + "h ago"; return Math.floor(d / 86400) + "d ago"; }
+
+    boot();
+  })();
+  </script>
+</body>
+</html>

--- a/scripts/deliver-mark-avel-marketpulse-v4.js
+++ b/scripts/deliver-mark-avel-marketpulse-v4.js
@@ -404,7 +404,7 @@ __SOURCE_TABLE__
   const SUPABASE_URL = process.env.SUPABASE_URL;
   const SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!SUPABASE_URL || !SERVICE_KEY) {
-    console.error("FATAL: SUPABASE_URL and a service key (SUPABASE_SERVICE_KEY or SUPABASE_SERVICE_ROLE_KEY) are required.");
+    console.error("FATAL: SUPABASE_URL and a Supabase service key env var are required (see .env.example).");
     process.exit(1);
   }
 

--- a/scripts/verify-agent-api.js
+++ b/scripts/verify-agent-api.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// ============================================================================
+// verify-agent-api.js — credential-free smoke test for the Agent Access API.
+// Curls the gate behavior (no secrets needed). Run against the preview now, or
+// against production after you merge.
+//
+//   node scripts/verify-agent-api.js                      # preview (default)
+//   node scripts/verify-agent-api.js https://missionmeetstech.com   # prod
+// ============================================================================
+
+const BASE = (process.argv[2] || "https://deploy-preview-103--curious-pony-0dec76.netlify.app").replace(/\/$/, "");
+
+const checks = [
+  { name: "Read API rejects no-token", method: "GET", path: "/api/v1/opportunities", expect: 401 },
+  { name: "Read API rejects bad token", method: "GET", path: "/api/v1/opportunities", headers: { Authorization: "Bearer nope" }, expect: 401 },
+  { name: "Tracker rejects no-token", method: "GET", path: "/api/v1/tracker", expect: 401 },
+  { name: "Recommended rejects no-token", method: "GET", path: "/api/v1/recommended", expect: 401 },
+  { name: "Token-create needs sign-in", method: "POST", path: "/api/tokens", body: { name: "x" }, expect: 401 },
+  { name: "Setup page loads", method: "GET", path: "/premium/ai-integrations.html", expect: 200 },
+];
+
+(async () => {
+  console.log(`\nVerifying Agent Access API at ${BASE}\n`);
+  let pass = 0;
+  for (const c of checks) {
+    try {
+      const res = await fetch(BASE + c.path, {
+        method: c.method,
+        headers: { "Content-Type": "application/json", ...(c.headers || {}) },
+        body: c.body ? JSON.stringify(c.body) : undefined,
+        redirect: "follow",
+      });
+      const ok = res.status === c.expect;
+      console.log(`  ${ok ? "✅" : "❌"} ${c.name}  (got ${res.status}, want ${c.expect})`);
+      if (ok) pass++;
+    } catch (e) {
+      console.log(`  ❌ ${c.name}  (request failed: ${e.message})`);
+    }
+  }
+  console.log(`\n${pass}/${checks.length} checks passed.\n`);
+  process.exit(pass === checks.length ? 0 : 1);
+})();

--- a/tests/unit/agent-auth.test.js
+++ b/tests/unit/agent-auth.test.js
@@ -1,0 +1,103 @@
+// Agent Access — auth middleware gate ordering (Phase 3, GATE 3 items 1,3,4)
+// and pagination clamp (item 4: limit>100 → 400).
+//
+// authenticateAgent accepts an injected db client (3rd arg) so we test the gate
+// chain with a hand-rolled Supabase stub — no module mocking, no flakiness.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { authenticateAgent } from "../../netlify/functions/lib/agent-auth.js";
+import { parsePaging } from "../../netlify/functions/lib/agent-data.js";
+
+const tokenRow = { id: "tok-1", user_id: "user-1", scopes: ["opportunities:read"], expires_at: null, revoked_at: null };
+let scenario;
+
+function fakeDb() {
+  const make = (table) => {
+    const b = {
+      select() { return b; }, eq() { return b; }, gte() { return b; }, is() { return b; },
+      order() { return b; }, limit() { return b; }, update() { return b; },
+      insert() { return Promise.resolve({ error: null }); },
+      async single() {
+        if (table === "api_tokens") return scenario.token ? { data: scenario.token, error: null } : { data: null, error: { message: "no" } };
+        if (table === "mp_users") return { data: { email: "owner@example.com" }, error: null };
+        if (table === "api_cost_ledger") return scenario.ledger ? { data: scenario.ledger, error: null } : { data: null, error: { message: "none" } };
+        return { data: null, error: { message: "none" } };
+      },
+      then(res) { return table === "api_audit_log" ? res({ count: scenario.auditCount || 0 }) : res({ data: [], count: 0, error: null }); },
+    };
+    return b;
+  };
+  return { from: (t) => make(t) };
+}
+
+beforeEach(() => { scenario = { token: tokenRow, ledger: null, auditCount: 0 }; });
+
+const evt = (headers = {}) => ({ httpMethod: "GET", headers, queryStringParameters: {} });
+const goodToken = "mmt_pat_" + "a".repeat(48);
+const run = (headers, scope) => authenticateAgent(evt(headers), scope, fakeDb());
+
+describe("authenticateAgent gate ordering", () => {
+  it("missing bearer → 401", async () => {
+    const r = await run({}, "opportunities:read");
+    expect(r.ok).toBe(false);
+    expect(r.response.statusCode).toBe(401);
+  });
+
+  it("structurally invalid token → 401 (no DB lookup)", async () => {
+    const r = await run({ authorization: "Bearer not-a-real-token" }, "opportunities:read");
+    expect(r.response.statusCode).toBe(401);
+  });
+
+  it("revoked token → 401", async () => {
+    scenario.token = { ...tokenRow, revoked_at: new Date().toISOString() };
+    const r = await run({ authorization: `Bearer ${goodToken}` }, "opportunities:read");
+    expect(r.response.statusCode).toBe(401);
+  });
+
+  it("expired token → 401", async () => {
+    scenario.token = { ...tokenRow, expires_at: "2000-01-01T00:00:00Z" };
+    const r = await run({ authorization: `Bearer ${goodToken}` }, "opportunities:read");
+    expect(r.response.statusCode).toBe(401);
+  });
+
+  it("valid token, wrong scope → 403", async () => {
+    const r = await run({ authorization: `Bearer ${goodToken}` }, "tracker:read");
+    expect(r.response.statusCode).toBe(403);
+  });
+
+  it("valid token + matching scope → ok", async () => {
+    const r = await run({ authorization: `Bearer ${goodToken}` }, "opportunities:read");
+    expect(r.ok).toBe(true);
+    expect(r.ctx.userId).toBe("user-1");
+  });
+
+  it("budget exhausted → 429 (before any data read)", async () => {
+    scenario.ledger = { spend_usd: 10, budget_usd: 5 };
+    const r = await run({ authorization: `Bearer ${goodToken}` }, "opportunities:read");
+    expect(r.response.statusCode).toBe(429);
+    expect(r.response.body).toContain("BUDGET_EXCEEDED");
+  });
+
+  it("session over limit → 429 + X-Session-Limit-Reached", async () => {
+    scenario.auditCount = 100; // 100 prior calls this session
+    const r = await authenticateAgent(
+      { httpMethod: "GET", headers: { authorization: `Bearer ${goodToken}`, "x-session-id": "11111111-1111-1111-1111-111111111111" }, queryStringParameters: {} },
+      "opportunities:read", fakeDb()
+    );
+    expect(r.response.statusCode).toBe(429);
+    expect(r.response.headers["X-Session-Limit-Reached"]).toBe("true");
+  });
+});
+
+describe("parsePaging (GATE 3 item 4)", () => {
+  it("defaults to limit 25 offset 0", () => {
+    expect(parsePaging({})).toEqual({ limit: 25, offset: 0 });
+  });
+  it("limit=500 → error (becomes 400 at handler)", () => {
+    expect(parsePaging({ limit: "500" }).error).toMatch(/cannot exceed 100/);
+  });
+  it("limit=100 ok, 101 rejected", () => {
+    expect(parsePaging({ limit: "100" })).toEqual({ limit: 100, offset: 0 });
+    expect(parsePaging({ limit: "101" }).error).toBeTruthy();
+  });
+});

--- a/tests/unit/agent-router-observability.test.js
+++ b/tests/unit/agent-router-observability.test.js
@@ -1,0 +1,73 @@
+// Agent Access — model router (Phase 4, GATE 4) + observability (Phase 5, GATE 5).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  PROVIDERS, BANNED_SUBSTRINGS, classifyPayload, route, invoke,
+} from "../../netlify/functions/lib/agent-model-router.js";
+import { evaluateAlerts, evaluateBreaker } from "../../netlify/functions/lib/agent-observability.js";
+
+describe("model router — classification + routing (GATE 4)", () => {
+  it("public payload routes to Gemini by default", () => {
+    expect(route("VA wants a cloud migration RFP").model).toBe("gemini-3-flash");
+  });
+  it("batch routes to GPT-5.4 nano, self-host to Llama 4", () => {
+    expect(route("x", { batch: true }).model).toBe("gpt-5.4-nano");
+    expect(route("x", { selfHost: true }).model).toBe("llama-4");
+  });
+  it("escalation goes to Claude Haiku", () => {
+    expect(route("x", { escalate: true }).model).toBe("claude-haiku-4-5");
+  });
+  it("CUI/PII classifies sensitive → Bedrock GovCloud", () => {
+    expect(classifyPayload("This doc is marked CUI")).toBe("sensitive");
+    expect(classifyPayload("SSN 123-45-6789")).toBe("sensitive");
+    expect(route("marked CUI//FOUO").model).toBe("bedrock-claude-govcloud");
+    expect(route("marked CUI//FOUO").boundary).toBe("sensitive");
+  });
+  it("every routing decision carries max_tokens (§2c)", () => {
+    expect(route("x").maxTokens).toBeGreaterThan(0);
+    expect(route("x", { maxTokens: 256 }).maxTokens).toBe(256);
+  });
+  it("NO Chinese-origin models in the provider allow-list", () => {
+    const ids = Object.keys(PROVIDERS).join(" ").toLowerCase();
+    for (const banned of BANNED_SUBSTRINGS) expect(ids).not.toContain(banned);
+  });
+});
+
+describe("model router — fail-closed invoke (GATE 4)", () => {
+  const saved = { ...process.env };
+  beforeEach(() => { delete process.env.CUI_PATH_CLEARED; delete process.env.GEMINI_API_KEY; });
+  afterEach(() => { process.env = { ...saved }; });
+
+  it("sensitive payload without CUI_PATH_CLEARED → 503 COMPLIANCE_HOLD", async () => {
+    const r = await invoke("contains CUI marking");
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(503);
+    expect(r.code).toBe("COMPLIANCE_HOLD");
+  });
+  it("public payload with no provider key → 503 PROVIDER_NOT_CONFIGURED (no call)", async () => {
+    const r = await invoke("public opportunity text");
+    expect(r.status).toBe(503);
+    expect(r.code).toBe("PROVIDER_NOT_CONFIGURED");
+    expect(r.decision.model).toBe("gemini-3-flash");
+  });
+  it("oversized input is rejected before routing (§2c)", async () => {
+    const r = await invoke("a".repeat(30000));
+    expect(r.code).toBe("INPUT_TOO_LARGE");
+  });
+});
+
+describe("observability — alert thresholds (§5) + breaker (§4)", () => {
+  it("fires AUTH_SPIKE/SCOPE_SPIKE/THROTTLE_SPIKE/HARVEST over thresholds", () => {
+    const fired = evaluateAlerts({ unauthedPerMin: 51, forbiddenPerMin: 101, throttledPerMin: 11, mbPerHr: 60 });
+    const kinds = fired.map((f) => f.kind);
+    expect(kinds).toEqual(expect.arrayContaining(["AUTH_SPIKE", "SCOPE_SPIKE", "THROTTLE_SPIKE", "HARVEST"]));
+  });
+  it("stays quiet under thresholds", () => {
+    expect(evaluateAlerts({ unauthedPerMin: 1, forbiddenPerMin: 1, throttledPerMin: 1, mbPerHr: 1 })).toEqual([]);
+  });
+  it("breaker opens only with a meaningful sample + high error rate", () => {
+    expect(evaluateBreaker(5, 5).open).toBe(false);       // sample too small
+    expect(evaluateBreaker(40, 30).open).toBe(true);      // 75% errors
+    expect(evaluateBreaker(40, 2).open).toBe(false);      // healthy
+  });
+});

--- a/tests/unit/agent-tokens.test.js
+++ b/tests/unit/agent-tokens.test.js
@@ -1,0 +1,96 @@
+// Agent Access — token crypto + scope/expiry helpers (Phase 2, GATE 2).
+// Enforces the security invariants the read API depends on:
+//   - raw token is mmt_pat_ + 48 hex (192 bits entropy)
+//   - stored hash is 64-char SHA-256 hex, never the raw token
+//   - prefix is display-only (8 hex), reveals nothing
+//   - unknown scopes are rejected (no silent drop)
+//   - expiry is constrained to the friendly options 30/90/365/never
+
+import { describe, it, expect } from "vitest";
+import crypto from "node:crypto";
+import {
+  generateToken, hashToken, looksLikeToken, normalizeScopes, expiryToIso,
+  VALID_SCOPES, DEFAULT_SCOPES, MAX_ACTIVE_TOKENS_PER_USER, DEFAULT_EXPIRY_DAYS,
+} from "../../netlify/functions/lib/agent-tokens.js";
+
+describe("generateToken", () => {
+  it("produces mmt_pat_ + 48 hex chars", () => {
+    const { raw } = generateToken();
+    expect(raw).toMatch(/^mmt_pat_[0-9a-f]{48}$/);
+  });
+  it("stores a 64-char SHA-256 hex hash, never the raw token", () => {
+    const { raw, hash } = generateToken();
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).not.toBe(raw);
+    expect(hash).toBe(crypto.createHash("sha256").update(raw).digest("hex"));
+  });
+  it("prefix is 8 hex chars and is a substring of the random part, not the whole token", () => {
+    const { raw, prefix } = generateToken();
+    expect(prefix).toMatch(/^[0-9a-f]{8}$/);
+    expect(raw).toContain(prefix);
+    expect(prefix.length).toBeLessThan(raw.length);
+  });
+  it("is unique across calls", () => {
+    const a = generateToken(), b = generateToken();
+    expect(a.raw).not.toBe(b.raw);
+    expect(a.hash).not.toBe(b.hash);
+  });
+});
+
+describe("hashToken", () => {
+  it("is deterministic and 64-hex", () => {
+    expect(hashToken("mmt_pat_abc")).toBe(hashToken("mmt_pat_abc"));
+    expect(hashToken("mmt_pat_abc")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("looksLikeToken", () => {
+  it("accepts a well-formed token and rejects junk", () => {
+    expect(looksLikeToken(generateToken().raw)).toBe(true);
+    expect(looksLikeToken("mmt_pat_short")).toBe(false);
+    expect(looksLikeToken("Bearer xyz")).toBe(false);
+    expect(looksLikeToken(null)).toBe(false);
+  });
+});
+
+describe("normalizeScopes", () => {
+  it("defaults to opportunities:read", () => {
+    expect(normalizeScopes(null)).toEqual({ ok: true, scopes: [...DEFAULT_SCOPES] });
+    expect(normalizeScopes([])).toEqual({ ok: true, scopes: [...DEFAULT_SCOPES] });
+  });
+  it("accepts every valid scope and dedupes", () => {
+    const r = normalizeScopes([...VALID_SCOPES, "intel:read"]);
+    expect(r.ok).toBe(true);
+    expect(new Set(r.scopes)).toEqual(new Set(VALID_SCOPES));
+  });
+  it("rejects unknown scopes (no silent drop)", () => {
+    const r = normalizeScopes(["opportunities:read", "opportunities:write"]);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/opportunities:write/);
+  });
+});
+
+describe("expiryToIso", () => {
+  it("default expiry is 90 days", () => {
+    expect(DEFAULT_EXPIRY_DAYS).toBe(90);
+    const iso = expiryToIso(90);
+    expect(new Date(iso).getTime()).toBeGreaterThan(Date.now());
+  });
+  it("null = never", () => {
+    expect(expiryToIso(null)).toBeNull();
+  });
+  it("rejects out-of-range values with undefined", () => {
+    expect(expiryToIso(7)).toBeUndefined();
+    expect(expiryToIso(99999)).toBeUndefined();
+  });
+  it("accepts 30 and 365", () => {
+    expect(typeof expiryToIso(30)).toBe("string");
+    expect(typeof expiryToIso(365)).toBe("string");
+  });
+});
+
+describe("policy constants", () => {
+  it("max 5 active tokens per user", () => {
+    expect(MAX_ACTIVE_TOKENS_PER_USER).toBe(5);
+  });
+});


### PR DESCRIPTION
## Agent Access API — Sprints 1 + 2 + 2.5 (read-only AI agent access)

Autonomous build per `claude_code_prompt_master_autonomous.md`. Ships to a **preview** for Mary to review and promote — **nothing here is live in production**, and the migration is **not applied** (gated for manual review).

### Two decisions made up front (the specs assumed a stack this repo doesn't run)
1. **Identity model** — the canonical schema keys everything off Supabase Auth (`auth.users` + `auth.uid()` RLS). mmt-site has **no Supabase Auth**; subscribers are email-keyed in `mp_users`. Per Mary's call, tokens key to `mp_users(id)`; RLS is **ON + fail-closed** (zero permissive policies, anon/authenticated revoked) with owner-scoping enforced in the function layer — exactly how every existing paid tool works.
2. **LLM router** — built but shipped **fail-closed** (Mary deferred it). No Gemini/OpenAI/Bedrock keys required; sensitive path 503s without `CUI_PATH_CLEARED`; public path 503s `PROVIDER_NOT_CONFIGURED` until keys land. `/recommended` reads the cache, so the read API needs no live model.

Token minting is anchored on the existing **customer-auth magic-link session** (verified email ownership) — not the spoofable `member-auth` email check.

### What's in it
- **Phase 1** — `migrations/20260616000000_agent_api_infra.sql`: `api_tokens`, `api_audit_log`, `api_cost_ledger`, `recommended_cache`, `idempotency_keys`. RLS fail-closed. **GATED — not pushed.**
- **Phase 2** — token CRUD (`tokens-create/list/revoke`), `lib/agent-tokens.js` (SHA-256 hash + 8-char prefix, raw shown once), `lib/agent-session.js`, max 5/user, 90-day default.
- **Phase 3** — `lib/agent-auth.js` 8-step gate chain (bearer→401 / revoked|expired→401 / scope→403 / budget→429 pre-call / session >100→429 / rate limit per-key 60-min+5k-day & global 1k-min→429 / audit). Read endpoints `/api/v1/opportunities(/:id)`, `/tracker`, `/recommended`. Service client isolated in `lib/`.
- **Phase 4** — `lib/agent-model-router.js` (classify-first, US/allied allow-list + banned-origin deny-list, fail-closed) + nightly `agent-score-batch` (flag-gated).
- **Phase 5** — `lib/agent-observability.js` (§5 alert sweep + §4 circuit breaker) + `agent-alert-sweep` (flag-gated).
- **Phase 5.5** — `/premium/ai-integrations` setup UX: guided wizard + advanced view + connection list + per-connection activity, a11y, human error copy. Verified in preview (desktop+mobile, no console errors, jargon-free guided mode, advanced toggle flips to dense table).

### Gates
37 new unit tests pass (391 total). `build.js` clean, `validate-routes` 31 features, `validate-dist` 512 pages. 0 `service_role` in read handlers, 0 Chinese-origin models wired, no secrets in diff.

### Mary's manual checklist (NOT auto-done)
- [ ] Review + `supabase db push` the gated migration
- [ ] Set monthly spend caps in Google AI Studio / OpenAI / Bedrock / Anthropic
- [ ] Attorney review of §11 + UX §8 data-handling copy, then set `CUI_PATH_CLEARED=true`
- [ ] Add provider keys (GEMINI/GOOGLE, OPENAI, AWS GovCloud) + wire SDKs (`chub get` first) to finish Phase 4
- [ ] Confirm SAM.gov source data carries no CUI before enabling `intel:read` broadly
- [ ] Promote primary-nav placement of "AI & Integrations" (currently in the premium Account group)
- [ ] Move advanced-view toggle persistence to server-side (member-preferences) per UX §3
- [ ] Install `gitleaks` in CI (not present locally; manual diff sweep was clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
