### PR TITLE
Make contract pipeline tracking real — Track buttons + My Pipeline + guide

### DIFF
--- a/agent-access-guide.html
+++ b/agent-access-guide.html
@@ -106,7 +106,7 @@
           <ul>
             <li><strong>My market intel:</strong> opportunities and trend data. Good for questions like "What should I be watching at VA this month?"</li>
             <li><strong>My live opportunities:</strong> the open bids in your tracker. Good for "Show me open DHA solicitations under NAICS 541512."</li>
-            <li><strong>My pipeline:</strong> what you are already tracking on the site. Good for "Summarize everything in my pipeline."</li>
+            <li><strong>My pipeline:</strong> the contracts you have tracked on the site. Good for "Summarize everything in my pipeline." (New to tracking? See <a href="/pipeline-guide">how to build your pipeline</a> — an empty pipeline gives your AI nothing to summarize.)</li>
           </ul>
           <p>Whatever you pick, your assistant can only read it. It can never edit, delete, or spend. Click <strong>Continue</strong>.</p>
         </div>

--- a/build.js
+++ b/build.js
@@ -825,6 +825,7 @@ function generateSitemap(articles, tags, contracts) {
     { loc: '/idiq-tracker.html', priority: '0.7' },
     { loc: '/help.html', priority: '0.5' },
     { loc: '/agent-access-guide.html', priority: '0.6' },
+    { loc: '/pipeline-guide.html', priority: '0.6' },
     { loc: '/agencies/', priority: '0.6' },
     { loc: '/premium/briefings/', priority: '0.5' },
     { loc: '/premium/monthly-briefs/', priority: '0.5' },
@@ -1843,6 +1844,7 @@ function generateContractTrackerHtml(contracts, contractArticleMap) {
               </div>
               <p class="text-xs mt-2 font-semibold" style="color:var(--mmt-teal);">View Intel &rarr;</p>
               </a>${relatedAnalysis}
+              <button type="button" class="mmt-track-btn" data-track-id="${escapeHtml(cSlug)}" data-track-title="${escapeHtml(c.name)}" data-track-url="/contracts/${cSlug}/" aria-pressed="false" title="Save this contract to your pipeline" style="display:none;margin-top:12px;align-items:center;gap:6px;font-size:12px;font-weight:700;color:var(--mmt-teal);background:rgba(69,123,157,0.08);border:1px solid rgba(69,123,157,0.25);border-radius:8px;padding:6px 12px;cursor:pointer;"><span class="mmt-track-icon">&#9734;</span> <span class="mmt-track-label">Track</span></button>
             </div>\n`;
     });
     html += `          </div>
@@ -1936,6 +1938,7 @@ function generateContractPages(contracts) {
         ? `<div><span style="color:var(--mmt-text-secondary);">NAICS:</span> <span class="contract-premium-field" data-field="naics" style="color:var(--mmt-navy);">Premium</span></div>`
         : '')
       .replace(/\{\{BUILD_DATE\}\}/g, new Date().toISOString().split('T')[0])
+      .replace(/\{\{TRACK_BUTTON\}\}/g, `<button type="button" class="mmt-track-btn" data-track-id="${escapeHtml(cSlug)}" data-track-title="${escapeHtml(c.name)}" data-track-url="/contracts/${cSlug}/" data-track-long="1" aria-pressed="false" title="Save this contract to your pipeline" style="display:none;align-items:center;gap:6px;font-size:0.75rem;font-weight:700;color:var(--mmt-teal);background:rgba(69,123,157,0.1);border:1px solid rgba(69,123,157,0.25);border-radius:8px;padding:6px 12px;cursor:pointer;"><span class="mmt-track-icon">&#9734;</span> <span class="mmt-track-label">Track this contract</span></button>`)
       .replace(/\{\{CANONICAL_URL\}\}/g, `${SITE_URL}/contracts/${cSlug}/`);
 
     // Inject slug-only placeholder; the premium payload is served by
@@ -3046,6 +3049,7 @@ function injectDashShell(html, activePage) {
     { href: '/contract-tracker.html', label: 'Contract Tracker', id: 'contract-tracker', group: 'Pursuit Tools' },
     { href: '/idiq-tracker.html', label: 'IDIQ Tracker', id: 'idiq-tracker' },
     { href: '/premium/calendar/', label: 'Pursuit Calendar', id: 'calendar' },
+    { href: '/premium/pipeline/', label: 'My Pipeline', id: 'pipeline' },
     { href: '/premium/single-bidder/', label: 'Sole-Source Watch', id: 'single-bidder', group: 'Capture Watch' },
     { href: '/premium/gao-sustain/', label: 'GAO Sustains', id: 'gao-sustain' },
     { href: '/premium/fpds-migration/', label: 'FPDS Sunset', id: 'fpds-migration' },
@@ -3126,6 +3130,7 @@ async function copyStaticFiles({ archive, feed, newsItems, contracts, contractAr
     'rfp-shredder.html',
     'primer.html',
     'agent-access-guide.html',
+    'pipeline-guide.html',
   ];
   // Premium subdirectory pages
   const premiumPages = [
@@ -3135,6 +3140,7 @@ async function copyStaticFiles({ archive, feed, newsItems, contracts, contractAr
     { src: 'premium/ask-mmt.html', dest: 'premium/ask-mmt.html', index: 'premium/ask-mmt/index.html' },
     { src: 'premium/dashboard.html', dest: 'premium/dashboard.html', index: 'premium/dashboard/index.html' },
     { src: 'premium/settings.html', dest: 'premium/settings.html', index: 'premium/settings/index.html' },
+    { src: 'premium/pipeline.html', dest: 'premium/pipeline.html', index: 'premium/pipeline/index.html' },
     // Sprint 4 (2026-05-06) — Wave 1 paywall enrichment
     { src: 'premium/fpds-migration.html', dest: 'premium/fpds-migration.html', index: 'premium/fpds-migration/index.html' },
     { src: 'premium/single-bidder.html', dest: 'premium/single-bidder.html', index: 'premium/single-bidder/index.html' },
@@ -3472,6 +3478,7 @@ ${innerHtml}
       { href: '/contract-tracker.html', label: 'Contract Tracker', id: 'contract-tracker', group: 'Pursuit Tools' },
       { href: '/idiq-tracker.html', label: 'IDIQ Tracker', id: 'idiq-tracker' },
       { href: '/premium/calendar/', label: 'Pursuit Calendar', id: 'calendar' },
+      { href: '/premium/pipeline/', label: 'My Pipeline', id: 'pipeline' },
       { href: '/premium/single-bidder/', label: 'Sole-Source Watch', id: 'single-bidder', group: 'Capture Watch' },
       { href: '/premium/gao-sustain/', label: 'GAO Sustains', id: 'gao-sustain' },
       { href: '/premium/fpds-migration/', label: 'FPDS Sunset', id: 'fpds-migration' },
@@ -3556,6 +3563,7 @@ ${innerHtml}
     'premium/compliance-check.html': 'compliance-check',
     'premium/signal-chain.html': 'signal-chain',
     'premium/settings.html': 'settings',
+    'premium/pipeline.html': 'pipeline',
     // Sprint 4 (2026-05-06) — Wave 1 paywall enrichment
     'premium/fpds-migration.html': 'fpds-migration',
     'premium/single-bidder.html': 'single-bidder',
@@ -3579,6 +3587,7 @@ ${innerHtml}
     { src: 'premium/signal-chain.html', dest: 'premium/signal-chain/index.html' },
     { src: 'premium/dashboard.html', dest: 'premium/dashboard/index.html' },
     { src: 'premium/settings.html', dest: 'premium/settings/index.html' },
+    { src: 'premium/pipeline.html', dest: 'premium/pipeline/index.html' },
     { src: 'premium/profile.html', dest: 'premium/profile/index.html' },
     // Sprint 4 (2026-05-06) — Wave 1 paywall enrichment
     { src: 'premium/fpds-migration.html', dest: 'premium/fpds-migration/index.html' },

--- a/docs/member-features.json
+++ b/docs/member-features.json
@@ -62,6 +62,20 @@
       "noindex": true
     },
     {
+      "feature_name": "My Pipeline",
+      "public_marketing_urls": [
+        "/pipeline"
+      ],
+      "member_url": "/premium/pipeline.html",
+      "backing_function": "netlify/functions/member-watchlist.js",
+      "entitlement_required": "premium|founding|institutional|admin",
+      "public_locked_preview_behavior": "redirect to dashboard.html (sign-in gate)",
+      "expected_data_source": "Supabase mmt_watchlist table (entry-based tracked contracts)",
+      "freshness_sla_hours": null,
+      "smoke_test_url": "/premium/pipeline.html",
+      "noindex": true
+    },
+    {
       "feature_name": "Capture Corner",
       "public_marketing_urls": [
         "/capture-corner"
@@ -262,6 +276,20 @@
       "expected_data_source": "static",
       "freshness_sla_hours": null,
       "smoke_test_url": "/agent-access-guide.html",
+      "noindex": false
+    },
+    {
+      "feature_name": "Pipeline Setup Guide",
+      "public_marketing_urls": [
+        "/pipeline-guide"
+      ],
+      "member_url": "/pipeline-guide.html",
+      "backing_function": "static page",
+      "entitlement_required": "public",
+      "public_locked_preview_behavior": "n/a",
+      "expected_data_source": "static",
+      "freshness_sla_hours": null,
+      "smoke_test_url": "/pipeline-guide.html",
       "noindex": false
     },
     {

--- a/js/mmt-paywall.js
+++ b/js/mmt-paywall.js
@@ -899,26 +899,89 @@
     });
   }
 
-  // --- AUT-05: Watchlist API helpers ---
+  // --- AUT-05: Watchlist / Pipeline API helpers ---
+  // These back the "Track" buttons (Contract Tracker + contract detail) and the
+  // My Pipeline page. They write to mmt_watchlist, the SAME table the Agent
+  // Access API reads for "your pipeline" — so tracking a contract here is what
+  // makes an AI agent's pipeline non-empty. All three return the fetch promise
+  // so callers can await the result and update UI.
   window.mmtWatchlistAdd = function(entryId, title, url) {
     var email = localStorage.getItem(EMAIL_KEY);
-    if (!email) return;
-    fetch('/.netlify/functions/member-watchlist', {
+    if (!email) return Promise.reject(new Error('not signed in'));
+    return fetch('/.netlify/functions/member-watchlist', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: email, action: 'add', entry_id: entryId, entry_title: title, entry_url: url }),
-    }).catch(function() {});
+    }).then(function(r) { if (!r.ok) throw new Error('save failed'); return r.json(); });
   };
 
   window.mmtWatchlistRemove = function(entryId) {
     var email = localStorage.getItem(EMAIL_KEY);
-    if (!email) return;
-    fetch('/.netlify/functions/member-watchlist', {
+    if (!email) return Promise.reject(new Error('not signed in'));
+    return fetch('/.netlify/functions/member-watchlist', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email: email, action: 'remove', entry_id: entryId }),
-    }).catch(function() {});
+    }).then(function(r) { if (!r.ok) throw new Error('remove failed'); return r.json(); });
   };
