### PR TITLE
Surface Agent Access add-on on pricing, settings, and tools hub

### DIFF
--- a/build.js
+++ b/build.js
@@ -3467,7 +3467,8 @@ ${innerHtml}
       { href: '/glossary.html', label: 'Glossary', id: 'glossary', group: 'Reference' },
       { href: '/newswire.html', label: 'Newswire', id: 'newswire' },
       { href: '/agency-sources.html', label: 'Agency Sources', id: 'agency-sources' },
-      { href: '/premium/settings/', label: 'Settings', id: 'settings', group: 'Account' },
+      { href: '/premium/ai-integrations/', label: 'AI & Integrations', id: 'ai-integrations', group: 'Account' },
+      { href: '/premium/settings/', label: 'Settings', id: 'settings' },
     ];
 
     let navHtml = '<nav class="dash-nav">\n';

--- a/premium/settings.html
+++ b/premium/settings.html
@@ -90,6 +90,11 @@
           <h3>Tool Discounts</h3>
           <p style="margin:0; color:var(--mmt-text-secondary); font-size:14px;"><strong>ProposalPulse:</strong> $14.99 per assessment (25% off standard $19.99)<br><strong>MarketPulse:</strong> $35 per brief (30% off standard $50)<br><span style="font-size:13px;">Discounts apply automatically when using your registered email.</span></p>
         </div>
+        <div class="dash-card" style="border-left:3px solid var(--mmt-teal);">
+          <h3 style="margin:0 0 6px;">AI &amp; Integrations</h3>
+          <p style="margin:0 0 12px; color:var(--mmt-text-secondary); font-size:14px;">Connect the AI you already use &mdash; Claude, ChatGPT, your own agent &mdash; to your live opportunities and market intel. It reads your pipeline so it can tell you what to chase. Read-only, revoke anytime, every access logged. Available as a $39/mo add-on on any paid plan.</p>
+          <a href="/premium/ai-integrations/" style="display:inline-block;background:var(--mmt-navy);color:#fff;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:700;font-size:13px;">Manage connections &rarr;</a>
+        </div>
         <!-- Notification Preferences -->
         <div class="dash-card" id="notif-card">
           <h3>Email Notifications</h3>

--- a/pricing.html
+++ b/pricing.html
@@ -169,7 +169,7 @@
   </section>
 
   <!-- Section 2: Pricing Cards -->
-  <section style="padding:24px 0 var(--space-section);">
+  <section id="plans" style="padding:24px 0 var(--space-section);">
     <div class="grid-4" style="gap:18px;align-items:stretch;">
 
       <!-- FOUNDING MEMBER (highlighted) -->
@@ -229,6 +229,7 @@
             <div class="plan-feature"><span class="check">&#10003;</span> Compliance Check &mdash; 15 checks/mo included (overage $4.99)</div>
             <div class="plan-feature"><span class="check">&#10003;</span> Pursuit Score &mdash; 20 scores/mo included (overage $3.99)</div>
             <div class="plan-feature"><span class="check">&#10003;</span> Signal Chain available as $49/mo add-on</div>
+            <div class="plan-feature"><span class="check">&#10003;</span> AI &amp; Integrations (Agent Access) available as $39/mo add-on</div>
           </div>
           <div style="margin-top:auto;padding-top:24px;">
             <a id="annualBtn" href="https://buy.stripe.com/eVqeVf0Fw8IA2qId994c801" class="btn-primary no-underline" style="width:100%;justify-content:center;" onclick="if(typeof plausible!=='undefined')plausible('Annual Subscribe Click')">Subscribe annually</a>
@@ -284,6 +285,36 @@
 
     </div>
     <p style="text-align:center;margin-top:20px;font-size:13px;color:var(--mmt-text-secondary);">&#128274; Your subscription is secured by Stripe. ProposalPulse and MarketPulse documents are not stored, not used to train models, and processed under the security practices documented at <a href="/security.html">missionmeetstech.com/security</a>.</p>
