### PR TITLE
Resolve 2026-07-03 intel-quality-report: staleness root cause + leakage cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,53 @@ Before declaring work complete, verify:
 
 ---
 
+## Sprint 2026-07-03 — Intel-quality-report leakage regression: full-set scrub path
+
+The weekly Friday `intel-quality-report` fired its "Chain-of-thought leakage
+in verification_notes" regression detector non-zero — 8 offender contract_intel
+rows carrying `CONTRADICTED:` / "could not verify" reasoning traces in a
+customer-facing field (the exact 2026-05-26 Danielle Applegate / CGI complaint
+pattern).
+
+Diagnosis (NOT prompt drift): every offender was 95–106 days stale — last
+written mid-to-late March 2026, i.e. BEFORE the persistence-layer sanitizer +
+tightened prompt landed 2026-05-26. New writes go through
+`sanitizeNotes` in `contract-intel-refresh-background.js` and the prompt bans
+the `CONTRADICTED:` prefix, so fresh rows are clean. The leakage is confined to
+legacy rows that were never re-refreshed. Subscribers were already protected at
+read time (the `js/contract-detail.js` render regex + the digest's >7d-stale
+exclusion), but the DB rows stayed dirty, which is what the DB-level detector
+alerts on.
+
+Fix: the prescribed remediation `scripts/cleanup-may26-subscriber-trust.js`
+could only scrub ONE hardcoded row (VA Health Services DevSecOps); its audit
+sweep (pass C) was read-only with a standing "extend this script to scrub the
+full set" TODO. Added a `--scrub-all` flag: pass C now writes sanitized
+`verification_notes` back to EVERY offender row (spreading the existing intel
+object so only stale/CONTRADICTED lines are removed — all other fields
+preserved), logs a `contract_intel_verification_notes_scrubbed` ops_event per
+row, and honors `--dry-run`. Sweep limit raised 200→500 to cover the full
+table.
+
+Runbook (Mary runs locally with prod env; no creds in the web session):
+```
+# preview
+SUPABASE_URL=... SUPABASE_SERVICE_KEY=... node scripts/cleanup-may26-subscriber-trust.js --scrub-all --dry-run
+# apply
+SUPABASE_URL=... SUPABASE_SERVICE_KEY=... node scripts/cleanup-may26-subscriber-trust.js --scrub-all
+```
+The next Friday `intel-quality-report` should then report leakage = 0.
+
+Hard rule (do not regress): **the persistence sanitizer + prompt are the
+forward guard; the `--scrub-all` sweep is the backfill for legacy rows.** If
+the detector fires again on rows written AFTER 2026-05-26, THAT is prompt drift
+— inspect `contract-intel-refresh-background.js` prompt + write path, don't
+just scrub. Verified 2026-07-03: sanitizer strips all 4 report leakage samples,
+keeps legitimate footnotes; `tests/unit/intel-notes-sanitizer.test.js` 11/11
+pass; script syntax clean.
+
+---
+
 ## Sprint 2026-07-01 (later still) — AWS Lambda 4KB env cap broke ALL function deploys
 
 Symptom: git deploys failed with `Build script returned non-zero exit code: 2`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,47 @@ just scrub. Verified 2026-07-03: sanitizer strips all 4 report leakage samples,
 keeps legitimate footnotes; `tests/unit/intel-notes-sanitizer.test.js` 11/11
 pass; script syntax clean.
 
