### PR TITLE
Close pipeline IDOR: require a verified token on member-watchlist

### DIFF
--- a/js/mmt-paywall.js
+++ b/js/mmt-paywall.js
@@ -903,34 +903,35 @@
   // These back the "Track" buttons (Contract Tracker + contract detail) and the
   // My Pipeline page. They write to mmt_watchlist, the SAME table the Agent
   // Access API reads for "your pipeline" — so tracking a contract here is what
-  // makes an AI agent's pipeline non-empty. All three return the fetch promise
-  // so callers can await the result and update UI.
-  window.mmtWatchlistAdd = function(entryId, title, url) {
-    var email = localStorage.getItem(EMAIL_KEY);
-    if (!email) return Promise.reject(new Error('not signed in'));
+  // makes an AI agent's pipeline non-empty. Every call carries the HMAC-signed
+  // mmt_subscriber_token; the server derives the email from it (the endpoint no
+  // longer trusts an email in the body). All three return the fetch promise so
+  // callers can await the result and update UI.
+  var TOKEN_KEY = "mmt_subscriber_token";
+  function postWatchlist(payload) {
+    var token = localStorage.getItem(TOKEN_KEY);
+    if (!token) return Promise.reject(new Error('not signed in'));
+    payload.token = token;
     return fetch('/.netlify/functions/member-watchlist', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: email, action: 'add', entry_id: entryId, entry_title: title, entry_url: url }),
-    }).then(function(r) { if (!r.ok) throw new Error('save failed'); return r.json(); });
+      body: JSON.stringify(payload),
+    }).then(function(r) { if (!r.ok) throw new Error('watchlist ' + r.status); return r.json(); });
+  }
+
+  window.mmtWatchlistAdd = function(entryId, title, url) {
+    return postWatchlist({ action: 'add', entry_id: entryId, entry_title: title, entry_url: url });
   };
 
   window.mmtWatchlistRemove = function(entryId) {
-    var email = localStorage.getItem(EMAIL_KEY);
-    if (!email) return Promise.reject(new Error('not signed in'));
-    return fetch('/.netlify/functions/member-watchlist', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: email, action: 'remove', entry_id: entryId }),
-    }).then(function(r) { if (!r.ok) throw new Error('remove failed'); return r.json(); });
+    return postWatchlist({ action: 'remove', entry_id: entryId });
   };
 
-  // GET the signed-in member's tracked items (their pipeline).
+  // POST list — returns the signed-in member's tracked items (their pipeline).
+  // POST (not GET) so the token never rides in a URL query string.
   window.mmtWatchlistList = function() {
-    var email = localStorage.getItem(EMAIL_KEY);
-    if (!email) return Promise.resolve([]);
-    return fetch('/.netlify/functions/member-watchlist?email=' + encodeURIComponent(email))
-      .then(function(r) { return r.ok ? r.json() : { items: [] }; })
+    if (!localStorage.getItem(TOKEN_KEY)) return Promise.resolve([]);
+    return postWatchlist({ action: 'list' })
       .then(function(d) { return (d && d.items) || []; })
       .catch(function() { return []; });
   };
@@ -942,8 +943,10 @@
     var btns = document.querySelectorAll('.mmt-track-btn[data-track-id]');
     if (!btns.length) return;
     if (!isAtLeastPremium(getSubscriberStatus())) return; // stays hidden for non-premium
