### PR TITLE
Send DHA CAE-confirmed update to free newsletter list

### DIFF
--- a/data/jul9-dha-cae-release/free-newsletter.md
+++ b/data/jul9-dha-cae-release/free-newsletter.md
@@ -1,0 +1,15 @@
+# The DHA acquisition chief seat is no longer Acting
+
+For months, the most important acquisition seat at the Defense Health Agency carried an "Acting" label. The Component Acquisition Executive, the person with final say over every medical-systems and health IT buy at the component level, was a placeholder while the April reorg sorted itself out.
+
+That changed. The seat is confirmed. Not acting, confirmed.
+
+I am not putting the name in this email, because a name drop is not the point. What matters for your pipeline is this: the person holding final acquisition decision authority at DHA is no longer provisional. That changes who signs, who you invest a relationship in, and how much weight to give a "we are still standing up" answer when DHA hands you one.
+
+I updated the DHA org chart with the confirmed CAE, the background that actually tells you something, and where this seat sits against the three-PAE consolidation running into the July 19 Full Operating Capability date. The full org chart is part of MMT Premium.
+
+**[See the confirmed CAE on the DHA org chart](https://missionmeetstech.com/premium/org-charts/dha)**
+
+Go look before your next DHA conversation. Knowing the seat is settled is worth more than most people will notice this week.
+
+Mary

--- a/netlify.toml
+++ b/netlify.toml
@@ -37,6 +37,7 @@
     "static/lead-magnets/**",
     "data/agent-access-launch/**",
     "data/linkedin-campaign/**",
+    "data/jul9-dha-cae-release/**",
   ]
 
 [[edge_functions]]
@@ -499,6 +500,15 @@
 # in ops_events as jul9_dha_cae_confirmed_sent (claimed before the send loop).
 # Kill switch: JUL9_DHA_CAE_DISABLED=true. Retire by 2026-07-23.
 [functions."jul9-dha-cae-confirmed-send"]
+  schedule = "*/15 * * * *"
+
+# FREE companion to the above: same DHA CAE-confirmed update, sent to the
+# Buttondown newsletter (free) list. Independent pipeline (Buttondown, not
+# Resend), idempotent via Buttondown's own sent-email history so it cannot
+# collide with the paid ops_events marker. Body: data/jul9-dha-cae-release/
+# free-newsletter.md. Kill switch: JUL9_DHA_CAE_FREE_DISABLED=true.
+# Retire by 2026-07-23 alongside the paid companion.
+[functions."jul9-dha-cae-free-send"]
   schedule = "*/15 * * * *"
 
 # Hourly Stripe -> mp_users safety-net sync.

