### PR TITLE
fix(motion): stop fade-up reveal from blanking pages when JS is blocked

### DIFF
--- a/js/mmt-motion.js
+++ b/js/mmt-motion.js
@@ -9,6 +9,27 @@
 
   if (!('IntersectionObserver' in window)) return;
 
+  // Opt in to the hidden pre-animation state ONLY now that this script is
+  // running. The CSS keeps .fade-up fully visible until <html> has `js-anim`,
+  // so if this script is ever blocked or errors (e.g. an embedded mobile
+  // webview / corporate proxy), the page stays visible instead of going solid
+  // white. This must be the same code path that reveals — see revealAll().
+  document.documentElement.classList.add('js-anim');
+
+  // Failsafe: nothing may stay hidden. If the observer never fires (mobile
+  // webview quirks, bfcache restore, etc.), force-reveal everything.
+  var revealed = false;
+  function revealAll() {
+    if (revealed) return;
+    revealed = true;
+    document.querySelectorAll('.fade-up').forEach(function(el) {
+      el.classList.add('visible');
+    });
+  }
+  // Belt-and-suspenders: reveal on load and after a hard timeout.
+  window.addEventListener('load', function() { setTimeout(revealAll, 1200); });
+  setTimeout(revealAll, 3000);
+
   // Immediately check if an element is in the viewport
   function isInViewport(el) {
     var rect = el.getBoundingClientRect();

--- a/src/input.css
+++ b/src/input.css
@@ -806,13 +806,22 @@
   }
 
   /* ---- Fade animation ---- */
+  /* Progressive enhancement: content is VISIBLE by default. The hidden
+     pre-animation state only applies once the reveal script (mmt-motion.js)
+     has added `js-anim` to <html>. That script is also the only thing that
+     reveals elements, so the code that hides is the same code that guarantees
+     the reveal — if it never runs (blocked/errored in a mobile webview), the
+     page stays fully visible instead of a solid-white screen. */
   .fade-up {
-    opacity: 0;
-    transform: translateY(20px);
     transition: opacity 0.5s ease, transform 0.5s ease;
   }
 
-  .fade-up.visible {
+  html.js-anim .fade-up {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  html.js-anim .fade-up.visible {
     opacity: 1;
     transform: translateY(0);
   }


### PR DESCRIPTION
## What & why

**Danielle Applegate (CGI Federal VP, Founding Member)** replied to the premium digest: the Contract Tracker links render as a **solid white page on mobile**.

### Root cause
`.fade-up` sections are server-rendered at `opacity:0` and only revealed when the deferred `js/mmt-motion.js` adds `.visible` via IntersectionObserver. The only safety nets were `prefers-reduced-motion` and `<noscript>` — **neither covers the actual failure mode**: JS enabled but the deferred reveal script blocked, delayed, or errored. That's common in Outlook's in-app WKWebView and corporate mobile proxies (note the "EXTERNAL SENDER" gateway on her mail). In that window every section stays `opacity:0` → a solid white page.

This was **sitewide** — every page using `fade-up` — the digest links just happened to land on Contract Tracker.

### Fix (progressive enhancement)
- Content is **visible by default**. The hidden pre-animation state is gated behind `html.js-anim`, which `mmt-motion.js` adds **only once it is actually running**. The code that hides is now the same code that guarantees the reveal — if the script never runs, nothing is ever hidden.
- Added a **failsafe** (`window load` + 3s timeout) that force-reveals any still-hidden element, so an observer misfire can't leave content blank either.

Two files: `src/input.css`, `js/mmt-motion.js`.

## Verification
- Mobile preview, **normal load**: `js-anim` applied, content renders and animates as before.
- Mobile preview, **`mmt-motion.js` blocked** (simulating the failing webview): page renders fully — no white screen.
- `node build.js` clean; `validate-dist` OK (542 pages); **414/414** unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)