-    var email = localStorage.getItem(EMAIL_KEY);
-    if (!email) return;
+    // The token is what the API authenticates on. Without it (rare: premium
+    // flagged via cache but no member-auth token), leave the buttons hidden
+    // rather than show a control that would 401 on click.
+    if (!localStorage.getItem('mmt_subscriber_token')) return;
 
     function setState(btn, tracked) {
       btn.setAttribute('data-tracked', tracked ? '1' : '0');

--- a/netlify/functions/lib/subscriber-token.js
+++ b/netlify/functions/lib/subscriber-token.js
@@ -1,0 +1,64 @@
+// ============================================================
+// subscriber-token.js — verify the HMAC-signed member token
+//
+// member-auth.js issues a token AFTER an entitlement check passes:
+//   tokenData  = `${normalizedEmail}:${expiry}`
+//   signature  = HMAC-SHA256(SUPABASE_SERVICE_KEY, tokenData).hex.slice(0,32)
+//   token      = base64(`${tokenData}:${signature}`)
+//
+// This helper reverses + verifies it WITHOUT a DB round-trip: recompute the
+// HMAC with the service key and timing-safe-compare. A valid token proves the
+// server authenticated this exact email, so callers should DERIVE the acting
+// email from the verified token and never trust an email passed in the request
+// body. Closes the "pass any email" IDOR on the member-* browser endpoints.
+//
+// Returns { ok: true, email } or { ok: false, reason }.
+// ============================================================
+
+const crypto = require("crypto");
+
+function verifySubscriberToken(token) {
+  try {
+    if (!token || typeof token !== "string") return { ok: false, reason: "missing" };
+
+    const secret = process.env.SUPABASE_SERVICE_KEY;
+    if (!secret) return { ok: false, reason: "server_misconfigured" };
+
+    const decoded = Buffer.from(token, "base64").toString("utf8");
+    // Format: email:expiry:signature — email has no colon, expiry is digits,
+    // signature is 32 hex chars. Split from the right so an unexpected colon
+    // in the email (there shouldn't be one) can't shift the parse.
+    const lastColon = decoded.lastIndexOf(":");
+    if (lastColon < 0) return { ok: false, reason: "malformed" };
+    const signature = decoded.slice(lastColon + 1);
+    const tokenData = decoded.slice(0, lastColon); // `email:expiry`
+    const midColon = tokenData.lastIndexOf(":");
+    if (midColon < 0) return { ok: false, reason: "malformed" };
+    const email = tokenData.slice(0, midColon);
+    const expiryStr = tokenData.slice(midColon + 1);
+    const expiry = parseInt(expiryStr, 10);
+
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return { ok: false, reason: "malformed" };
+    if (!expiry || Number.isNaN(expiry)) return { ok: false, reason: "malformed" };
+    if (!/^[a-f0-9]{32}$/.test(signature)) return { ok: false, reason: "malformed" };
+    if (Date.now() > expiry) return { ok: false, reason: "expired" };
+
+    const expected = crypto
+      .createHmac("sha256", secret)
+      .update(tokenData)
+      .digest("hex")
+      .substring(0, 32);
+
+    const a = Buffer.from(signature, "utf8");
+    const b = Buffer.from(expected, "utf8");
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+      return { ok: false, reason: "bad_signature" };
+    }
+
+    return { ok: true, email: email.toLowerCase().trim() };
+  } catch (e) {
+    return { ok: false, reason: "error" };
+  }
+}
+
+module.exports = { verifySubscriberToken };

--- a/netlify/functions/member-watchlist.js
+++ b/netlify/functions/member-watchlist.js
@@ -1,15 +1,26 @@
 /**
- * member-watchlist.js — CRUD for member watchlist entries
+ * member-watchlist.js — CRUD for a member's tracked contracts (their pipeline)
  *
- * GET  ?email=x         → returns watchlist items for member
- * POST { email, action: 'add'|'remove', entry_id, entry_title, entry_url }
+ * All requests are POST and MUST carry a valid `token` (the HMAC-signed
+ * mmt_subscriber_token issued by member-auth.js). The acting email is DERIVED
+ * from the verified token — an email passed in the body is ignored. This closes
+ * the prior IDOR where any caller could read/write another member's pipeline by
+ * passing their email.
+ *
+ *   POST { token, action: 'list' }                              → { items }
+ *   POST { token, action: 'add', entry_id, entry_title, entry_url } → { saved }
+ *   POST { token, action: 'remove', entry_id }                  → { removed }
  *
  * Stores in Supabase table: mmt_watchlist
  * Schema: id (uuid), email (text), entry_id (text), entry_title (text),
  *         entry_url (text), saved_at (timestamptz)
+ *
+ * NOTE: the Agent Access API reads mmt_watchlist directly (lib/agent-data.js),
+ * not through this endpoint, so this auth change is browser-only.
  */
 
 const { createClient } = require('@supabase/supabase-js');