+
+  // GET the signed-in member's tracked items (their pipeline).
+  window.mmtWatchlistList = function() {
+    var email = localStorage.getItem(EMAIL_KEY);
+    if (!email) return Promise.resolve([]);
+    return fetch('/.netlify/functions/member-watchlist?email=' + encodeURIComponent(email))
+      .then(function(r) { return r.ok ? r.json() : { items: [] }; })
+      .then(function(d) { return (d && d.items) || []; })
+      .catch(function() { return []; });
+  };
+
+  // Wire every "Track" button on the page. Premium-only: the buttons ship
+  // hidden (display:none) and are only revealed for a signed-in premium member,
+  // so the public Contract Tracker stays clean for free/public visitors.
+  function initTrackButtons() {
+    var btns = document.querySelectorAll('.mmt-track-btn[data-track-id]');
+    if (!btns.length) return;
+    if (!isAtLeastPremium(getSubscriberStatus())) return; // stays hidden for non-premium
+    var email = localStorage.getItem(EMAIL_KEY);
+    if (!email) return;
+
+    function setState(btn, tracked) {
+      btn.setAttribute('data-tracked', tracked ? '1' : '0');
+      btn.setAttribute('aria-pressed', tracked ? 'true' : 'false');
+      var label = btn.querySelector('.mmt-track-label');
+      var icon = btn.querySelector('.mmt-track-icon');
+      if (label) label.textContent = tracked ? (btn.getAttribute('data-track-long') ? 'Tracking this contract' : 'Tracking') : (btn.getAttribute('data-track-long') ? 'Track this contract' : 'Track');
+      if (icon) icon.textContent = tracked ? '★' : '☆'; // ★ / ☆
+    }
+
+    for (var i = 0; i < btns.length; i++) { btns[i].style.display = 'inline-flex'; }
+
+    window.mmtWatchlistList().then(function(items) {
+      var set = {};
+      items.forEach(function(it) { set[it.entry_id] = true; });
+      for (var j = 0; j < btns.length; j++) {
+        setState(btns[j], !!set[btns[j].getAttribute('data-track-id')]);
+      }
+    });
+
+    for (var k = 0; k < btns.length; k++) {
+      (function(btn) {
+        btn.addEventListener('click', function(e) {
+          e.preventDefault(); e.stopPropagation();
+          var id = btn.getAttribute('data-track-id');
+          var title = btn.getAttribute('data-track-title') || '';
+          var url = btn.getAttribute('data-track-url') || '';
+          var wasTracked = btn.getAttribute('data-tracked') === '1';
+          btn.disabled = true; btn.style.opacity = '0.6';
+          var op = wasTracked ? window.mmtWatchlistRemove(id) : window.mmtWatchlistAdd(id, title, url);
+          op.then(function() { setState(btn, !wasTracked); })
+            .catch(function() {})
+            .then(function() { btn.disabled = false; btn.style.opacity = '1'; });
+        });
+      })(btns[k]);
+    }
+  }
+  window.mmtInitTrackButtons = initTrackButtons;
 
   // --- AUT-08: Read state API helper ---
   window.mmtMarkRead = function(entryId) {
@@ -956,6 +1019,7 @@
     trackGateViews(status);
     initStickyBar();
     initDashboardButton();
+    initTrackButtons();
   }
 
   if (document.readyState === "loading") {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1177,6 +1177,11 @@
   status = 200
 
 [[redirects]]
+  from = "/pipeline"
+  to = "/premium/pipeline.html"
+  status = 200
+
+[[redirects]]
   from = "/askmtt"
   to = "/premium/ask-mmt.html"
   status = 200
@@ -1230,6 +1235,11 @@
 [[redirects]]
   from = "/agent-access-guide"
   to = "/agent-access-guide.html"
+  status = 200
+
+[[redirects]]
+  from = "/pipeline-guide"
+  to = "/pipeline-guide.html"
   status = 200
 
 [[redirects]]

--- a/pipeline-guide.html
+++ b/pipeline-guide.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How to Build Your Pipeline — Mission Meets Tech</title>
+  <meta name="description" content="A plain-English guide to tracking federal contract opportunities on Mission Meets Tech: how to add a contract to your pipeline, where to see it, and how your AI assistant reads it.">
+  <link rel="canonical" href="https://missionmeetstech.com/pipeline-guide">
+  <meta property="og:title" content="How to Build Your Pipeline — Mission Meets Tech">
+  <meta property="og:description" content="Track the contracts you care about, see them in one place, and let your AI assistant work from your real pipeline.">
+  <meta property="og:url" content="https://missionmeetstech.com/pipeline-guide">
+  <meta property="og:type" content="website">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-v3.png">
+  <script defer data-domain="missionmeetstech.com" src="https://plausible.io/js/script.js"></script>
+  <link rel="stylesheet" href="/styles/tailwind.css">
+  <style>
+    :root { --mmt-teal:#457B9D; --mmt-navy:#0A192F; --mmt-soft:#F3F4F6; --mmt-white:#FFFFFF; --mmt-text:#102033; --mmt-text-secondary:#5C6B7A; --mmt-border:#D8E0E8; }
+    body { font-family:'Inter',-apple-system,BlinkMacSystemFont,sans-serif; background:var(--mmt-white); color:var(--mmt-navy); }
+    .guide-body h2 { font-size:1.5rem; font-weight:800; margin:48px 0 16px; padding-top:24px; border-top:1px solid var(--mmt-border); color:var(--mmt-navy); }
+    .guide-body h3 { font-size:1.15rem; font-weight:700; margin:28px 0 10px; color:var(--mmt-navy); }
+    .guide-body p { font-size:15px; line-height:1.75; color:var(--mmt-text-secondary); margin-bottom:12px; max-width:66ch; }
+    .guide-body ul, .guide-body ol { font-size:15px; line-height:1.75; color:var(--mmt-text-secondary); margin-bottom:16px; padding-left:24px; max-width:66ch; }
+    .guide-body li { margin-bottom:8px; }
+    .guide-body strong { color:var(--mmt-navy); }
+    .guide-body a { color:var(--mmt-teal); text-decoration:none; font-weight:600; }
+    .guide-body a:hover { text-decoration:underline; }
+    .guide-body hr { border:none; border-top:1px solid var(--mmt-border); margin:32px 0; }
+    .guide-toc { background:var(--mmt-soft); border-radius:12px; padding:24px; margin-bottom:32px; }
+    .guide-toc a { display:block; padding:4px 0; font-size:14px; color:var(--mmt-teal); text-decoration:none; }
+    .guide-toc a:hover { text-decoration:underline; }
+    .step { display:flex; gap:16px; align-items:flex-start; margin:0 0 20px; max-width:70ch; }
+    .step-num { flex:0 0 auto; width:34px; height:34px; border-radius:50%; background:var(--mmt-navy); color:#fff; font-weight:800; font-size:15px; display:flex; align-items:center; justify-content:center; margin-top:2px; }
+    .step-body { flex:1; }
+    .step-body h3 { margin:2px 0 6px; }
+    .callout { border:1px solid var(--mmt-border); border-left:4px solid var(--mmt-teal); background:var(--mmt-soft); border-radius:8px; padding:18px 20px; margin:20px 0; max-width:70ch; }
+    .callout h3 { margin-top:0; }
+    .callout p { margin-bottom:8px; }
+    .lede { font-size:17px; line-height:1.6; color:var(--mmt-text-secondary); margin-bottom:32px; max-width:68ch; }
+    .track-chip { display:inline-flex; align-items:center; gap:6px; font-size:13px; font-weight:700; color:var(--mmt-teal); background:rgba(69,123,157,0.08); border:1px solid rgba(69,123,157,0.25); border-radius:8px; padding:4px 10px; white-space:nowrap; }
+  </style>
+</head>
+<body>
+  <nav class="nav-editorial"></nav>
+
+  <main class="wrap" style="max-width:820px;padding:40px 24px 80px;">
+    <div class="section-label" style="margin-bottom:12px;">Premium Guide</div>
+    <h1 style="font-size:clamp(28px,3.5vw,40px);line-height:1.1;letter-spacing:-0.03em;margin-bottom:12px;">How to Build Your Pipeline</h1>
+    <p class="lede">Your pipeline is the short list of federal contracts you actually care about. Track the ones worth watching, see them in one place, and let the AI assistant you connected work from your real book of business instead of the whole firehose. Here is how, in about a minute.</p>
+
+    <div class="guide-toc">
+      <strong style="display:block;margin-bottom:8px;font-size:13px;text-transform:uppercase;letter-spacing:0.08em;color:var(--mmt-text-secondary);">On this page</strong>
+      <a href="#what">What your pipeline is</a>
+      <a href="#track">How to track a contract</a>
+      <a href="#view">Where to see your pipeline</a>
+      <a href="#ai">How your AI reads it</a>
+      <a href="#alerts">Pipeline vs. keyword alerts</a>
+      <a href="#tips">Tips</a>
+      <a href="#help">Get help</a>
+    </div>
+
+    <div class="guide-body">
+
+      <h2 id="what">What your pipeline is</h2>
+      <p>Mission Meets Tech tracks a lot of federal health IT contracts. Most of them are not yours to chase. Your pipeline is the handful you have decided to keep an eye on: a recompete you are positioning for, a vehicle you want on, a program you are teaming around.</p>
+      <p>You build it by tracking contracts one at a time. Once something is in your pipeline it shows up on your own <strong>My Pipeline</strong> page, and your connected AI assistant can read it when you ask about your opportunities. This is a premium feature.</p>
+
+      <h2 id="track">How to track a contract</h2>
+
+      <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Open the Contract Tracker</h3>
+          <p>Go to <a href="/contract-tracker.html">the Contract Tracker</a>, or open any individual contract's detail page. Make sure you are signed in as a premium member, since the Track button is a premium feature.</p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>Click Track</h3>
+          <p>On each contract card you will see a <span class="track-chip">&#9734; Track</span> button. Click it. The star fills in and the label changes to <span class="track-chip">&#9733; Tracking</span>, which means it is saved to your pipeline. On a contract's detail page the same button reads <strong>Track this contract</strong>.</p>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Untrack anytime</h3>
+          <p>Changed your mind? Click the button again and it drops off your pipeline. You can also remove items from the My Pipeline page itself.</p>
+        </div>
+      </div>
+
+      <div class="callout">
+        <p style="margin:0;"><strong>Not seeing a Track button?</strong> It only appears for signed-in premium members. If you are on the free list, the button stays hidden. You can add premium (which unlocks tracking and the AI pipeline) from the <a href="/pricing">pricing page</a>.</p>
+      </div>
+
+      <h2 id="view">Where to see your pipeline</h2>
+      <p>Two places, both premium:</p>
+      <ul>
+        <li><strong>The My Pipeline page.</strong> Open <a href="/pipeline">My Pipeline</a> (it is also in your dashboard sidebar under Pursuit Tools). Every contract you have tracked is listed there, newest first, each linking back to its intelligence page. Remove any of them with one click.</li>
+        <li><strong>Your dashboard.</strong> The premium <a href="/premium/dashboard.html">dashboard</a> has a My Pipeline card near the top that takes you straight there.</li>
+      </ul>
+
+      <h2 id="ai">How your AI reads it</h2>
+      <div class="callout">
+        <h3>This is the same list your AI assistant sees.</h3>
+        <p>If you have connected an assistant with <a href="/agent-access-guide">Agent Access</a>, the contracts you track here are exactly what it reads when you ask about your pipeline. Track a few contracts, then ask your assistant "summarize everything in my pipeline" or "which of my tracked contracts has the nearest deadline," and it answers from this list, with sourcing.</p>
+        <p style="margin-bottom:0;">In other words: an empty pipeline means your AI has nothing to summarize. Tracking a handful of contracts is what makes that feature useful.</p>
+      </div>
+
+      <h2 id="alerts">Pipeline vs. keyword alerts</h2>
+      <p>These are two different tools, and it is worth knowing which is which:</p>
+      <ul>
+        <li><strong>Your pipeline (this guide)</strong> is specific contracts you tracked. You see them on the My Pipeline page, and your AI reads them.</li>
+        <li><strong>Keyword alerts</strong> live in <a href="/premium/settings.html">Settings</a>, under Watchlist. There you type terms like "T4NG2" or "CCN Next Gen," and when something new matching that term shows up, it gets called out in your <strong>daily digest email</strong>. That is about getting notified, not about building a tracked list.</li>
+      </ul>
+      <p>Use both: track the contracts you are working, and set keyword alerts for the topics you want to hear about the moment they move.</p>
+
+      <h2 id="tips">Tips</h2>
+      <ul>
+        <li><strong>Keep it tight.</strong> A pipeline of five to fifteen contracts you are truly working beats a list of fifty. It keeps your My Pipeline page and your AI answers sharp.</li>
+        <li><strong>Track from wherever you are.</strong> The button is on both the Contract Tracker cards and each contract's detail page, so you can add one the moment you decide it is worth watching.</li>
+        <li><strong>Revisit it.</strong> When a pursuit closes or you decide to pass, untrack it so your pipeline reflects what is actually live.</li>
+      </ul>
+
+      <h2 id="help">Get help</h2>
+      <p>Questions about tracking or your pipeline? Email <a href="mailto:support@missionmeetstech.com">support@missionmeetstech.com</a>. To connect your AI assistant so it can read your pipeline, see the <a href="/agent-access-guide">Agent Access setup guide</a>.</p>
+
+    </div>
+  </main>
+
+  <footer class="wrap"></footer>
+</body>
+</html>

--- a/premium/dashboard.html
+++ b/premium/dashboard.html
@@ -139,6 +139,12 @@
 
   <!-- Premium tools row — the three new Premium-included tools -->
   <p style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--mmt-text-secondary);margin:24px 0 10px;">Premium tools &middot; included with your subscription</p>
+  <a href="/premium/pipeline.html" class="dash-card" style="text-decoration:none;color:inherit;display:block;">
+    <h3>&#9733; My Pipeline</h3>
+    <p style="margin:0 0 10px;color:var(--mmt-text-secondary);font-size:13px;line-height:1.5;">The contracts you are tracking. Add one with the <strong style="color:var(--mmt-navy);">&#9734; Track</strong> button on any contract in the Contract Tracker. Your connected AI reads this same list.</p>
+    <span style="font-size:13px;font-weight:600;color:var(--mmt-teal);">Open my pipeline &rarr;</span>
+  </a>
+
   <div class="dash-tools-grid">
     <a href="/premium/pursuit-score.html" class="dash-card" style="text-decoration:none;color:inherit;display:block;transition:border-color 0.15s;">
       <h3 style="font-size:15px;margin:0 0 6px;">Pursuit Score</h3>

--- a/premium/pipeline.html
+++ b/premium/pipeline.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Pipeline — Mission Meets Tech</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/styles/tailwind.css">
+  <link rel="icon" href="/favicon-v3.png" type="image/png">
+  <style>
+    /* Content styles only. The layout shell (sidebar + mobile nav) is injected
+       at build time by build.js injectDashShell(). This file ships NO
+       dash-shell / dash-nav / dash-header / dash-main markup, so there is
+       exactly one shell in the built page. See docs/dashboard-mobile-spec.md. */
+    :root { --mmt-navy:#0A192F; --mmt-teal:#457B9D; --mmt-white:#FFFFFF; --mmt-surface:#F3F4F6; --mmt-text-secondary:#6B7280; --mmt-border:#E5E7EB; }
+    .dash-card { background:var(--mmt-white); border-radius:12px; padding:24px; margin-bottom:16px; border:1px solid var(--mmt-border); }
+    .btn-primary { display:inline-block; background:var(--mmt-navy); color:var(--mmt-white) !important; font-weight:700; padding:10px 20px; border-radius:8px; text-decoration:none; font-size:13px; }
+    .dash-content-header { display:flex; align-items:center; justify-content:space-between; gap:12px 16px; flex-wrap:wrap; margin-bottom:24px; }
+    .dash-content-header .dch-title { font-size:14px; font-weight:700; }
+    .dash-content-header .dch-meta { display:flex; align-items:center; gap:16px; flex-wrap:wrap; }
+    .pl-item { display:flex; align-items:flex-start; justify-content:space-between; gap:16px; padding:16px 0; border-bottom:1px solid var(--mmt-border); }
+    .pl-item:last-child { border-bottom:none; }
+    .pl-item h3 { margin:0 0 4px; font-size:16px; font-weight:700; }
+    .pl-item h3 a { color:var(--mmt-navy); text-decoration:none; }
+    .pl-item h3 a:hover { color:var(--mmt-teal); text-decoration:underline; }
+    .pl-meta { font-size:12px; color:var(--mmt-text-secondary); }
+    .pl-remove { flex:0 0 auto; background:none; border:1px solid var(--mmt-border); color:var(--mmt-text-secondary); border-radius:8px; padding:6px 12px; font-size:12px; font-weight:600; cursor:pointer; white-space:nowrap; }
+    .pl-remove:hover { border-color:#E63946; color:#E63946; }
+    .pl-empty { text-align:center; padding:32px 16px; }
+    .pl-empty p { color:var(--mmt-text-secondary); font-size:15px; margin-bottom:16px; }
+    @media (max-width:768px) { .dash-card a, .dash-card button { min-height:44px; } }
+  </style>
+  <script>
+    (function() {
+      var isPremium = localStorage.getItem('mmt_premium') === 'true';
+      var ts = localStorage.getItem('mmt_premium_ts');
+      var withinWindow = ts && (Date.now() - parseInt(ts)) < 30 * 24 * 60 * 60 * 1000;
+      if (!isPremium || !withinWindow) {
+        window.location.href = '/dashboard.html?next=' + encodeURIComponent(window.location.pathname);
+      }
+    })();
+  </script>
+</head>
+<body>
+  <nav class="nav-editorial"></nav>
+
+  <div class="dash-content-header">
+    <span class="dch-title">&#9733; My Pipeline</span>
+    <div class="dch-meta">
+      <span style="font-size:13px; color:var(--mmt-text-secondary);" id="pl-email"></span>
+      <a href="/contract-tracker.html" style="font-size:12px; color:var(--mmt-teal); text-decoration:none;">Browse Contract Tracker</a>
+    </div>
+  </div>
+
+  <h1 style="font-size:clamp(24px,3vw,32px);line-height:1.1;letter-spacing:-0.02em;margin:0 0 8px;color:var(--mmt-navy);">My Pipeline</h1>
+  <p style="font-size:15px;line-height:1.6;color:var(--mmt-text-secondary);max-width:64ch;margin-bottom:24px;">
+    The contracts you are tracking. Add one by clicking <strong style="color:var(--mmt-navy);">&#9734; Track</strong> on any contract in the
+    <a href="/contract-tracker.html" style="color:var(--mmt-teal);text-decoration:none;font-weight:600;">Contract Tracker</a>
+    or on a contract detail page. Your connected AI assistant reads this same list when you ask it about your pipeline.
+    <a href="/pipeline-guide" style="color:var(--mmt-teal);text-decoration:none;font-weight:600;">See how it works.</a>
+  </p>
+
+  <div class="dash-card">
+    <div id="pl-list" aria-busy="true">
+      <p style="color:var(--mmt-text-secondary);font-size:14px;">Loading your pipeline&hellip;</p>
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var email = localStorage.getItem('mmt_email');
+      var listEl = document.getElementById('pl-list');
+      var emailEl = document.getElementById('pl-email');
+      if (emailEl && email) emailEl.textContent = email;
+
+      function esc(s) {
+        return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+      }
+      function fmtDate(iso) {
+        try { return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }); }
+        catch (e) { return ''; }
+      }
+      function emptyState() {
+        listEl.setAttribute('aria-busy', 'false');
+        listEl.innerHTML =
+          '<div class="pl-empty">' +
+          '<p>You are not tracking anything yet. Open the Contract Tracker and click <strong>&#9734; Track</strong> on any contract to build your pipeline.</p>' +
+          '<a class="btn-primary" href="/contract-tracker.html">Browse the Contract Tracker</a>' +
+          '</div>';
+      }
+
+      function render(items) {
+        listEl.setAttribute('aria-busy', 'false');
+        if (!items || !items.length) { emptyState(); return; }
+        listEl.innerHTML = items.map(function (it) {
+          var url = it.entry_url || ('/contracts/' + encodeURIComponent(it.entry_id) + '/');
+          var title = it.entry_title || it.entry_id;
+          return '<div class="pl-item" data-id="' + esc(it.entry_id) + '">' +
+            '<div><h3><a href="' + esc(url) + '">' + esc(title) + '</a></h3>' +
+            '<div class="pl-meta">Tracked ' + esc(fmtDate(it.saved_at)) + '</div></div>' +
+            '<button class="pl-remove" data-remove="' + esc(it.entry_id) + '">Remove</button>' +
+            '</div>';
+        }).join('');
+        Array.prototype.forEach.call(listEl.querySelectorAll('[data-remove]'), function (btn) {
+          btn.addEventListener('click', function () {
+            var id = btn.getAttribute('data-remove');
+            btn.disabled = true; btn.textContent = 'Removing…';
+            fetch('/.netlify/functions/member-watchlist', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ email: email, action: 'remove', entry_id: id })
+            }).then(function (r) {
+              if (!r.ok) throw new Error('remove failed');
+              var row = listEl.querySelector('.pl-item[data-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]');
+              if (row) row.parentNode.removeChild(row);
+              if (!listEl.querySelector('.pl-item')) emptyState();
+            }).catch(function () {
+              btn.disabled = false; btn.textContent = 'Remove';
+              alert('Could not remove that item. Please try again.');
+            });
+          });
+        });
+      }
+
+      if (!email) { emptyState(); return; }
+      fetch('/.netlify/functions/member-watchlist?email=' + encodeURIComponent(email))
+        .then(function (r) { return r.ok ? r.json() : { items: [] }; })
+        .then(function (d) { render((d && d.items) || []); })
+        .catch(function () {
+          listEl.setAttribute('aria-busy', 'false');
+          listEl.innerHTML = '<p style="color:var(--mmt-text-secondary);font-size:14px;">Could not load your pipeline right now. Refresh to try again.</p>';
+        });
+    })();
+  </script>
+</body>
+</html>