+### Part 2 — the underlying staleness (49 rows, 31–106d)
+
+The same report's "Stale contract_intel rows (>14d)" list was the real problem.
+Two distinct root causes (cross-referenced the 49 stale names against the
+63-name contracts.json roster):
+
+**B — 38 in-roster rows starved by budget/cadence.** `contract-intel-refresh-
+background.js` processed the roster in contracts.json FILE ORDER, spent its
+13-min `RUN_BUDGET_MS` on the first ~half, then hit the platform kill. The 20h
+`freshCutoff` resets before the next 24h cron, so `freshContracts` is empty at
+every run → the loop restarted from file index 0 daily and the roster TAIL
+starved indefinitely. Fix: process **stalest-first** — sort `contractsToProcess`
+by `last_updated` ascending (never-refreshed first) using the `existing` rows
+already fetched. Now every run attacks the oldest rows first, so the full
+roster is covered in a few runs and no row can starve. Zero added cost. This
+self-heals the 38 in-roster rows over the next ~3 daily runs after deploy.
+
+**A — 11 orphaned rows (the oldest, 95–106d; all 8 leakage rows are here).**
+Their `contract_name` has NO exact match in the roster (em-dash vs hyphen,
+parenthetical variants — e.g. row `"Community Care Network (CCN) Next Gen"` vs
+roster `"Community Care Network Next Gen (CCN NG)"`; `"Defense Health Agency
+Telehealth Programs"` vs roster `"DHA Telehealth Programs"`). Drift from the
+MMT-INTEL-02 migration off the hardcoded array. The refresh writes fresh rows
+under the CANONICAL names and leaves these variant-named rows as stale
+duplicates it never targets. Guard added: `intel-quality-report.js` now has an
+**Orphaned contract_intel rows** section (`_orphaned()` diffs contract_intel
+names against `getRefreshRoster()`), so drift surfaces in days, not months.
+Reconciling the existing 11 (rename to canonical vs archive the stale
+duplicate) is a **data decision for Mary** — needs prod creds + a judgment call
+per row; not auto-archived.
+
+Hard rule (do not regress): **the refresh roster must be processed
+stalest-first, never file order** — file order + a per-run budget + a
+sub-cadence freshness cutoff silently starves the roster tail. And **a
+contract_intel row whose name isn't in the roster is invisible to the
+refresh** — renaming a contracts.json entry orphans its old row; the
+orphan detector is the tripwire.
+
+Verified 2026-07-03: both functions `node -c` clean; full unit suite 414/414 +
+`tests/contract-intel-pipeline.test.js` 14/14 pass.
+
 ---
 
 ## Sprint 2026-07-01 (later still) — AWS Lambda 4KB env cap broke ALL function deploys

--- a/netlify/functions/contract-intel-refresh-background.js
+++ b/netlify/functions/contract-intel-refresh-background.js
@@ -604,16 +604,37 @@ exports.handler = async (event) => {
       .map((r) => r.contract_name)
   );
 
+  // Name -> last_updated lookup, reused to order the roster STALEST-FIRST
+  // below. A missing entry (never refreshed) sorts oldest.
+  const lastUpdatedMap = new Map(
+    (existing || []).map((r) => [r.contract_name, r.last_updated || null])
+  );
+
   // MMT-INTEL-02: Pull the roster from contracts.json instead of the
   // drifted hardcoded array. Any non-archived contracts.json entry is
   // automatically enrolled.
   const CONTRACTS = getRefreshRoster();
   console.log(`Refresh roster (from contracts.json): ${CONTRACTS.length} contracts`);
 
-  // If force_contract is set, only process that one contract
+  // 2026-07-03 staleness fix: process the roster STALEST-FIRST, not in
+  // contracts.json file order. Root cause of the 95-106d backlog surfaced by
+  // intel-quality-report: the 13-min RUN_BUDGET only reached the first ~half
+  // of the 63-contract roster, and because the 20h fresh-cutoff resets before
+  // the next 24h cron, every run restarted from the top of the file — so the
+  // tail of the roster starved indefinitely. Ordering by last_updated ascending
+  // means each run always attacks the oldest rows first, so the full roster is
+  // covered within a few runs and no row can starve. (The fresh-skip above
+  // still short-circuits anything refreshed in the last 20h — those sort last.)
   const contractsToProcess = forceContract
     ? CONTRACTS.filter((c) => c.name === forceContract)