+const { verifySubscriberToken } = require('./lib/subscriber-token');
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -18,73 +29,80 @@ const supabase = createClient(
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': 'https://missionmeetstech.com',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type',
 };
+
+function json(statusCode, obj) {
+  return { statusCode, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' }, body: JSON.stringify(obj) };
+}
 
 exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: CORS_HEADERS };
   }
 
-  try {
-    if (event.httpMethod === 'GET') {
-      const email = event.queryStringParameters?.email;
-      if (!email) return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'email required' }) };
+  // Reads used to be GET ?email= — removed so a token never rides in a URL
+  // (query strings get logged). Everything is POST with the token in the body.
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'method_not_allowed', message: 'Use POST with a token.' });
+  }
 
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch (e) {
+    return json(400, { error: 'bad_request', message: 'Invalid JSON.' });
+  }
+
+  // --- Auth: verify the signed token; derive the email from it. ---
+  const auth = verifySubscriberToken(body.token);
+  if (!auth.ok) {
+    return json(401, { error: 'unauthorized', message: 'Please sign in again to manage your pipeline.' });
+  }
+  const email = auth.email;
+  const { action, entry_id, entry_title, entry_url } = body;
+
+  try {
+    if (action === 'list') {
       const { data, error } = await supabase
         .from('mmt_watchlist')
         .select('entry_id, entry_title, entry_url, saved_at')
-        .eq('email', email.toLowerCase().trim())
+        .eq('email', email)
         .order('saved_at', { ascending: false });
-
       if (error) throw error;
-      return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ items: data || [] }) };
+      return json(200, { items: data || [] });
     }
 
-    if (event.httpMethod === 'POST') {
-      const body = JSON.parse(event.body);
-      const { email, action, entry_id, entry_title, entry_url } = body;
-
-      if (!email || !action || !entry_id) {
-        return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'email, action, entry_id required' }) };
-      }
-
-      const cleanEmail = email.toLowerCase().trim();
-
-      if (action === 'add') {
-        // Upsert — don't duplicate
-        const { error } = await supabase
-          .from('mmt_watchlist')
-          .upsert({
-            email: cleanEmail,
-            entry_id,
-            entry_title: entry_title || '',
-            entry_url: entry_url || '',
-            saved_at: new Date().toISOString(),
-          }, { onConflict: 'email,entry_id' });
-
-        if (error) throw error;
-        return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ saved: true }) };
-      }
-
-      if (action === 'remove') {
-        const { error } = await supabase
-          .from('mmt_watchlist')
-          .delete()
-          .eq('email', cleanEmail)
-          .eq('entry_id', entry_id);
-
-        if (error) throw error;
-        return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ removed: true }) };
-      }
-
-      return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'action must be add or remove' }) };
+    if (action === 'add') {
+      if (!entry_id) return json(400, { error: 'bad_request', message: 'entry_id required' });
+      const { error } = await supabase
+        .from('mmt_watchlist')
+        .upsert({
+          email,
+          entry_id,
+          entry_title: entry_title || '',
+          entry_url: entry_url || '',
+          saved_at: new Date().toISOString(),
+        }, { onConflict: 'email,entry_id' });
+      if (error) throw error;
+      return json(200, { saved: true });
     }
 
-    return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'method not allowed' }) };
+    if (action === 'remove') {
+      if (!entry_id) return json(400, { error: 'bad_request', message: 'entry_id required' });
+      const { error } = await supabase
+        .from('mmt_watchlist')
+        .delete()
+        .eq('email', email)
+        .eq('entry_id', entry_id);
+      if (error) throw error;
+      return json(200, { removed: true });
+    }
+
+    return json(400, { error: 'bad_request', message: 'action must be list, add, or remove' });
   } catch (err) {
     console.error('Watchlist error:', err);
-    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'internal error' }) };
+    return json(500, { error: 'internal_error', message: 'Something went wrong. Try again.' });
   }
 };

