### PR TITLE
Add Primer card to top of premium dashboard

### DIFF
--- a/premium/dashboard.html
+++ b/premium/dashboard.html
@@ -84,7 +84,7 @@
   <h1 style="font-size:24px; font-weight:800; margin:0 0 4px;">Welcome back.</h1>
   <p style="color:var(--mmt-text-secondary); margin:0 0 32px; font-size:14px;">Your Premium access is active.</p>
 
-  <a href="/primer.html" class="dash-card" style="display:flex;align-items:center;justify-content:space-between;gap:16px;text-decoration:none;color:inherit;background:var(--mmt-navy);border-color:var(--mmt-navy);flex-wrap:wrap;">
+  <a href="/primer.html" class="dash-card" style="display:flex;align-items:center;justify-content:space-between;gap:16px;text-decoration:none;color:rgb(255,255,255);background:var(--mmt-navy);border:1px solid rgba(255,255,255,0.14);flex-wrap:wrap;">
     <div>
       <div style="font-size:11px;font-weight:800;letter-spacing:0.12em;text-transform:uppercase;color:#9ec3e6;margin-bottom:6px;">New here? Start here</div>
       <h3 style="color:rgb(255,255,255);margin:0 0 4px;">The Primer: how to turn MMT into pipeline</h3>

--- a/premium/dashboard.html
+++ b/premium/dashboard.html
@@ -84,6 +84,15 @@
   <h1 style="font-size:24px; font-weight:800; margin:0 0 4px;">Welcome back.</h1>
   <p style="color:var(--mmt-text-secondary); margin:0 0 32px; font-size:14px;">Your Premium access is active.</p>
 
+  <a href="/primer.html" class="dash-card" style="display:flex;align-items:center;justify-content:space-between;gap:16px;text-decoration:none;color:inherit;background:var(--mmt-navy);border-color:var(--mmt-navy);flex-wrap:wrap;">
+    <div>
+      <div style="font-size:11px;font-weight:800;letter-spacing:0.12em;text-transform:uppercase;color:#9ec3e6;margin-bottom:6px;">New here? Start here</div>
+      <h3 style="color:rgb(255,255,255);margin:0 0 4px;">The Primer: how to turn MMT into pipeline</h3>
+      <p style="margin:0;color:#e6edf5;font-size:14px;max-width:60ch;">The federal acquisition timeline, which tool to reach for at each stage, and how MMT compares to the industry standard.</p>
+    </div>
+    <span style="font-size:13px;font-weight:700;color:rgb(255,255,255);background:var(--mmt-teal);padding:10px 18px;border-radius:7px;white-space:nowrap;">Read the primer &rarr;</span>
+  </a>
+
   <div class="dash-card" style="border-left:3px solid var(--mmt-teal);">
     <h3>Capture Intelligence — This Month</h3>
     <p style="margin:0 0 12px; color:var(--mmt-text-secondary); font-size:14px;">Full sheet with all action windows, confidence labels, and deep-dive analysis. 24 signals across 10 agencies.</p>


### PR DESCRIPTION
## What

Surfaces **The Primer** as the first card on `/premium/dashboard.html`, above Capture Intelligence. The dashboard page is already premium-gated, so the card sits behind the paywall as requested.

- Navy card, teal "Read the primer →" button, links to `/primer.html`.
- White text uses `rgb(255,255,255)` so it survives the source-theme cleaner's `#fff`→navy pass (the codebase's own documented trick).
- The public homepage entry band from the earlier Primer work stays exactly as-is — this only **adds** the dashboard entry.

## Verification

- `node build.js` clean; card renders in both `dist/premium/dashboard.html` and `dist/premium/dashboard/index.html`.
- White-on-navy heading and white-on-teal button confirmed in built output (no navy-on-navy).
- `validate-dist`: OK, 572 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY4AuYNkBTwfpbA2MyNGYb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY4AuYNkBTwfpbA2MyNGYb)_