--- a/templates/contract.html
+++ b/templates/contract.html
@@ -158,7 +158,8 @@
           </div>
         </div>
         {{NAICS_ROW}}
-        <div class="mt-4 pt-4 flex flex-wrap gap-3" style="border-top:1px solid var(--mmt-border);">
+        <div class="mt-4 pt-4 flex flex-wrap gap-3 items-center" style="border-top:1px solid var(--mmt-border);">
+          {{TRACK_BUTTON}}
           {{SAM_LINK_BLOCK}}
         </div>
       </div>


### PR DESCRIPTION
Closes the gap surfaced while writing the pipeline how-to: the pipeline feature was half-built. There was **no Track button anywhere**, and the Agent Access "your pipeline" scope read `mmt_watchlist` — a table nothing on the site wrote to — so an AI agent's pipeline was **always empty**. This wires it end to end.

## What shipped
- **Track buttons** on every Contract Tracker card and each contract detail page. They ship `display:none` and are revealed only for signed-in premium members (verified: 0 visible for non-premium — no paywall leak). Clicking writes to `mmt_watchlist`, the exact table Agent Access already reads.
- **`js/mmt-paywall.js`**: the orphaned `mmtWatchlistAdd/Remove` become a real toggle API (return promises), plus `mmtWatchlistList()` and `initTrackButtons()`.
- **My Pipeline page** (`/pipeline`): lists tracked contracts with links + one-click remove, empty-state CTA. Uses the canonical dash shell; sidebar link under Pursuit Tools; dashboard card.
- **Pipeline how-to guide** (`/pipeline-guide`, public): track → view → your AI reads it, and clarifies it vs. the Settings keyword-alert watchlist. Cross-linked with the Agent Access guide.
- Redirects + `member-features.json` entries.

## Why it matters
This makes the "My pipeline" promise in the Agent Access guide (and the FHAS email) **true** — track a few contracts and an AI agent's "summarize my pipeline" actually returns them.

## Verified in preview
Track toggle POSTs correct `add`/`remove` payloads · buttons hidden for non-premium · My Pipeline + guide render · no console errors · build.js clean · validate-dist 591 OK · validate-routes 35 features · scan-pii OK.

## Follow-up (not in this PR)
`member-watchlist.js` trusts the `email` in the request (same pattern as `member-preferences.js` / `member-read-state.js`) — a pre-existing IDOR across all member endpoints. The agent side is properly token-authed. Worth a separate hardening pass; flagging, not fixing here to stay scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)