--- a/premium/pipeline.html
+++ b/premium/pipeline.html
@@ -69,9 +69,23 @@
   <script>
     (function () {
       var email = localStorage.getItem('mmt_email');
+      var token = localStorage.getItem('mmt_subscriber_token');
       var listEl = document.getElementById('pl-list');
       var emailEl = document.getElementById('pl-email');
       if (emailEl && email) emailEl.textContent = email;
+
+      function post(payload) {
+        payload.token = token;
+        return fetch('/.netlify/functions/member-watchlist', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+      }
+      function needSignIn() {
+        listEl.setAttribute('aria-busy', 'false');
+        listEl.innerHTML = '<p style="color:var(--mmt-text-secondary);font-size:14px;">Your session has expired. <a href="/dashboard.html" style="color:var(--mmt-teal);font-weight:600;">Sign in again</a> to see your pipeline.</p>';
+      }
 
       function esc(s) {
         return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -105,11 +119,7 @@
           btn.addEventListener('click', function () {
             var id = btn.getAttribute('data-remove');
             btn.disabled = true; btn.textContent = 'Removing…';
-            fetch('/.netlify/functions/member-watchlist', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ email: email, action: 'remove', entry_id: id })
-            }).then(function (r) {
+            post({ action: 'remove', entry_id: id }).then(function (r) {
               if (!r.ok) throw new Error('remove failed');
               var row = listEl.querySelector('.pl-item[data-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]');
               if (row) row.parentNode.removeChild(row);
@@ -122,10 +132,13 @@
         });
       }
 
-      if (!email) { emptyState(); return; }
-      fetch('/.netlify/functions/member-watchlist?email=' + encodeURIComponent(email))
-        .then(function (r) { return r.ok ? r.json() : { items: [] }; })
-        .then(function (d) { render((d && d.items) || []); })
+      if (!token) { needSignIn(); return; }
+      post({ action: 'list' })
+        .then(function (r) {
+          if (r.status === 401) { needSignIn(); return null; }
+          return r.ok ? r.json() : { items: [] };
+        })
+        .then(function (d) { if (d) render((d && d.items) || []); })
         .catch(function () {
           listEl.setAttribute('aria-busy', 'false');
           listEl.innerHTML = '<p style="color:var(--mmt-text-secondary);font-size:14px;">Could not load your pipeline right now. Refresh to try again.</p>';

--- a/tests/unit/subscriber-token.test.js
+++ b/tests/unit/subscriber-token.test.js
@@ -1,0 +1,80 @@
+// tests/unit/subscriber-token.test.js
+//
+// Locks the contract for netlify/functions/lib/subscriber-token.js — the
+// HMAC verifier that closes the member-watchlist "pass any email" IDOR.
+// A token must only verify when its signature matches the service key and it
+// has not expired; the acting email is derived from inside the signed token.
+
+const assert = require("node:assert/strict");
+const crypto = require("crypto");
+
+const TEST_SECRET = "test-service-key-0123456789";
+process.env.SUPABASE_SERVICE_KEY = TEST_SECRET;
+
+const { verifySubscriberToken } = require("../../netlify/functions/lib/subscriber-token");
+
+// Mint a token exactly the way member-auth.js does.
+function mint(email, expiry, secret) {
+  secret = secret || TEST_SECRET;
+  const tokenData = `${email}:${expiry}`;
+  const signature = crypto.createHmac("sha256", secret).update(tokenData).digest("hex").substring(0, 32);
+  return Buffer.from(`${tokenData}:${signature}`).toString("base64");
+}
+
+const FUTURE = Date.now() + 30 * 24 * 60 * 60 * 1000;
+const PAST = Date.now() - 1000;
+
+test("valid token verifies and returns the signed email", () => {
+  const r = verifySubscriberToken(mint("user@example.com", FUTURE));
+  assert.equal(r.ok, true);
+  assert.equal(r.email, "user@example.com");
+});
+
+test("email is normalized (lowercased/trimmed) on return", () => {
+  // member-auth signs an already-normalized email, but the verifier must not
+  // hand back a different-cased string than what it verified.
+  const r = verifySubscriberToken(mint("user@example.com", FUTURE));
+  assert.equal(r.email, "user@example.com");
+});
+
+test("tampered email fails (signature no longer matches)", () => {
+  const good = mint("victim@example.com", FUTURE);
+  const decoded = Buffer.from(good, "base64").toString("utf8"); // victim@…:exp:sig
+  const forged = decoded.replace("victim@example.com", "attacker@example.com");
+  const r = verifySubscriberToken(Buffer.from(forged, "utf8").toString("base64"));
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "bad_signature");
+});
+
+test("wrong secret fails", () => {
+  const r = verifySubscriberToken(mint("user@example.com", FUTURE, "not-the-real-secret-value"));
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "bad_signature");
+});
+
+test("expired token fails", () => {
+  const r = verifySubscriberToken(mint("user@example.com", PAST));
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "expired");
+});
+
+test("missing token fails", () => {
+  assert.equal(verifySubscriberToken(null).ok, false);
+  assert.equal(verifySubscriberToken(undefined).ok, false);
+  assert.equal(verifySubscriberToken("").ok, false);
+  assert.equal(verifySubscriberToken(123).ok, false);
+});
+
+test("malformed token fails", () => {
+  assert.equal(verifySubscriberToken("not-base64-at-all!!!").ok, false);
+  assert.equal(verifySubscriberToken(Buffer.from("only-one-part", "utf8").toString("base64")).ok, false);
+  assert.equal(verifySubscriberToken(Buffer.from("no-at-sign:123:abc", "utf8").toString("base64")).ok, false);
+});
+
+test("bad expiry (non-numeric) fails", () => {
+  const email = "user@example.com";
+  const tokenData = `${email}:notanumber`;
+  const sig = crypto.createHmac("sha256", TEST_SECRET).update(tokenData).digest("hex").substring(0, 32);
+  const token = Buffer.from(`${tokenData}:${sig}`, "utf8").toString("base64");
+  assert.equal(verifySubscriberToken(token).ok, false);
+});


### PR DESCRIPTION
Follow-up hardening for the pipeline feature (#136), as flagged in that PR.

## The problem
`member-watchlist` trusted the `email` in the request body/query, so anyone who knew a member's email could read or modify their pipeline (IDOR).

## The fix
Every request now carries the **HMAC-signed `mmt_subscriber_token`** that `member-auth` already issues (after an entitlement check). The signature is verified server-side and the acting email is **derived from the token** — an email in the body is ignored.

- **`lib/subscriber-token.js`** (new): `verifySubscriberToken()` — base64 decode → verify `HMAC-SHA256(SUPABASE_SERVICE_KEY)` with a timing-safe compare → expiry check. Reusable.
- **`member-watchlist.js`**: POST-only; token required; `list` is now `POST action:'list'` (token never rides in a URL); `GET → 405`; `401` on bad/missing/expired.
- **Client** (`mmt-paywall.js`, `pipeline.html`): send the token; Track buttons stay hidden without one; pipeline shows a "sign in again" state on 401.
- **8 unit tests** for the verifier.

The Agent Access API reads `mmt_watchlist` **directly** (not via this endpoint), so this is browser-only and does not touch the agent path.

## Verified (full QA/QC + e2e)
- Unit: **455/455** (incl. 8 new).
- Server auth-gate harness: no/bad/expired token → **401**, `GET → 405`, **body-email swap ignored** (uses the token's email), valid token passes.
- build clean · validate-dist **591** · validate-routes **35** · scan-pii OK.
- Browser e2e: hidden for non-premium **and** premium-without-token; `list`/`add`/`remove` carry the token with **no email in the body**; graceful 401 → sign-in state; both guides render + cross-link.

## Follow-up (not in this PR)
`member-preferences.js` and `member-read-state.js` share the same trust-the-email pattern. The verify helper is built to drop into both — recommend a small follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)