### PR TITLE
fix(loops): bundle spec JSONs statically so the runner works on Lambda

### DIFF
--- a/netlify/functions/lib/loops/registry.js
+++ b/netlify/functions/lib/loops/registry.js
@@ -43,6 +43,18 @@ const REGISTRY = {
   // budget-delta tracking — not to run two parallel change-detectors.
 };
 
+// Static id -> spec map. Same reason as REGISTRY above: esbuild follows
+// static require()s (and inlines .json), so every spec is bundled into the
+// loop function. loadSpec() previously fs.readFileSync'd __dirname/specs,
+// which breaks once esbuild flattens the bundle — the source dir no longer
+// exists at /var/task and the JSON was never bundled. Requiring the specs
+// statically is the only bundler-safe way to ship them.
+const SPECS = {
+  opportunity_discovery: require("./specs/opportunity_discovery.json"),
+  contract_tracker_freshness: require("./specs/contract_tracker_freshness.json"),
+  contract_intel_freshness: require("./specs/contract_intel_freshness.json"),
+};
+
 function resolve(fnId) {
   const mod = REGISTRY[fnId];
   if (!mod || typeof mod.run !== "function") {
@@ -51,4 +63,4 @@ function resolve(fnId) {
   return mod.run;
 }
 
-module.exports = { REGISTRY, resolve };
+module.exports = { REGISTRY, resolve, SPECS };

--- a/netlify/functions/lib/loops/runner.js
+++ b/netlify/functions/lib/loops/runner.js
@@ -19,18 +19,17 @@
 //   node netlify/functions/lib/loops/runner.js --loop opportunity_discovery --dry-run
 // ============================================================
 
-const fs = require("fs");
-const path = require("path");
-const { resolve: resolveFn } = require("./registry");
-
-const SPEC_DIR = path.join(__dirname, "specs");
+const { resolve: resolveFn, SPECS } = require("./registry");
 
 function loadSpec(loopName) {
-  const file = path.join(SPEC_DIR, `${loopName}.json`);
-  if (!fs.existsSync(file)) {
-    throw new Error(`loop spec not found: ${file}`);
+  const raw = SPECS[loopName];
+  if (!raw) {
+    throw new Error(`loop spec not found: ${loopName}`);
   }
-  const spec = JSON.parse(fs.readFileSync(file, "utf8"));
+  // Clone so a step can't mutate the require()-cached spec across warm
+  // Lambda invocations (fs.readFileSync + JSON.parse used to give a fresh
+  // object each call; preserve that guarantee).
+  const spec = JSON.parse(JSON.stringify(raw));
   if (spec.name !== loopName) {
     throw new Error(`spec.name "${spec.name}" != requested "${loopName}"`);
   }


### PR DESCRIPTION
## Incident

After `LOOPS_ENABLED` was corrected to `true`, the loops ran for the first time and **every loop failed** on its scheduled run:

```
loop spec not found: /var/task/netlify/functions/specs/contract_tracker_freshness.json
```

`loop_contract_freshness` alert-emailed on every hourly tick.

## Root cause

`runner.js loadSpec()` read specs via `fs.readFileSync(path.join(__dirname, "specs", ...))`. Netlify's esbuild **flattens the function bundle**, so at runtime:
- `__dirname` is `/var/task/netlify/functions`, not `.../lib/loops` → wrong path (note the error path is missing the `lib/loops/` segment)
- esbuild never bundled the spec JSON at all (it doesn't follow `fs` reads)

It worked locally (real source dirs exist) and broke on Lambda. Latent since the loop system shipped — only exposed now that the loops actually execute.

## Fix

Add a static `SPECS` map to `registry.js` that `require()`s each spec `.json`, and have `loadSpec()` read from it. This is the **same static-require pattern `registry.js` already uses for step/eval modules** precisely so esbuild bundles them (the file's own comment warns that dynamic requires "silently drop modules from the bundle"). Removed the now-unused `fs`/`path`/`SPEC_DIR`. Spec is deep-cloned per call to preserve the prior fresh-object-per-invocation behavior on warm Lambdas.

## Verification
- `node runner.js --loop contract_tracker_freshness --dry-run` resolves the spec ✓
- `loadSpec()` resolves all 3 specs via the static map, rejects unknown ✓
- **Bundle proof**: esbuild-bundled `loop-contract-freshness.js` inlines all 3 spec JSONs (as CJS modules) with **zero residual runtime fs spec reads** ✓
- `tests/unit/loops.test.js` — 13/13 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)