### PR TITLE
feat(loops): contract_intel freshness watchdog under the loop framework

### DIFF
--- a/docs/MMT-Loop-System.md
+++ b/docs/MMT-Loop-System.md
@@ -23,6 +23,7 @@ no path to a publishable directory.
 |---|---|---|
 | **L1 Opportunity Discovery** | ✅ shipped | Daily SAM.gov discovery, staged for review |
 | **L3 Contract Tracker Freshness** | ✅ shipped | Hourly data-trust guard + public `/status.json` |
+| **Contract Intel Freshness** | ✅ shipped | 6-hourly independent watchdog on `contract_intel` coverage; catches the nightly refresh falling behind its roster or stopping entirely |
 | L2 Pursuit Score QA | ⏸ deferred | Needs Mary's 50-row hand-graded golden set; fabricating it would violate the repo's no-fabricated-fixtures rule. Fast-follow once the golden set exists. |
 | L4 Agency Drift | ❌ dropped | `netlify/functions/org-chart-monitor.js` already hashes agency leadership pages and emails Mary on change. A second detector would just double-notify. Future: port org-chart-monitor into this framework + add budget-delta. |
 | L5 Newsletter QA | ❌ out of scope | Mary handles newsletter content independently. |
@@ -103,6 +104,27 @@ reachable-but-stale or non-2xx source as **drift** → alerts Mary.
 - Unknown lag (table/column unresolved) is treated as "unknown", never a false
   STALE (see the CLAUDE.md false-STALE sprint).
 - `/status.json` serves the newest row per source for an uptime badge.
+
+## Contract Intel Freshness (intel-coverage watchdog)
+
+`specs/contract_intel_freshness.json`. Every 6h.
+
+`coverage` (read `contract_intel` + roster, run the SAME pure
+`computeCoverage()` the nightly `contract-intel-refresh` uses inline) →
+`snapshot` (best-effort `loop_status` row, `source=contract_intel`). Eval
+`intel_coverage` marks **drift** when the refresh has fallen behind its roster
+**or** appears to have stopped running entirely → alerts Mary.
+
+- **Why a loop AND an inline guard?** The inline coverage guard in
+  `contract-intel-refresh-background.js` only fires *when the refresh runs* — a
+  dead/disabled cron logs nothing, so "the refresh stopped" is invisible to it.
+  This loop observes from the outside: it also tracks the age of the newest
+  `contract_intel` row (`newestRowAgeHours`); if that climbs past the expected
+  daily gap, the whole pipeline has stalled and this catches it within one tick.
+- No LLM, no external API — one Supabase read. Detection-only (no data writes).
+- Best-effort snapshot: the drift alert needs no tables, so a missing
+  `loop_status` (pre-migration) never suppresses the alert.
+- `loop_config` seed: `migrations/20260717000000_contract_intel_freshness_loop.sql`.
 
 ## Running locally
 

--- a/migrations/20260717000000_contract_intel_freshness_loop.sql
+++ b/migrations/20260717000000_contract_intel_freshness_loop.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- 20260717000000_contract_intel_freshness_loop.sql
+--
+-- Seeds the loop_config row for the contract_intel_freshness watchdog
+-- (netlify/functions/lib/loops/specs/contract_intel_freshness.json).
+--
+-- Depends on loop_config from 20260610000000_loop_infra.sql. Additive,
+-- idempotent (do-nothing on conflict), no destructive statements — safe
+-- to re-run. GATED: apply only after the loop_infra migration is live and
+-- alongside setting LOOPS_ENABLED=true. The loop runs without this row
+-- (readConfig falls back to enabled=true defaults); the seed exists so the
+-- loop can be disabled / retuned from config without a code deploy.
+-- ============================================================
+
+insert into loop_config (loop_name, enabled, cron_expr, max_cost_usd, notes) values
+  ('contract_intel_freshness', true, '0 */6 * * *', 0.02,
+   'Independent watchdog on contract_intel coverage/freshness (reuses computeCoverage). Catches the nightly refresh falling behind its roster OR stopping entirely. No LLM, no external API.')
+on conflict (loop_name) do nothing;

