### PR TITLE
feat(intel): self-observing coverage guard for the contract-intel refresh loop

### DIFF
--- a/netlify/functions/contract-intel-refresh-background.js
+++ b/netlify/functions/contract-intel-refresh-background.js
@@ -24,6 +24,7 @@ const { checkFreshness } = require("./lib/stale-detector");
 const { disambiguate } = require("./lib/entity-disambiguator");
 const { trackAnthropic } = require("./lib/cost-tracker");
 const { getRefreshRoster } = require("./lib/refresh-roster");
+const { computeCoverage } = require("./lib/refresh-coverage");
 const { validateSources } = require("./lib/url-validator");
 const { sanitizeNotes, strippedNotes } = require("./lib/intel-notes-sanitizer");
 
@@ -840,6 +841,52 @@ exports.handler = async (event) => {
     console.error("Threshold adjustment failed (non-blocking):", threshErr.message);
   }
 
+  // --- Self-observing coverage guard (durable-loop tripwire) ---------------
+  // The loop resumes stalest-first every run (last_updated IS the checkpoint),
+  // so it self-heals as long as throughput >= roster growth. The ONE case that
+  // ordering can't fix is the roster outpacing a 13-min budget: rows then age
+  // past SLA and today only the WEEKLY intel-quality-report notices. Measure
+  // coverage on the POST-run state so "the loop is falling behind" surfaces the
+  // same day, in the ledger. Best-effort — never let it fail the run. Skipped
+  // for single-contract force refreshes (not a roster-coverage pass).
+  let coverage = null;
+  if (!forceContract) {
+    try {
+      const { data: afterRows } = await supabase
+        .from("contract_intel")
+        .select("contract_name, last_updated");
+      const postMap = new Map((afterRows || []).map((r) => [r.contract_name, r.last_updated || null]));
+      coverage = computeCoverage(CONTRACTS.map((c) => c.name), postMap);
+      console.log(
+        `Coverage: ${coverage.coveragePct}% fresh (${coverage.covered}/${coverage.total}), ` +
+        `stale=${coverage.staleCount}, never=${coverage.neverRefreshed}, oldest=${coverage.oldestHours ?? "∞"}h, behind=${coverage.behind}`,
+      );
+      // Leading-indicator tripwire: distinct, queryable ledger row the moment
+      // the loop can't keep the roster inside SLA — days ahead of the weekly
+      // report. No email (the weekly report already escalates; this is the
+      // earlier ledger signal MissionPulse / the report can pick up).
+      if (coverage.behind) {
+        await logOpsEvent(supabase, {
+          event_type: "intel_refresh_behind",
+          source_function: "contract-intel-refresh",
+          severity: "warn",
+          signature: "roster_outpacing_budget",
+          details: {
+            reason: coverage.behindReason,
+            coverage_pct: coverage.coveragePct,
+            stale_count: coverage.staleCount,
+            never_refreshed: coverage.neverRefreshed,
+            oldest_hours: coverage.oldestHours,
+            roster_total: coverage.total,
+            truncated_for_budget: truncatedForBudget,
+          },
+        });
+      }
+    } catch (covErr) {
+      console.error("Coverage computation failed (non-blocking):", covErr.message);
+    }
+  }
+
   // Log to ops_events with cost estimate
   // Claude Sonnet + web_search: ~$3-6 per 1000 requests. 2 calls per contract (research + verify).
   const totalCalls = successCount * 2;
@@ -857,6 +904,7 @@ exports.handler = async (event) => {
       cost_estimate: costEstimate,
       api_calls: totalCalls,
       run_ms: Date.now() - runStart,
+      coverage,
     },
   });
 

