### PR TITLE
fix: show 'AI & Integrations' in premium sidebar (second nav array was missing it)

### DIFF
--- a/build.js
+++ b/build.js
@@ -3467,7 +3467,8 @@ ${innerHtml}
       { href: '/glossary.html', label: 'Glossary', id: 'glossary', group: 'Reference' },
       { href: '/newswire.html', label: 'Newswire', id: 'newswire' },
       { href: '/agency-sources.html', label: 'Agency Sources', id: 'agency-sources' },
-      { href: '/premium/settings/', label: 'Settings', id: 'settings', group: 'Account' },
+      { href: '/premium/ai-integrations/', label: 'AI & Integrations', id: 'ai-integrations', group: 'Account' },
+      { href: '/premium/settings/', label: 'Settings', id: 'settings' },
     ];
 
     let navHtml = '<nav class="dash-nav">\n';


### PR DESCRIPTION
## Fix: "AI & Integrations" missing from the premium sidebar (Account group)

Mary reported the link wasn't showing under **Account** on `/premium/settings`.

**Root cause:** `build.js` has TWO `injectDashShell()` functions, each with its own nav links array — a module-scope copy (~line 3036) and a nested copy (~line 3445). The Phase 5.5 change only added the entry to the module-scope array, which builds some pages (e.g. calendar). The **dashPageMap pages (settings, dashboard, ask-mmt, pursuit-score, …) are built by the nested copy**, which was missing the entry — so the link was absent there.

**Fix:** add the `ai-integrations` entry to the nested array too. One line. Verified the link now renders in the Account group (above Settings) across settings/dashboard/calendar/ask-mmt/pursuit-score/single-bidder/profile/compliance-check/signal-chain. `validate-dist` 542 pages pass.

Flagged the duplicate-array tech debt in the commit so future nav changes update both until they're de-duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