-    : CONTRACTS;
+    : [...CONTRACTS].sort((a, b) => {
+        const la = lastUpdatedMap.get(a.name);
+        const lb = lastUpdatedMap.get(b.name);
+        if (!la && !lb) return 0;
+        if (!la) return -1; // never-refreshed first
+        if (!lb) return 1;
+        return la < lb ? -1 : la > lb ? 1 : 0; // oldest first
+      });
 
   if (forceContract && contractsToProcess.length === 0) {
     console.error(`Contract not found: ${forceContract}`);

--- a/netlify/functions/intel-quality-report.js
+++ b/netlify/functions/intel-quality-report.js
@@ -19,6 +19,7 @@ const { sendEmail } = require("./lib/send-email");
 const { isRootDomainUrl } = require("./lib/url-validator");
 const { logOpsEvent } = require("./lib/ops-ledger");
 const { hasStaleNotes, strippedNotes } = require("./lib/intel-notes-sanitizer");
+const { getRefreshRoster } = require("./lib/refresh-roster");
 
 const ADMIN_EMAIL = "mary@missionmeetstech.com";
 
@@ -48,6 +49,39 @@ async function _badUrls(supabase) {
     });
     if (bad.length) out.push({ contract_name: r.contract_name, bad_count: bad.length });
   }
+  return out;
+}
+
+// 2026-07-03: Orphan detector. A contract_intel row whose contract_name is
+// NOT in the refresh roster (contracts.json non-archived names) can never be
+// targeted by contract-intel-refresh-background — it rots forever. This is how
+// 11 rows reached 95-106d staleness: names drifted from the roster (em-dash vs
+// hyphen, parenthetical variants) during the MMT-INTEL-02 migration, leaving
+// stale duplicates the pipeline writes fresh copies alongside. Surfacing them
+// weekly catches drift in days, not months. Read-only — reconciliation
+// (rename vs archive) is a human decision.
+async function _orphaned(supabase) {
+  let rosterNames;
+  try {
+    rosterNames = new Set(getRefreshRoster().map((c) => c.name));
+  } catch (e) {
+    console.warn("orphan check: roster load failed:", e.message);
+    return [];
+  }
+  if (rosterNames.size === 0) return []; // roster unreadable — don't false-flag everything
+  const { data } = await supabase
+    .from("contract_intel")
+    .select("contract_name, last_updated");
+  const out = [];
+  for (const r of (data || [])) {
+    if (!r.contract_name) continue;
+    if (rosterNames.has(r.contract_name)) continue;
+    const ageDays = r.last_updated
+      ? Math.floor((Date.now() - new Date(r.last_updated).getTime()) / (24 * 3600 * 1000))
+      : null;
+    out.push({ contract_name: r.contract_name, last_updated: r.last_updated, age_days: ageDays });
+  }
+  out.sort((a, b) => (b.age_days || 0) - (a.age_days || 0));
   return out;
 }
 
@@ -129,8 +163,9 @@ exports.handler = async () => {
   }
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
-  let stale = [], badUrls = [], radar, vehicle, failures = {}, staleNotes = [], urlSweep = {};
+  let stale = [], badUrls = [], radar, vehicle, failures = {}, staleNotes = [], urlSweep = {}, orphaned = [];
   try { stale = await _stale(supabase); } catch (e) { console.warn("stale query failed:", e.message); }
+  try { orphaned = await _orphaned(supabase); } catch (e) { console.warn("orphan scan failed:", e.message); }
   try { badUrls = await _badUrls(supabase); } catch (e) { console.warn("badUrls query failed:", e.message); }
   try { radar = await _radarHealth(supabase, null); } catch { radar = { last_scan: null, age_hours: Infinity, total: 0 }; }
   try { vehicle = await _radarHealth(supabase, "contract_vehicle"); } catch { vehicle = { last_scan: null, age_hours: Infinity, total: 0 }; }