+  </section>
+
+  <!-- Section 2b: Add-ons -->
+  <section class="section" style="padding-top:0;">
+    <div style="max-width:900px;margin:0 auto;">
+      <h2 style="text-align:center;margin-bottom:8px;">Add-ons</h2>
+      <p style="text-align:center;margin-bottom:32px;color:var(--mmt-text-secondary);">Stack these on any paid plan. Add or drop them anytime.</p>
+      <div id="agent-access" class="card plan-card highlighted" style="padding:32px;max-width:560px;margin:0 auto;display:flex;flex-direction:column;">
+        <div style="margin-bottom:20px;">
+          <div style="font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:0.12em;color:var(--mmt-teal);margin-bottom:12px;">AI &amp; Integrations &middot; Agent Access</div>
+          <div class="plan-price">$39<span class="period">/mo first agent</span></div>
+          <p style="margin-top:8px;font-size:14px;font-weight:600;color:var(--mmt-navy);">+$29/mo each additional agent &middot; cancel anytime</p>
+          <p style="margin-top:10px;">Connect the AI you already use &mdash; Claude, ChatGPT, your own agent &mdash; to your live opportunities and market intel. It reads your pipeline so it can tell you what to chase before you open your laptop.</p>
+        </div>
+        <div style="flex:1;display:flex;flex-direction:column;">
+          <div style="border-top:1px solid var(--mmt-border-light);padding-top:20px;display:flex;flex-direction:column;gap:2px;">
+            <div class="plan-feature"><span class="check">&#10003;</span> Read-only &mdash; your AI can read, never change or spend</div>
+            <div class="plan-feature"><span class="check">&#10003;</span> You pick what it sees: market intel, live opportunities, your pipeline</div>
+            <div class="plan-feature"><span class="check">&#10003;</span> Revoke any connection and access stops immediately</div>
+            <div class="plan-feature"><span class="check">&#10003;</span> Every read is logged &mdash; see the activity on each connection</div>
+            <div class="plan-feature"><span class="check">&#10003;</span> Works with Claude Desktop, ChatGPT, or any tool that speaks the API</div>
+            <div class="plan-feature"><span class="check">&#10003;</span> Institutional plan includes unlimited agents</div>
+          </div>
+          <div style="margin-top:auto;padding-top:24px;">
+            <a href="/premium/ai-integrations/" class="btn-primary no-underline" style="width:100%;justify-content:center;" onclick="if(typeof plausible!=='undefined')plausible('Agent Access Pricing Click')">Set up Agent Access</a>
+            <p style="margin-top:12px;font-size:13px;color:var(--mmt-text-secondary);text-align:center;">Need a plan first? <a href="#plans">See premium plans</a> &mdash; you add AI access once you're in.</p>
+          </div>
+        </div>
+      </div>
+    </div>
   </section>
 
   <!-- Section 3: Comparison Table -->
@@ -400,6 +431,11 @@
                 <td style="color:var(--mmt-navy);font-weight:600;">Watchlist Alerts</td>
                 <td style="opacity:0.4;">Not included</td>
                 <td>Institutional only</td>
+              </tr>
+              <tr>
+                <td style="color:var(--mmt-navy);font-weight:600;">AI &amp; Integrations (Agent Access)</td>
+                <td style="opacity:0.4;">Not included</td>
+                <td style="color:var(--mmt-teal);font-weight:700;">$39/mo add-on &middot; unlimited on Institutional</td>
               </tr>
             </tbody>
           </table>

--- a/tools.html
+++ b/tools.html
@@ -70,6 +70,12 @@
           <span style="font-size:12px;font-weight:700;color:var(--mmt-teal,#457B9D);">Open tool &rarr;</span>
         </a>
 
+        <a href="/premium/ai-integrations/" class="tool-card" data-testid="tool-ai-integrations" style="display:block;padding:18px 20px;background:var(--mmt-white,#fff);border:1px solid var(--mmt-border,#E5E7EB);border-radius:12px;text-decoration:none;color:var(--mmt-navy,#0A192F);">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;"><strong style="font-size:15px;">AI &amp; Integrations</strong><span style="font-size:9px;font-weight:800;background:rgba(69,123,157,0.12);color:var(--mmt-teal,#457B9D);padding:2px 6px;border-radius:3px;">ADD-ON</span></div>
+          <p style="font-size:13px;color:var(--mmt-text-secondary,#6B7280);line-height:1.5;margin:0 0 8px;">Connect the AI you already use &mdash; Claude, ChatGPT, your own agent &mdash; to your live opportunities and market intel. Read-only, revoke anytime, every access logged. $39/mo add-on on any paid plan.</p>
+          <span style="font-size:12px;font-weight:700;color:var(--mmt-teal,#457B9D);">Set up &rarr;</span>
+        </a>
+
       </div>
     </section>
 


### PR DESCRIPTION
## Why

The paid **AI & Integrations (Agent Access)** add-on shipped live (PRs #103/#104) but was only reachable from the premium dashboard sidebar. That's invisible to anyone *deciding whether to buy*, and the pricing page didn't mention it at all. This closes the discoverability gap so we can market it to paying and non-paying subscribers.

## What changed

- **pricing.html** — new "Add-ons" section with an Agent Access card ($39/mo first agent, $29/mo each additional, monthly/annual), a per-plan feature line on the Annual card, a comparison-table row, and a `#plans` anchor for the "See premium plans" link.
- **premium/settings.html** — an "AI & Integrations" card linking to the connection manager (where you instinctively looked).
- **tools.html** — an "AI & Integrations" card with an ADD-ON badge in the Premium group.

## Marketing CTA path

Both subscriber lists point at **/premium/ai-integrations**, which routes paying members to the in-app upsell and non-payers to the gate → pricing. (Decided with Mary.)

## Verification
- `node build.js` clean (exit 0)
- `validate-dist` OK — 542 pages, all sweeps pass
- New content confirmed in dist for all three pages
- Visual check in local preview (tools hub card, pricing add-on card, settings card)

## Notes
- Not merged — code change following the review default. Ready when you are.
- The Stripe purchase still requires the magic-link sign-in inside the in-app flow; this PR is discoverability only, not a checkout-flow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)