--- a/netlify.toml
+++ b/netlify.toml
@@ -206,6 +206,12 @@
 [functions."loop-contract-freshness"]
   schedule = "0 * * * *"
 
+# Contract Intel Freshness — every 6h. Independent watchdog on contract_intel
+# coverage (reuses computeCoverage); catches the refresh falling behind its
+# roster OR stopping entirely. No LLM, no external API; writes loop_status.
+[functions."loop-contract-intel-freshness"]
+  schedule = "0 */6 * * *"
+
 [functions."score-cleanup"]
   schedule = "*/30 * * * *"
 

--- a/netlify/functions/lib/loops/evals/intel_coverage.js
+++ b/netlify/functions/lib/loops/evals/intel_coverage.js
@@ -1,0 +1,49 @@
+// ============================================================
+// evals/intel_coverage.js (contract_intel_freshness)
+//
+// Drift gate for the contract_intel freshness watchdog. Two independent
+// failure modes make the run drift (→ on_drift alert to Mary):
+//   1. coverage.behind  — the refresh is cycling too slowly for its roster
+//      (stalest-first ordering can't fix a budget that's outpaced).
+//   2. refreshStalled    — the newest contract_intel row anywhere is older
+//      than the expected daily gap, i.e. the refresh cron itself has stopped.
+//
+// Detection-only, like every loop eval. It never edits data; it decides
+// whether Mary gets pinged and records the coverage snapshot in loop_evals.
+// ============================================================
+
+async function run(ctx) {
+  const d = (ctx.data && ctx.data.coverage) || {};
+  const cov = d.coverage || {};
+  const behind = !!cov.behind;
+  const stalled = !!d.refreshStalled;
+  const problem = behind || stalled;
+
+  const reasons = [];
+  if (behind) reasons.push(cov.behindReason || "coverage behind SLA");
+  if (stalled) {
+    reasons.push(
+      `refresh appears stalled: newest contract_intel row is ${d.newestRowAgeHours}h old (> ${d.maxRefreshGapHours}h expected gap)`,
+    );
+  }
+
+  return {
+    passed: !problem,
+    drift: problem,
+    score: typeof cov.coveragePct === "number" ? cov.coveragePct : null,
+    threshold: 100,
+    details: {
+      coverage_pct: cov.coveragePct ?? null,
+      covered: cov.covered ?? null,
+      stale_count: cov.staleCount ?? null,
+      never_refreshed: cov.neverRefreshed ?? null,
+      oldest_hours: cov.oldestHours ?? null,
+      roster_total: cov.total ?? null,
+      newest_row_age_hours: d.newestRowAgeHours ?? null,
+      refresh_stalled: stalled,
+      reasons,
+    },
+  };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/fetchers/contract_intel_coverage.js
+++ b/netlify/functions/lib/loops/fetchers/contract_intel_coverage.js
@@ -1,0 +1,70 @@
+// ============================================================
+// fetchers/contract_intel_coverage.js (contract_intel_freshness step "coverage")
+//
+// Reads the contract_intel table + the refresh roster (contracts.json)
+// and computes coverage with the SAME pure computeCoverage() the nightly
+// refresh uses inline. The point of doing it here, in the loop framework,
+// is that this observes the refresh from the OUTSIDE:
+//
+//   - The inline coverage guard in contract-intel-refresh-background.js
+//     only fires WHEN the refresh runs. A dead/disabled cron logs nothing,
+//     so "the refresh stopped entirely" is invisible to it.
+//   - This loop runs on its own cron. It measures the same coverage AND a
+//     liveness signal (age of the newest contract_intel row anywhere): if
+//     the refresh cron has stalled, every row ages and newestRowAgeHours
+//     climbs past the expected daily gap — caught here within one loop tick.
+//
+// No LLM, no external API — one Supabase read. Pure logic lives in
+// lib/refresh-coverage.js (unit-tested); this is just the I/O shell.
+// ============================================================
+
+const { getRefreshRoster } = require("../../refresh-roster");
+const { computeCoverage } = require("../../refresh-coverage");
+const { hoursSince } = require("../util");
+
+async function run(ctx, config) {
+  const roster = getRefreshRoster();
+  const names = roster.map((c) => c.name);
+
+  let rows = [];
+  if (ctx.supabase) {
+    try {
+      const { data, error } = await ctx.supabase
+        .from("contract_intel")
+        .select("contract_name, last_updated");
+      if (error) throw error;
+      rows = data || [];
+    } catch (e) {
+      // Table unreadable (e.g. pre-migration). Treat as "no data": coverage
+      // math then reports every roster row as never-refreshed, which the
+      // eval surfaces as drift rather than crashing the loop.
+      ctx.log?.warn?.(`contract_intel_coverage: read failed (${e.message})`);
+      rows = [];
+    }
+  }
+
+  const lastUpdatedMap = new Map(rows.map((r) => [r.contract_name, r.last_updated || null]));
+  const coverage = computeCoverage(names, lastUpdatedMap, {
+    staleHours: config.stale_hours,
+    behindHours: config.behind_hours,
+    neverRefreshedFraction: config.never_refreshed_fraction,
+  });
+
+  // Liveness: hours since the MOST RECENT contract_intel write anywhere.
+  // Small = the refresh ran recently; large = the whole pipeline has stalled.
+  // null when the table is empty/unreadable (can't distinguish stalled from
+  // never-populated, so we don't guess).
+  let newestRowAgeHours = null;
+  for (const r of rows) {
+    const h = hoursSince(r.last_updated);
+    if (Number.isFinite(h) && (newestRowAgeHours == null || h < newestRowAgeHours)) {
+      newestRowAgeHours = Number(h.toFixed(1));
+    }
+  }
+  const maxRefreshGapHours = config.max_refresh_gap_hours ?? 26; // daily cron + margin
+  const refreshStalled = newestRowAgeHours != null && newestRowAgeHours > maxRefreshGapHours;
+
+  return { coverage, newestRowAgeHours, refreshStalled, maxRefreshGapHours, rosterTotal: names.length };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/publishers/intel_coverage_snapshot.js
+++ b/netlify/functions/lib/loops/publishers/intel_coverage_snapshot.js
@@ -1,0 +1,44 @@
+// ============================================================
+// publishers/intel_coverage_snapshot.js (contract_intel_freshness step "snapshot")
+//
+// Persists one loop_status row (source="contract_intel") per run so the
+// public /status.json surfaces intel freshness alongside the L3 sources.
+// A NORMAL step (not a gated publish): we want the unhealthy state recorded
+// too, not gated behind the eval passing.
+//
+// BEST-EFFORT by design (unlike L3's status_snapshot, which throws): the
+// core deliverable of this loop is the eval + drift alert, which need no
+// tables. If loop_status doesn't exist yet (pre-migration) the insert is
+// skipped, not fatal — a missing bonus surface must never suppress the
+// coverage alert.
+// ============================================================
+
+async function run(ctx) {
+  const d = (ctx.data && ctx.data.coverage) || {};
+  const cov = d.coverage || {};
+  if (!ctx.supabase) return { written: 0, skipped: "no_supabase" };
+
+  const healthy = !cov.behind && !d.refreshStalled;
+  const row = {
+    checked_at: new Date().toISOString(),
+    source: "contract_intel",
+    http_status: null,
+    latency_ms: null,
+    // Prefer the oldest in-roster refreshed-row age; fall back to the
+    // liveness age when some rows are never-refreshed (oldest is null).
+    lag_hours: cov.oldestHours ?? d.newestRowAgeHours ?? null,
+    healthy,
+    run_id: ctx.runId || null,
+  };
+
+  try {
+    const { error } = await ctx.supabase.from("loop_status").insert(row);
+    if (error) throw error;
+  } catch (e) {
+    return { written: 0, skipped: `loop_status_unavailable:${String(e.message).slice(0, 80)}` };
+  }
+  ctx.outputRef = "loop_status:contract_intel";
+  return { written: 1, healthy };
+}
+
+module.exports = { run };

--- a/netlify/functions/lib/loops/registry.js
+++ b/netlify/functions/lib/loops/registry.js
@@ -30,6 +30,11 @@ const REGISTRY = {
   "publishers/status_snapshot": require("./publishers/status_snapshot"),
   "evals/lag_thresholds": require("./evals/lag_thresholds"),
 
+  // --- contract_intel_freshness (intel-coverage watchdog) ---
+  "fetchers/contract_intel_coverage": require("./fetchers/contract_intel_coverage"),
+  "publishers/intel_coverage_snapshot": require("./publishers/intel_coverage_snapshot"),
+  "evals/intel_coverage": require("./evals/intel_coverage"),
+
   // NOTE: L4 (agency drift) is intentionally NOT a loop. The existing
   // netlify/functions/org-chart-monitor.js already hashes the canonical
   // agency leadership pages and emails Mary on change (weekly, no

--- a/netlify/functions/lib/loops/specs/contract_intel_freshness.json
+++ b/netlify/functions/lib/loops/specs/contract_intel_freshness.json
@@ -1,0 +1,24 @@
+{
+  "name": "contract_intel_freshness",
+  "version": 1,
+  "description": "Independent watchdog on contract_intel coverage/freshness. Reuses the pure computeCoverage() the nightly refresh uses inline, but observes from OUTSIDE the refresh function, so it catches both 'refresh fell behind its roster' and 'refresh stopped running entirely' (a dead cron logs nothing the inline guard could see). Writes loop_runs/loop_evals + a loop_status snapshot (source=contract_intel) for /status.json, and alerts Mary on drift. No LLM, no external API — one Supabase read.",
+  "trigger": { "type": "cron", "expr": "0 */6 * * *" },
+  "steps": [
+    {
+      "id": "coverage",
+      "fn": "fetchers/contract_intel_coverage",
+      "stale_hours": 48,
+      "behind_hours": 72,
+      "never_refreshed_fraction": 0.15,
+      "max_refresh_gap_hours": 26
+    },
+    { "id": "snapshot", "fn": "publishers/intel_coverage_snapshot" }
+  ],
+  "evals": [
+    { "name": "intel_coverage", "fn": "evals/intel_coverage" }
+  ],
+  "alerts": {
+    "on_fail": { "email": "mary@missionmeetstech.com", "ops_event": "LOOP_FAIL" },
+    "on_drift": { "email": "mary@missionmeetstech.com", "ops_event": "LOOP_DRIFT" }
+  }
+}

--- a/netlify/functions/loop-contract-intel-freshness.js
+++ b/netlify/functions/loop-contract-intel-freshness.js
@@ -1,0 +1,32 @@
+// ============================================================
+// loop-contract-intel-freshness.js — scheduled entry for the
+// contract_intel freshness watchdog.
+//
+// Cron '0 */6 * * *' (see netlify.toml). Every 6h it recomputes
+// contract_intel coverage from OUTSIDE the nightly refresh, so it catches
+// both "refresh fell behind the roster" and "refresh stopped running
+// entirely" — the latter being invisible to the refresh's own inline guard
+// (a dead cron logs nothing). No LLM, no external API — one Supabase read.
+// Wrapped with withOpsLogging for the dead-man switch.
+// ============================================================
+
+const { createClient } = require("@supabase/supabase-js");
+const { withOpsLogging } = require("./lib/scheduled-fn-wrapper");
+const { runLoop } = require("./lib/loops/runner");
+
+async function _handler() {
+  // Feature flag — same guard as the other loop crons. Off until the gated
+  // loop_infra migration is applied and LOOPS_ENABLED=true is set, so this
+  // is a clean no-op (never errors/alerts) before activation.
+  if (process.env.LOOPS_ENABLED !== "true") {
+    return { statusCode: 200, body: JSON.stringify({ status: "skipped", reason: "LOOPS_ENABLED!=true" }) };
+  }
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_KEY) {
+    return { statusCode: 500, body: JSON.stringify({ error: "supabase env missing" }) };
+  }
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+  const summary = await runLoop("contract_intel_freshness", { trigger: "cron", supabase });
+  return { statusCode: 200, body: JSON.stringify(summary) };
+}
+
+exports.handler = withOpsLogging("loop_contract_intel_freshness", _handler);

--- a/tests/unit/contract-intel-freshness-loop.test.js
+++ b/tests/unit/contract-intel-freshness-loop.test.js
@@ -1,0 +1,143 @@
+// Unit tests for the contract_intel_freshness watchdog loop.
+// Pure logic + injected fakes — no network, no real Supabase, no LLM.
+// Locks the spec wiring, the drift eval, and the fetcher's coverage +
+// liveness signals against regression.
+
+import { describe, it, expect } from "vitest";
+import { runLoop, loadSpec } from "../../netlify/functions/lib/loops/runner.js";
+import { resolve } from "../../netlify/functions/lib/loops/registry.js";
+import coverageFetcher from "../../netlify/functions/lib/loops/fetchers/contract_intel_coverage.js";
+import intelCoverageEval from "../../netlify/functions/lib/loops/evals/intel_coverage.js";
+import intelSnapshot from "../../netlify/functions/lib/loops/publishers/intel_coverage_snapshot.js";
+
+const hoursAgo = (h) => new Date(Date.now() - h * 3_600_000).toISOString();
+
+// Minimal Supabase stub: contract_intel select returns the rows we hand it.
+function fakeSupabase(rows) {
+  return {
+    from(table) {
+      return {
+        select() {
+          if (table === "contract_intel") return Promise.resolve({ data: rows, error: null });
+          return Promise.resolve({ data: [], error: null });
+        },
+        insert() {
+          return Promise.resolve({ error: null });
+        },
+      };
+    },
+  };
+}
+
+describe("spec + registry wiring", () => {
+  it("loads the spec and resolves every referenced fn", () => {
+    const spec = loadSpec("contract_intel_freshness");
+    expect(spec.name).toBe("contract_intel_freshness");
+    for (const step of spec.steps) expect(typeof resolve(step.fn)).toBe("function");
+    for (const ev of spec.evals) expect(typeof resolve(ev.fn)).toBe("function");
+  });
+
+  it("dry-run plans without executing", async () => {
+    const log = { info() {}, warn() {} };
+    const summary = await runLoop("contract_intel_freshness", { dryRun: true, supabase: null, log });
+    expect(summary.status).toBe("skipped");
+    expect(summary.reason).toBe("dry-run");
+    expect(summary.plan).toContain("coverage");
+    expect(summary.plan).toContain("snapshot");
+  });
+});
+
+describe("intel_coverage eval — drift gating", () => {
+  it("passes when coverage is healthy and refresh is live", async () => {
+    const ctx = { data: { coverage: { coverage: { behind: false, coveragePct: 100 }, refreshStalled: false } } };
+    const r = await intelCoverageEval.run(ctx);
+    expect(r.passed).toBe(true);
+    expect(r.drift).toBe(false);
+    expect(r.score).toBe(100);
+  });
+
+  it("drifts when coverage is behind", async () => {
+    const ctx = {
+      data: { coverage: { coverage: { behind: true, behindReason: "oldest refreshed row is 90h old", coveragePct: 40 }, refreshStalled: false } },
+    };
+    const r = await intelCoverageEval.run(ctx);
+    expect(r.passed).toBe(false);
+    expect(r.drift).toBe(true);
+    expect(r.details.reasons.join(" ")).toMatch(/90h/);
+  });
+
+  it("drifts when the refresh cron appears stalled even if coverage% looks ok", async () => {
+    const ctx = {
+      data: { coverage: { coverage: { behind: false, coveragePct: 100 }, refreshStalled: true, newestRowAgeHours: 40, maxRefreshGapHours: 26 } },
+    };
+    const r = await intelCoverageEval.run(ctx);
+    expect(r.passed).toBe(false);
+    expect(r.drift).toBe(true);
+    expect(r.details.reasons.join(" ")).toMatch(/stalled/);
+  });
+});
+
+describe("contract_intel_coverage fetcher", () => {
+  it("computes coverage over the live roster and reports a fresh, live signal", async () => {
+    // Every roster contract refreshed 3h ago → healthy, not stalled.
+    const { getRefreshRoster } = await import("../../netlify/functions/lib/refresh-roster.js");
+    const names = getRefreshRoster().map((c) => c.name);
+    expect(names.length).toBeGreaterThan(0); // contracts.json resolved
+    const rows = names.map((contract_name) => ({ contract_name, last_updated: hoursAgo(3) }));
+    const ctx = { supabase: fakeSupabase(rows) };
+    const out = await coverageFetcher.run(ctx, { max_refresh_gap_hours: 26 });
+    expect(out.coverage.behind).toBe(false);
+    expect(out.coverage.coveragePct).toBe(100);
+    expect(out.refreshStalled).toBe(false);
+    expect(out.newestRowAgeHours).toBeGreaterThanOrEqual(2);
+    expect(out.newestRowAgeHours).toBeLessThan(5);
+  });
+
+  it("flags refreshStalled when the newest row is older than the gap", async () => {
+    const { getRefreshRoster } = await import("../../netlify/functions/lib/refresh-roster.js");
+    const names = getRefreshRoster().map((c) => c.name);
+    const rows = names.map((contract_name) => ({ contract_name, last_updated: hoursAgo(40) }));
+    const ctx = { supabase: fakeSupabase(rows) };
+    const out = await coverageFetcher.run(ctx, { max_refresh_gap_hours: 26 });
+    expect(out.newestRowAgeHours).toBeGreaterThan(26);
+    expect(out.refreshStalled).toBe(true);
+  });
+
+  it("treats an unreadable/empty table as no data without throwing", async () => {
+    const ctx = { supabase: fakeSupabase([]) };
+    const out = await coverageFetcher.run(ctx, {});
+    expect(out.newestRowAgeHours).toBeNull();
+    expect(out.refreshStalled).toBe(false); // null age can't be judged stalled
+    expect(out.coverage.total).toBeGreaterThan(0);
+    expect(out.coverage.neverRefreshed).toBe(out.coverage.total); // no rows → all never-refreshed
+  });
+});
+
+describe("intel_coverage_snapshot publisher", () => {
+  it("is best-effort: skips cleanly when loop_status is unavailable", async () => {
+    const badSupabase = {
+      from() {
+        return { insert() { return Promise.resolve({ error: { message: "relation loop_status does not exist" } }); } };
+      },
+    };
+    const ctx = { supabase: badSupabase, data: { coverage: { coverage: { behind: false }, refreshStalled: false } } };
+    const r = await intelSnapshot.run(ctx);
+    expect(r.written).toBe(0);
+    expect(r.skipped).toMatch(/loop_status_unavailable/);
+  });
+
+  it("writes one healthy row when coverage is fine", async () => {
+    const inserted = [];
+    const okSupabase = {
+      from() {
+        return { insert(row) { inserted.push(row); return Promise.resolve({ error: null }); } };
+      },
+    };
+    const ctx = { runId: "run-1", supabase: okSupabase, data: { coverage: { coverage: { behind: false, oldestHours: 12 }, refreshStalled: false } } };
+    const r = await intelSnapshot.run(ctx);
+    expect(r.written).toBe(1);
+    expect(inserted[0].source).toBe("contract_intel");
+    expect(inserted[0].healthy).toBe(true);
+    expect(inserted[0].lag_hours).toBe(12);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #132. Brings **contract-intel freshness observability** under the `lib/loops/` runner so it gets the framework treatment you asked for — a first-class run ledger (`loop_runs`), eval-gating (`loop_evals`), and gated drift alerts — **without** the reckless full port of the revenue-critical research/verify/upsert pipeline.

**The engineering call, stated plainly:** a literal "move the whole refresh into the runner" would trade a working, subscriber-facing intel pipeline (kill switch, cost tracking, confidence engine, change detection, per-item LLM budget + resumption) for architectural purity — exactly the kind of mock-rewrite the repo's agent contracts forbid. The runner is built for *detection/staging* loops, not per-item research with a wall-clock budget. So the heavy pipeline stays inline; the **freshness watchdog** is the piece that belongs in the framework, and it's genuinely additive.

**Why a loop *and* the inline guard from #132?** The inline coverage guard only fires *when the refresh runs*. A dead or disabled cron logs nothing, so "the refresh stopped entirely" is invisible to it. This loop observes from the **outside** on its own 6h cron: it reuses the same pure `computeCoverage()`, and additionally tracks the age of the newest `contract_intel` row (`newestRowAgeHours`) — if the pipeline stalls, every row ages and the eval drifts within one tick.

## Changes (the repo's "new loop" recipe: spec + fn modules + registry + scheduled fn + toml block + loop_config seed)
- `specs/contract_intel_freshness.json` — 6-hourly, no LLM, no external API
- `fetchers/contract_intel_coverage.js` — reads `contract_intel` + roster, runs `computeCoverage`, derives the liveness signal
- `evals/intel_coverage.js` — drift on behind-coverage **or** stalled-refresh
- `publishers/intel_coverage_snapshot.js` — best-effort `loop_status` row (`source=contract_intel`) for `/status.json`; never suppresses the alert if the table is missing pre-migration
- `loop-contract-intel-freshness.js` — scheduled entry, `LOOPS_ENABLED`-gated no-op like the other loop crons
- `registry.js`, `netlify.toml` — wired
- `migrations/20260717000000_contract_intel_freshness_loop.sql` — gated, idempotent `loop_config` seed (INSERT only, no `CREATE TABLE`)
- `docs/MMT-Loop-System.md` — documented
- `tests/unit/contract-intel-freshness-loop.test.js` — 10 tests

## Activation (only you can do these — prod creds)
- Set `LOOPS_ENABLED=true` in Netlify → enables the **drift alert** (needs no tables).
- Apply the gated `loop_infra` migration + this seed → adds run/eval/status **persistence** + `/status.json` surfacing.
- Until then the cron is a **clean no-op** (first line returns `skipped`), so this is safe to ship inactive.

## Checklist
- [x] Unit tests passing (`447/447`, incl. 10 new)
- [x] Dry-run resolves (`node runner.js --loop contract_intel_freshness --dry-run`)
- [x] `node -c` clean on all new modules; `scan-pii` OK
- [ ] Smoke/E2E — n/a (no route/HTML change)
- [ ] `node build.js` — hangs on Supabase hydrate without prod env in the web session; **touches no `build.js` input** (functions + lib + migration + test)
- [x] Migration Safety — INSERT-only, no `CREATE TABLE`, in `migrations/` (not scanned path), idempotent
- [x] No secrets; server-side `SUPABASE_SERVICE_KEY` use only (no client exposure)
- [x] PR is focused (rebased onto latest `main` so the diff is only the 10 new loop files)

## Risk Assessment
- **Critical surfaces touched**: none — this is a detection-only loop; it reads `contract_intel` and writes only `loop_*` observability tables. The refresh pipeline is untouched.
- **Security impact**: none
- **Contract changes**: none (additive loop + new ops event types on drift)
- **Rollback plan**: revert the commit and drop the `netlify.toml` block — zero data migration; the loop simply stops existing.

## Evidence
```
node runner.js --loop contract_intel_freshness --dry-run → plan [coverage, snapshot]
node_modules/.bin/vitest run tests/unit                  → 37 files, 447 passed
scan-pii                                                 → OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6bkrPHg5zzWK4hQfD9xbT)_