@@ -139,11 +174,12 @@ exports.handler = async () => {
   try { urlSweep = await _urlRecheckSweep(supabase); } catch (e) { console.warn("urlSweep query failed:", e.message); urlSweep = {}; }
 
   const allGreen = stale.length === 0 && badUrls.length === 0 && staleNotes.length === 0
+    && orphaned.length === 0
     && radar.age_hours <= 48 && vehicle.age_hours <= 168
     && Object.keys(failures).length === 0;
   const subject = allGreen
     ? "MMT intel quality — all green"
-    : `MMT intel quality — ${stale.length} stale, ${badUrls.length} bad URL, ${staleNotes.length} note-leak, radar ${radar.age_hours}h`;
+    : `MMT intel quality — ${stale.length} stale, ${orphaned.length} orphaned, ${badUrls.length} bad URL, ${staleNotes.length} note-leak, radar ${radar.age_hours}h`;
 
   const html = `<!DOCTYPE html><html><body style="font-family:-apple-system,sans-serif;padding:24px;color:#0A192F;">
     <h2 style="margin:0 0 8px;">Intel quality report &middot; ${new Date().toISOString().slice(0,10)}</h2>
@@ -153,6 +189,9 @@ exports.handler = async () => {
       const ageDays = Math.floor((Date.now() - new Date(r.last_updated).getTime()) / (24*3600*1000));
       return `<li>${esc(r.contract_name)} &mdash; ${ageDays}d</li>`;
     }).join("")}</ul>`}
+    <h3 style="font-size:14px;margin:16px 0 6px;">Orphaned contract_intel rows (name not in refresh roster)</h3>
+    <p style="color:#5C6B7A;font-size:12px;margin:0 0 6px;">These rows can never be refreshed — their contract_name has no match in contracts.json, so contract-intel-refresh skips them. Usually a naming drift (em-dash vs hyphen, parenthetical variant) leaving a stale duplicate. Reconcile: rename the row to its roster name, or archive it if a fresh canonical row already exists.</p>
+    ${orphaned.length === 0 ? "<p>None.</p>" : `<ul>${orphaned.map((r) => `<li>${esc(r.contract_name)} &mdash; ${r.age_days === null ? "never refreshed" : r.age_days + "d"}</li>`).join("")}</ul>`}
     <h3 style="font-size:14px;margin:16px 0 6px;">Contracts with root-domain source URLs</h3>
     ${badUrls.length === 0 ? "<p>None.</p>" : `<ul>${badUrls.map((r) => `<li>${esc(r.contract_name)} &mdash; ${r.bad_count} bad</li>`).join("")}</ul>`}
     <h3 style="font-size:14px;margin:16px 0 6px;">Chain-of-thought leakage in verification_notes</h3>
@@ -181,9 +220,9 @@ exports.handler = async () => {
       source_function: "intel-quality-report",
       severity: allGreen ? "info" : "warn",
       signature: "weekly_qa",
-      details: { stale: stale.length, bad_urls: badUrls.length, stale_notes: staleNotes.length, url_archived_7d: urlSweep.archived_7d || 0, radar_age_h: radar.age_hours, vehicle_age_h: vehicle.age_hours, failure_keys: Object.keys(failures).length },
+      details: { stale: stale.length, orphaned: orphaned.length, bad_urls: badUrls.length, stale_notes: staleNotes.length, url_archived_7d: urlSweep.archived_7d || 0, radar_age_h: radar.age_hours, vehicle_age_h: vehicle.age_hours, failure_keys: Object.keys(failures).length },
     });
   } catch { /* non-blocking */ }
 
-  return { statusCode: 200, body: JSON.stringify({ ok: true, stale: stale.length, bad_urls: badUrls.length, stale_notes: staleNotes.length, url_sweep: urlSweep, radar, vehicle, failures }) };
+  return { statusCode: 200, body: JSON.stringify({ ok: true, stale: stale.length, orphaned: orphaned.length, bad_urls: badUrls.length, stale_notes: staleNotes.length, url_sweep: urlSweep, radar, vehicle, failures }) };
 };

--- a/scripts/cleanup-may26-subscriber-trust.js
+++ b/scripts/cleanup-may26-subscriber-trust.js
@@ -28,14 +28,22 @@
 //   SUPABASE_URL=... SUPABASE_SERVICE_KEY=... node scripts/cleanup-may26-subscriber-trust.js
 //
 // Flags:
-//   --dry-run   : do everything except the UPDATE statements
-//   --no-sweep  : skip the C audit pass
+//   --dry-run    : do everything except the UPDATE statements
+//   --no-sweep   : skip the C audit pass
+//   --scrub-all  : in the C sweep, WRITE sanitized verification_notes back
+//                  to every offender row (not just the one DevSecOps row in
+//                  pass B). Use this to clear the intel-quality-report
+//                  "Chain-of-thought leakage" regression when it fires on
+//                  legacy rows that predate the persistence-layer sanitizer.
+//                  Honors --dry-run. Only stale/CONTRADICTED lines are
+//                  removed; all other intel fields are left untouched.
 // ============================================================
 
 const { createClient } = require("@supabase/supabase-js");
 
 const DRY_RUN = process.argv.includes("--dry-run");
 const SKIP_SWEEP = process.argv.includes("--no-sweep");
+const SCRUB_ALL = process.argv.includes("--scrub-all");
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY;
@@ -48,7 +56,7 @@ if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
 // Single source of truth for the strip rule — see
 // netlify/functions/lib/intel-notes-sanitizer.js. Locked by
 // tests/unit/intel-notes-sanitizer.test.js.
-const { sanitizeNotes } = require("../netlify/functions/lib/intel-notes-sanitizer");
+const { sanitizeNotes, strippedNotes } = require("../netlify/functions/lib/intel-notes-sanitizer");
 
 async function headStatus(url, timeoutMs = 6000) {
   const ac = new AbortController();
@@ -206,15 +214,16 @@ async function cleanDevSecOpsIntel(supabase) {
 }
 
 async function auditAllIntel(supabase) {
-  console.log("\n[C] Auditing all contract_intel rows for stale verification_notes (read-only)...");
+  const mode = SCRUB_ALL ? (DRY_RUN ? "SCRUB-ALL / DRY-RUN" : "SCRUB-ALL / LIVE") : "read-only";
+  console.log(`\n[C] Auditing all contract_intel rows for stale verification_notes (${mode})...`);
   const { data: rows, error } = await supabase
     .from("contract_intel")
     .select("id, contract_name, intel, last_updated")
     .order("last_updated", { ascending: false })
-    .limit(200);
+    .limit(500);
   if (error) {
     console.log(`  query error: ${error.message}`);
-    return;
+    return { scanned: 0, dirty: 0, scrubbed: 0, error: error.message };
   }
   let totalRows = 0;
   let dirtyRows = 0;
@@ -229,19 +238,60 @@ async function auditAllIntel(supabase) {
     if (diff > 0) {
       dirtyRows++;
       totalStripped += diff;
-      offenders.push({ id: row.id, name: row.contract_name, diff, before_count: before.length });
+      offenders.push({ row, id: row.id, name: row.contract_name, before, after, diff, before_count: before.length });
     }
   }
   console.log(`  scanned ${totalRows} rows; ${dirtyRows} have stale lines; ${totalStripped} stripped total.`);
-  if (offenders.length) {
-    console.log("  offenders (top 10 by diff):");
-    offenders.sort((a, b) => b.diff - a.diff).slice(0, 10).forEach((o) => {
-      console.log(`    - id=${o.id} "${o.name}" stripped=${o.diff}/${o.before_count}`);
-    });
-    if (!DRY_RUN) {
-      console.log("  re-run with the explicit per-contract path or extend this script to scrub the full set.");
-    }
+  if (!offenders.length) return { scanned: totalRows, dirty: 0, scrubbed: 0 };
+
+  offenders.sort((a, b) => b.diff - a.diff);
+  console.log("  offenders (top 10 by diff):");
+  offenders.slice(0, 10).forEach((o) => {
+    console.log(`    - id=${o.id} "${o.name}" stripped=${o.diff}/${o.before_count}`);
+  });
+
+  if (!SCRUB_ALL) {
+    console.log("  read-only sweep. Re-run with --scrub-all to write sanitized notes back to every offender.");
+    return { scanned: totalRows, dirty: dirtyRows, scrubbed: 0 };
   }
+
+  // --scrub-all: persist the sanitized notes for every offender. Mirrors the
+  // single-row write in pass B, but across the full set. Each write only
+  // removes stale/CONTRADICTED lines (via the shared sanitizer); every other
+  // intel field is preserved by spreading the existing intel object.
+  let scrubbed = 0;
+  for (const o of offenders) {
+    const dropped = strippedNotes(o.before);
+    console.log(`  ${DRY_RUN ? "[dry-run] would scrub" : "scrubbing"} id=${o.id} "${o.name}" (${o.diff} line${o.diff === 1 ? "" : "s"})`);
+    dropped.forEach((n, i) => {
+      console.log(`      [strip ${i + 1}] ${String(n).slice(0, 160)}${String(n).length > 160 ? "..." : ""}`);
+    });
+    if (DRY_RUN) continue;
+    const newIntel = { ...(o.row.intel || {}), verification_notes: o.after };
+    const { error: updErr } = await supabase
+      .from("contract_intel")
+      .update({ intel: newIntel })
+      .eq("id", o.id);
+    if (updErr) {
+      console.log(`      UPDATE failed: ${updErr.message}`);
+      continue;
+    }
+    await supabase.from("ops_events").insert({
+      event_type: "contract_intel_verification_notes_scrubbed",
+      details: {
+        row_id: o.id,
+        contract_name: o.name,
+        before_count: o.before.length,
+        after_count: o.after.length,
+        stripped: dropped,
+        triggered_by: "intel-quality-report leakage regression (--scrub-all sweep)",
+        script: "cleanup-may26-subscriber-trust.js",
+      },
+    });
+    scrubbed++;
+  }
+  console.log(`  scrubbed ${scrubbed}/${dirtyRows} offender row(s).`);
+  return { scanned: totalRows, dirty: dirtyRows, scrubbed };
 }
 
 (async () => {
@@ -250,9 +300,10 @@ async function auditAllIntel(supabase) {
 
   const a = await fixBrokenTelehealthRow(supabase);
   const b = await cleanDevSecOpsIntel(supabase);
-  if (!SKIP_SWEEP) await auditAllIntel(supabase);
+  let c = { skipped: true };
+  if (!SKIP_SWEEP) c = await auditAllIntel(supabase);
 
-  console.log("\nsummary:", { telehealth: a, devsecops: b, dry_run: DRY_RUN });
+  console.log("\nsummary:", { telehealth: a, devsecops: b, sweep: c, dry_run: DRY_RUN, scrub_all: SCRUB_ALL });
   process.exit(0);
 })().catch((err) => {
   console.error("fatal:", err);


### PR DESCRIPTION
## Summary

Resolves the findings in the weekly Friday `intel-quality-report` for 2026-07-03. Two things fired: a large **staleness backlog** (49 `contract_intel` rows, 31–106 days old) and the **chain-of-thought leakage** regression detector (8 rows). This PR fixes the root cause of the staleness so it stops recurring, and ships the cleanup path for the leaked notes.

---

## Part 1 — Staleness root cause (the real problem)

Cross-referencing the 49 stale row names against the 63-name `contracts.json` refresh roster showed **two distinct causes**:

**B) 38 in-roster rows starved by budget/cadence.** `contract-intel-refresh-background.js` processed the roster in **contracts.json file order**, spent its 13-minute `RUN_BUDGET_MS` on the first ~half, then hit the platform kill. The 20h freshness cutoff resets *before* the next 24h cron, so `freshContracts` is empty at every run → the loop restarted from file index 0 daily and the **roster tail starved indefinitely**.
→ **Fix:** process **stalest-first** — sort `contractsToProcess` by `last_updated` ascending (never-refreshed first), reusing the `existing` rows the function already fetches. Every run now attacks the oldest rows first, so the full roster is covered in a few runs and no row can starve. Zero added cost. **This self-heals the 38 in-roster rows over the next ~3 daily runs after deploy.**

**A) 11 orphaned rows (the oldest, 95–106 days).** Their `contract_name` has **no exact match** in the roster — naming drift from the MMT-INTEL-02 migration (em-dash vs hyphen, parenthetical variants), e.g. row `"Community Care Network (CCN) Next Gen"` vs roster `"Community Care Network Next Gen (CCN NG)"`, `"Defense Health Agency Telehealth Programs"` vs roster `"DHA Telehealth Programs"`. The refresh writes fresh rows under the *canonical* names and never targets these variant-named duplicates.
→ **Guard:** `intel-quality-report.js` now has an **"Orphaned contract_intel rows"** section (`_orphaned()` diffs `contract_intel` names against `getRefreshRoster()`), so future drift surfaces in **days, not months**.
→ **Reconciling the existing 11** (rename to canonical vs archive the stale duplicate) is a **data decision for Mary** — needs prod creds and a per-row judgment call, so it is *not* auto-archived here.

## Part 2 — Chain-of-thought leakage cleanup

All 8 leakage rows are in the orphaned set above — frozen since March, so they predate the 2026-05-26 persistence-layer sanitizer + tightened prompt (this is **not** prompt drift; new writes are already clean, and subscribers were already shielded by the `contract-detail.js` render filter + the digest's stale-row exclusion). The prescribed remediation script could only scrub one hardcoded row; added a **`--scrub-all`** flag to `scripts/cleanup-may26-subscriber-trust.js` so it writes sanitized `verification_notes` back to every offender (preserving all other intel fields), logs an ops_event per row, and honors `--dry-run`.

## Changes

- `netlify/functions/contract-intel-refresh-background.js` — stalest-first roster ordering.
- `netlify/functions/intel-quality-report.js` — orphan detector section + subject/ops_event fields.
- `scripts/cleanup-may26-subscriber-trust.js` — `--scrub-all` full-set scrub path.
- `CLAUDE.md` — sprint note with both root causes, the two new hard rules, and the runbook.

**Operational follow-ups (need prod creds — for Mary, or hand me creds):**
```
# clear the leaked notes on the 8/11 dirty rows:
SUPABASE_URL=... SUPABASE_SERVICE_KEY=... node scripts/cleanup-may26-subscriber-trust.js --scrub-all --dry-run   # preview
SUPABASE_URL=... SUPABASE_SERVICE_KEY=... node scripts/cleanup-may26-subscriber-trust.js --scrub-all             # apply
```
The 38 in-roster stale rows need no manual step — they self-heal via stalest-first ordering once this deploys. The 11 orphans need the rename-vs-archive decision.

## Checklist
- [x] Unit tests passing — full suite 414/414 + `contract-intel-pipeline` 14/14; `intel-notes-sanitizer` 11/11
- [x] Syntax check (CI "lint") — both functions `node -c` clean
- [ ] Build / integrity audit — build hydrates from Supabase, can't run without creds in the web session
- [x] Security lint — no secrets; no new external calls
- [x] Idempotency — scrub writes keyed per-row + logged; refresh upsert unchanged

## Risk Assessment
- **Critical surfaces touched**: `contract-intel-refresh-background.js` (data-writing cron) — the change is ordering-only; the upsert, budget, fresh-skip, and validation logic are untouched. `intel-quality-report.js` — additive read-only section. `cleanup-may26-subscriber-trust.js` — opt-in write path only.
- **Security impact**: none
- **Contract changes**: none — sanitizer module + its test unchanged
- **Rollback plan**: revert the commits. The ordering change is behavior-preserving except for *which* contracts each run reaches; reverting restores file order. No migrations.

## Evidence
- Cross-reference script confirmed 11/49 stale rows are orphaned (no roster match), 38/49 are in-roster (starved).
- `npx vitest run tests/unit` → 414 passed; `tests/contract-intel-pipeline.test.js` → 14 passed.
- `node -c` clean on both functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfqZEYoU5QNSSAN5RrvL1Z