--- a/netlify/functions/lib/refresh-coverage.js
+++ b/netlify/functions/lib/refresh-coverage.js
@@ -1,0 +1,122 @@
+// ============================================================
+// refresh-coverage.js — self-observing coverage math for the
+// contract-intel refresh loop.
+//
+// WHY THIS EXISTS (the "durable loop" / Orchestrator idea, applied):
+// contract-intel-refresh-background.js is already a resumable loop —
+// last_updated is its persisted checkpoint and it processes the roster
+// STALEST-FIRST, so every run picks up exactly the rows the previous
+// (budget-killed) run didn't reach. That self-heals as long as the
+// loop's throughput keeps pace with the roster. The ONE failure mode
+// the stalest-first ordering does NOT prevent is the roster GROWING
+// faster than a 13-min budget can cycle it: rows then age past their
+// SLA and the only detector today is the WEEKLY intel-quality-report —
+// a lagging indicator by up to 7 days.
+//
+// computeCoverage() turns that into a PER-RUN leading indicator: the
+// loop measures how much of its own roster is fresh and whether the
+// oldest row has drifted past the SLA, so "the loop is falling behind"
+// surfaces the same day, in the ops ledger, not a week later.
+//
+// Pure: no I/O, no Date.now() capture inside (caller passes `now`), so
+// it is fully deterministic and unit-testable offline.
+// ============================================================
+
+const MS_PER_HOUR = 3_600_000;
+
+// A refreshed row older than this is counted "stale" for coverage %.
+const STALE_HOURS_DEFAULT = 48;
+// The oldest *refreshed* row drifting past this ⇒ the loop is cycling
+// too slowly (throughput < roster). 72h = three daily runs missed.
+const BEHIND_HOURS_DEFAULT = 72;
+// Fraction of the roster that may be never-refreshed before we call the
+// loop "behind" on that signal alone. A couple of freshly-added
+// contracts are EXPECTED to be never-refreshed for a run or two (they
+// sort first and get picked up), so a single add must not trip the
+// alarm — only a large untouched fraction means the budget genuinely
+// can't get around the roster.
+const NEVER_REFRESHED_FRACTION_DEFAULT = 0.15;
+
+/**
+ * Measure how well the stalest-first refresh loop is keeping up.
+ *
+ * @param {string[]} rosterNames   canonical contract names in the roster
+ * @param {Map<string,string|null>} lastUpdatedMap  name -> last_updated ISO
+ *        (or null/absent when the row has never been refreshed)
+ * @param {object} [opts]
+ * @param {number} [opts.now=Date.now()]  reference epoch ms
+ * @param {number} [opts.staleHours=48]
+ * @param {number} [opts.behindHours=72]
+ * @param {number} [opts.neverRefreshedFraction=0.15]
+ * @returns {{
+ *   total:number, covered:number, staleCount:number, neverRefreshed:number,
+ *   coveragePct:number, oldestHours:(number|null), staleHours:number,
+ *   behindHours:number, behind:boolean, behindReason:(string|null)
+ * }}
+ */
+function computeCoverage(rosterNames, lastUpdatedMap, opts = {}) {
+  const now = Number.isFinite(opts.now) ? opts.now : Date.now();
+  const staleHours = opts.staleHours ?? STALE_HOURS_DEFAULT;
+  const behindHours = opts.behindHours ?? BEHIND_HOURS_DEFAULT;
+  const neverFraction = opts.neverRefreshedFraction ?? NEVER_REFRESHED_FRACTION_DEFAULT;
+
+  const names = Array.isArray(rosterNames) ? rosterNames : [];
+  const map = lastUpdatedMap instanceof Map ? lastUpdatedMap : new Map();
+
+  const total = names.length;
+  let neverRefreshed = 0;
+  let staleCount = 0;
+  let maxFiniteAge = 0;
+
+  for (const name of names) {
+    const lu = map.get(name);
+    const t = lu ? new Date(lu).getTime() : NaN;
+    if (!Number.isFinite(t)) {
+      // never refreshed (or an unparseable timestamp) — counts as stale
+      neverRefreshed++;
+      staleCount++;
+      continue;
+    }
+    const age = (now - t) / MS_PER_HOUR;
+    if (age > staleHours) staleCount++;
+    if (age > maxFiniteAge) maxFiniteAge = age;
+  }
+
+  const coveragePct = total ? Math.round(((total - staleCount) / total) * 100) : 100;
+
+  // "Behind" = the loop cannot keep the roster inside SLA. Two signals:
+  //   1. the oldest row that HAS been refreshed drifted past behindHours
+  //      (throughput < roster even for rows it already reached), or
+  //   2. a large fraction of the roster has NEVER been refreshed (the
+  //      budget can't even get around to the never-seen rows). A lone
+  //      new add stays under the fraction and does not trip this.
+  let behind = false;
+  let behindReason = null;
+  if (total > 0 && maxFiniteAge > behindHours) {
+    behind = true;
+    behindReason = `oldest refreshed row is ${Math.round(maxFiniteAge)}h old (SLA ${behindHours}h)`;
+  } else if (total > 0 && neverRefreshed / total > neverFraction) {
+    behind = true;
+    behindReason = `${neverRefreshed}/${total} contracts never refreshed (> ${Math.round(neverFraction * 100)}% of roster)`;
+  }
+
+  return {
+    total,
+    covered: total - staleCount,
+    staleCount,
+    neverRefreshed,
+    coveragePct,
+    oldestHours: neverRefreshed > 0 ? null : Math.round(maxFiniteAge),
+    staleHours,
+    behindHours,
+    behind,
+    behindReason,
+  };
+}
+
+module.exports = {
+  computeCoverage,
+  STALE_HOURS_DEFAULT,
+  BEHIND_HOURS_DEFAULT,
+  NEVER_REFRESHED_FRACTION_DEFAULT,
+};

