### PR TITLE
fix(loops): allow on-demand triggering of contract_intel_freshness watchdog

### DIFF
--- a/netlify/functions/loop-runner.js
+++ b/netlify/functions/loop-runner.js
@@ -5,13 +5,18 @@
 // Lets Mary (or a CI step) trigger a named loop out of band, including a
 // --dry-run plan. Scheduled execution does NOT go through here — each
 // loop has its own thin scheduled function (loop-opportunity-discovery,
-// loop-contract-freshness) so Netlify's cron can target it directly.
+// loop-contract-freshness, loop-contract-intel-freshness) so Netlify's
+// cron can target it directly.
 // ============================================================
 
 const { createClient } = require("@supabase/supabase-js");
 const { runLoop } = require("./lib/loops/runner");
 
-const ALLOWED = new Set(["opportunity_discovery", "contract_tracker_freshness"]);
+const ALLOWED = new Set([
+  "opportunity_discovery",
+  "contract_tracker_freshness",
+  "contract_intel_freshness",
+]);
 
 function unauthorized() {
   return { statusCode: 401, body: JSON.stringify({ error: "Unauthorized" }) };


### PR DESCRIPTION
## What

Adds `contract_intel_freshness` to the `ALLOWED` set in `loop-runner.js` so the watchdog can be triggered on demand via the secret-gated `/loop-runner` endpoint.

## Why

The `contract_intel_freshness` watchdog (from #133) shipped with a scheduled function (`loop-contract-intel-freshness.js`) and a `0 */6 * * *` cron, but it was never added to `loop-runner.js`'s `ALLOWED` set. So it could only run on its 6-hour cron — a manual trigger returned `400 {"error":"unknown loop"}`. The other two loops (L1, L3) are both on-demand triggerable; this brings the watchdog to parity.

## Why this one line is sufficient

The watchdog's spec (`specs/contract_intel_freshness.json`) and all three of its step/eval modules are already wired into `registry.js`:
- `fetchers/contract_intel_coverage`
- `publishers/intel_coverage_snapshot`
- `evals/intel_coverage`

Verified they resolve (`registry.js` loads cleanly). So allowing the name completes the full on-demand run path — no other wiring needed.

## Verification
- `node -c netlify/functions/loop-runner.js` — clean
- `registry.js` requires all watchdog modules without error
- Scoped diff: `loop-runner.js` only (+ header-comment accuracy)

## Test after merge + deploy
```bash
curl -sS -X POST "https://missionmeetstech.com/.netlify/functions/loop-runner?key=\$LOOP_RUNNER_SECRET" \
  -H 'content-type: application/json' \
  -d '{"loop_name":"contract_intel_freshness","dry_run":true}' | jq .
```
Should return a plan (not `400 unknown loop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)