--- a/netlify/functions/jul9-dha-cae-free-send.js
+++ b/netlify/functions/jul9-dha-cae-free-send.js
@@ -1,0 +1,107 @@
+// ============================================================
+// jul9-dha-cae-free-send.js — one-shot DHA CAE-confirmed leadership
+// update to the FREE Buttondown newsletter list. Companion to
+// jul9-dha-cae-confirmed-send.js, which already sent the same update to
+// PAID subscribers via Resend. Modeled on agent-access-free-send.js.
+//
+// The two pipelines are independent by design:
+//   - PAID  -> Resend + mp_users, idempotent via ops_events marker.
+//   - FREE  -> Buttondown (owns the list + unsubscribe footer + branded
+//     header), idempotent via Buttondown's own sent-email history.
+// Because paid went out over Resend, Buttondown has no record of this
+// subject, so this free send is NOT falsely skipped and cannot collide
+// with the paid idempotency marker.
+//
+// Fires on a Netlify cron (netlify.toml), guarded to send EXACTLY ONCE:
+//   - DATE GUARD: only on/after RUN_DATE_UTC (2026-07-09).
+//   - IDEMPOTENCY: skips if Buttondown already has a sent email whose
+//     subject matches (same check newsletter-send.js / agent-access use).
+//   - KILL SWITCH: JUL9_DHA_CAE_FREE_DISABLED=true halts.
+//
+// Buttondown renders the markdown body and applies the newsletter's
+// header/footer. Body is read from data/jul9-dha-cae-release/
+// free-newsletter.md (netlify.toml included_files).
+//
+// Retire (delete function + netlify.toml block + data dir) after
+// 2026-07-23, alongside the paid companion.
+// ============================================================
+
+const fs = require("fs");
+const path = require("path");
+
+const BUTTONDOWN_API_KEY = process.env.BUTTONDOWN_API_KEY;
+const SUBJECT = "[MMT Premium] The DHA acquisition chief seat is no longer Acting";
+const RUN_DATE_UTC = "2026-07-09";
+
+const SOURCE_PATHS = [
+  path.join(__dirname, "..", "..", "data", "jul9-dha-cae-release", "free-newsletter.md"),
+  path.join(__dirname, "data", "jul9-dha-cae-release", "free-newsletter.md"),
+];
+
+function todayOnOrAfterRunDate() {
+  return new Date().toISOString().slice(0, 10) >= RUN_DATE_UTC;
+}
+
+function readBodyMd() {
+  for (const p of SOURCE_PATHS) {
+    try { if (fs.existsSync(p)) return fs.readFileSync(p, "utf8"); } catch (err) { console.warn("readBodyMd:", p, err.message); }
+  }
+  return null;
+}
+
+exports.handler = async () => {
+  const checkedAt = new Date().toISOString();
+  console.log("jul9-dha-cae-free-send: triggered", checkedAt);
+
+  if (String(process.env.JUL9_DHA_CAE_FREE_DISABLED || "").toLowerCase() === "true") {
+    return { statusCode: 200, body: JSON.stringify({ skipped: "kill_switch", checkedAt }) };
+  }
+  if (!todayOnOrAfterRunDate()) {
+    return { statusCode: 200, body: JSON.stringify({ skipped: "not_yet_run_date", expected: RUN_DATE_UTC }) };
+  }
+  if (!BUTTONDOWN_API_KEY) {
+    return { statusCode: 200, body: JSON.stringify({ skipped: "no_buttondown_key", checkedAt }) };
+  }
+
+  const bodyMd = readBodyMd();
+  if (!bodyMd) return { statusCode: 500, body: JSON.stringify({ error: "source_missing", expected: SOURCE_PATHS }) };
+  // Subject carries the headline; drop the markdown H1 so it is not
+  // duplicated in the email body.
+  const body = bodyMd.replace(/^# .+?\n/, "").trim();
+
+  try {
+    // Idempotency: skip if an email with this subject was already sent.
+    const sentRes = await fetch("https://api.buttondown.com/v1/emails?status=sent&count=10", {
+      headers: { Authorization: `Token ${BUTTONDOWN_API_KEY}` },
+    });
+    if (sentRes.ok) {
+      const sentData = await sentRes.json();
+      const already = (sentData.results || []).some(
+        (e) => e.subject && e.subject.includes(SUBJECT.substring(0, 40))
+      );
+      if (already) {
+        return { statusCode: 200, body: JSON.stringify({ skipped: "already_sent", checkedAt }) };
+      }
+    }
+
+    const sendRes = await fetch("https://api.buttondown.com/v1/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Token ${BUTTONDOWN_API_KEY}`,
+        "Content-Type": "application/json",
+        "X-Buttondown-Live-Dangerously": "true",
+      },
+      body: JSON.stringify({ subject: SUBJECT, body, status: "about_to_send" }),
+    });
+    if (!sendRes.ok) {
+      const errText = await sendRes.text();
+      throw new Error(`Buttondown API error ${sendRes.status}: ${errText.slice(0, 300)}`);
+    }
+    const result = await sendRes.json();
+    console.log(`jul9-dha-cae-free-send: sent "${SUBJECT}" — id ${result.id}`);
+    return { statusCode: 200, body: JSON.stringify({ sent: true, id: result.id, checkedAt }) };
+  } catch (err) {
+    console.error("jul9-dha-cae-free-send error:", err.message);
+    return { statusCode: 500, body: JSON.stringify({ error: err.message, checkedAt }) };
+  }
+};


### PR DESCRIPTION
## What

The DHA CAE-confirmed leadership update already went to **paid** subscribers via `jul9-dha-cae-confirmed-send.js` (Resend). This adds the **free** companion so the same email reaches the free newsletter list.

- `netlify/functions/jul9-dha-cae-free-send.js` — sends the update to the free **Buttondown** list (Buttondown owns the recipient list, unsubscribe footer, and branded header). Modeled on the proven `agent-access-free-send.js`.
- `data/jul9-dha-cae-release/free-newsletter.md` — the email body (markdown). Same message as the paid HTML: seat is confirmed, no name dropped, CTA to the DHA org chart. One added line makes clear the full org chart is MMT Premium, so the `[MMT Premium]`-subject teaser is honest for free readers.
- `netlify.toml` — cron schedule + `included_files` entry.

## Why the two pipelines don't collide

- **Paid** → Resend + `mp_users`, idempotent via an `ops_events` marker.
- **Free** → Buttondown, idempotent via Buttondown's own sent-email history.

Paid went out over Resend, so Buttondown has no record of this subject — the free send is not falsely skipped, and it cannot double-fire against the paid marker.

## Guards (send exactly once)

- Date guard: on/after `2026-07-09` UTC.
- Idempotency: skips if Buttondown already sent this subject.
- Kill switch: `JUL9_DHA_CAE_FREE_DISABLED=true`.
- Every send path already checks delivery; on Buttondown error the function returns 500 and retries next tick until it succeeds once.

Retires (function + toml block + data dir) on 2026-07-23 alongside the paid companion.

## Verification

- `node -c` on the function: clean.
- Voice sweep on the body: 0 em dashes, 0 exclamations, 0 banned words.
- `scan-pii`: OK (no customer emails in tracked source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY4AuYNkBTwfpbA2MyNGYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY4AuYNkBTwfpbA2MyNGYb)_