--- a/tests/unit/refresh-coverage.test.js
+++ b/tests/unit/refresh-coverage.test.js
@@ -1,0 +1,129 @@
+// Unit tests for the contract-intel refresh coverage guard.
+// Pure logic — no network, no Supabase. Locks the leading-indicator
+// tripwire math so a regression can't silently blind the durable loop.
+
+import { describe, it, expect } from "vitest";
+import { computeCoverage } from "../../netlify/functions/lib/refresh-coverage.js";
+
+const NOW = Date.UTC(2026, 6, 17, 12, 0, 0); // fixed reference epoch
+const hoursAgo = (h) => new Date(NOW - h * 3_600_000).toISOString();
+
+function mapOf(entries) {
+  return new Map(entries);
+}
+
+describe("computeCoverage — healthy roster", () => {
+  it("reports 100% coverage when every row is inside SLA", () => {
+    const names = ["A", "B", "C"];
+    const map = mapOf([
+      ["A", hoursAgo(2)],
+      ["B", hoursAgo(10)],
+      ["C", hoursAgo(30)],
+    ]);
+    const cov = computeCoverage(names, map, { now: NOW });
+    expect(cov.total).toBe(3);
+    expect(cov.covered).toBe(3);
+    expect(cov.staleCount).toBe(0);
+    expect(cov.neverRefreshed).toBe(0);
+    expect(cov.coveragePct).toBe(100);
+    expect(cov.oldestHours).toBe(30);
+    expect(cov.behind).toBe(false);
+    expect(cov.behindReason).toBeNull();
+  });
+
+  it("counts rows over staleHours as stale but not necessarily behind", () => {
+    const names = ["A", "B", "C", "D"];
+    const map = mapOf([
+      ["A", hoursAgo(2)],
+      ["B", hoursAgo(50)], // > 48h stale, < 72h behind
+      ["C", hoursAgo(60)],
+      ["D", hoursAgo(1)],
+    ]);
+    const cov = computeCoverage(names, map, { now: NOW });
+    expect(cov.staleCount).toBe(2);
+    expect(cov.coveragePct).toBe(50);
+    expect(cov.oldestHours).toBe(60);
+    expect(cov.behind).toBe(false); // oldest 60h < 72h behind threshold
+  });
+});
+
+describe("computeCoverage — behind: oldest refreshed row past SLA", () => {
+  it("trips behind when the oldest refreshed row exceeds behindHours", () => {
+    const names = ["A", "B"];
+    const map = mapOf([
+      ["A", hoursAgo(5)],
+      ["B", hoursAgo(80)], // > 72h
+    ]);
+    const cov = computeCoverage(names, map, { now: NOW });
+    expect(cov.behind).toBe(true);
+    expect(cov.behindReason).toMatch(/oldest refreshed row is 80h old/);
+  });
+
+  it("honors a custom behindHours threshold", () => {
+    const names = ["A"];
+    const map = mapOf([["A", hoursAgo(30)]]);
+    expect(computeCoverage(names, map, { now: NOW }).behind).toBe(false);
+    expect(computeCoverage(names, map, { now: NOW, behindHours: 24 }).behind).toBe(true);
+  });
+});
+
+describe("computeCoverage — never-refreshed handling", () => {
+  it("a single freshly-added contract does NOT trip behind (self-heals)", () => {
+    // 1 of 10 never refreshed = 10% < 15% fraction threshold
+    const names = Array.from({ length: 10 }, (_, i) => `C${i}`);
+    const map = mapOf(names.slice(1).map((n) => [n, hoursAgo(3)])); // C0 absent
+    const cov = computeCoverage(names, map, { now: NOW });
+    expect(cov.neverRefreshed).toBe(1);
+    expect(cov.oldestHours).toBeNull(); // unknown while any row is never-refreshed
+    expect(cov.behind).toBe(false);
+  });
+
+  it("a large never-refreshed fraction trips behind", () => {
+    // 3 of 10 never refreshed = 30% > 15%
+    const names = Array.from({ length: 10 }, (_, i) => `C${i}`);
+    const map = mapOf(names.slice(3).map((n) => [n, hoursAgo(3)]));
+    const cov = computeCoverage(names, map, { now: NOW });
+    expect(cov.neverRefreshed).toBe(3);
+    expect(cov.behind).toBe(true);
+    expect(cov.behindReason).toMatch(/never refreshed/);
+  });
+
+  it("treats an unparseable timestamp as never-refreshed", () => {
+    const names = ["A", "B"];
+    const map = mapOf([
+      ["A", "not-a-date"],
+      ["B", hoursAgo(3)],
+    ]);
+    const cov = computeCoverage(names, map, { now: NOW });
+    expect(cov.neverRefreshed).toBe(1);
+    expect(cov.staleCount).toBe(1);
+  });
+
+  it("null last_updated counts as never-refreshed", () => {
+    const cov = computeCoverage(["A"], mapOf([["A", null]]), { now: NOW });
+    expect(cov.neverRefreshed).toBe(1);
+    expect(cov.oldestHours).toBeNull();
+  });
+});
+
+describe("computeCoverage — edge cases", () => {
+  it("empty roster is vacuously 100% and never behind", () => {
+    const cov = computeCoverage([], new Map(), { now: NOW });
+    expect(cov.total).toBe(0);
+    expect(cov.coveragePct).toBe(100);
+    expect(cov.behind).toBe(false);
+  });
+
+  it("tolerates non-array / non-Map inputs without throwing", () => {
+    expect(() => computeCoverage(null, null, { now: NOW })).not.toThrow();
+    const cov = computeCoverage(undefined, undefined, { now: NOW });
+    expect(cov.total).toBe(0);
+    expect(cov.behind).toBe(false);
+  });
+
+  it("a row missing from the map is never-refreshed, not an error", () => {
+    const cov = computeCoverage(["A", "B"], mapOf([["A", hoursAgo(4)]]), { now: NOW });
+    expect(cov.total).toBe(2);
+    expect(cov.neverRefreshed).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Applies the "durable / self-observing loop" idea (Palantir Orchestrator, DevCon 6) to the one place in the system where it pays off. The nightly `contract-intel-refresh` is **already** a resumable loop — `last_updated` is its persisted checkpoint and it processes the roster **stalest-first**, so every budget-killed run automatically resumes on the rows the previous run didn't reach. That self-heals as long as throughput keeps pace with the roster.

The single failure mode stalest-first ordering can't fix is the **roster growing faster than a 13-minute budget can cycle it** — rows then age past SLA and today only the **weekly** `intel-quality-report` notices, a lagging indicator by up to 7 days. This PR makes the loop measure its own coverage every run and drop a distinct, queryable tripwire the moment it's outpaced — days ahead of the weekly report. No change to research/upsert behavior.

## Changes
- **`netlify/functions/lib/refresh-coverage.js`** (new): pure `computeCoverage()` — deterministic, no I/O, caller passes `now`. Distinguishes a lone freshly-added contract (expected; self-heals in 1–2 runs) from a genuine fall-behind via the oldest-refreshed-row age and a never-refreshed fraction threshold.
- **`netlify/functions/contract-intel-refresh-background.js`**: after the loop, computes a coverage snapshot on the **post-run** DB state, folds it into the existing `contract_data_refresh` completion event, and logs a `warn` `intel_refresh_behind` (`signature: roster_outpacing_budget`) event when behind. Best-effort / non-blocking; skipped for single-contract force refreshes.
- **`tests/unit/refresh-coverage.test.js`** (new): 11 tests — healthy / stale / behind-by-age / behind-by-never-refreshed-fraction / unparseable + null timestamps / empty + malformed inputs.

## Checklist
- [x] Unit tests passing (`437/437`, incl. 11 new)
- [ ] Smoke tests passing (`npm run test:smoke`) — post-deploy, live-endpoint only
- [ ] E2E tests passing — n/a to this change
- [ ] Integrity audit passing (`node integrity-audit.js`) — requires prod env; unaffected (no route/HTML change)
- [ ] Build succeeds (`node build.js`) — hangs on Supabase hydrate without prod env in the web session; **this change touches no `build.js` input** (Netlify function + lib + test, nothing rendered into `dist/`)
- [x] Security lint passing (no secrets; no new external calls)
- [x] No new uploads without access controls (none added)
- [x] No new external calls without retry and validation (the only new I/O is one Supabase `select`, best-effort, wrapped in try/catch)
- [x] No critical-path changes without smoke-test evidence (research/upsert path unchanged; addition is post-loop observability)
- [x] No breaking contract changes (additive `details.coverage` field + a new ops event type)
- [x] PR is focused

## Risk Assessment
- **Critical surfaces touched**: `contract-intel-refresh-background.js` — data-writing, but this change only **reads** post-run state and **logs**; it does not alter what gets written to `contract_intel`.
- **Security impact**: none
- **Contract changes**: compatible (new optional `coverage` object in the completion event; new `intel_refresh_behind` ops event)
- **Rollback plan**: revert the commit — the refresh loop returns to its prior behavior with zero data migration.

## Evidence
```
node -c netlify/functions/lib/refresh-coverage.js            → OK
node -c netlify/functions/contract-intel-refresh-background.js → OK
node_modules/.bin/vitest run tests/unit/refresh-coverage.test.js → 11 passed
node_modules/.bin/vitest run tests/unit                       → 36 files, 437 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6bkrPHg5zzWK4hQfD9xbT)_