### PR TITLE
Close IDOR on member-preferences + member-read-state (finish member-* hardening)

### DIFF
--- a/js/mmt-paywall.js
+++ b/js/mmt-paywall.js
@@ -987,13 +987,15 @@
   window.mmtInitTrackButtons = initTrackButtons;
 
   // --- AUT-08: Read state API helper ---
+  // member-read-state now authenticates on the signed token; email is derived
+  // server-side. Send the token, not the email.
   window.mmtMarkRead = function(entryId) {
-    var email = localStorage.getItem(EMAIL_KEY);
-    if (!email) return;
+    var token = localStorage.getItem(TOKEN_KEY);
+    if (!token) return;
     fetch('/.netlify/functions/member-read-state', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: email, entry_id: entryId }),
+      body: JSON.stringify({ token: token, entry_id: entryId }),
     }).catch(function() {});
   };
 

--- a/netlify/functions/member-preferences.js
+++ b/netlify/functions/member-preferences.js
@@ -1,7 +1,12 @@
 /**
  * member-preferences.js — Save member preferences + sync to Buttondown tags
  *
- * POST { email, agencies, role, naics, notifications }
+ * All requests are POST and MUST carry a valid `token` (the HMAC-signed
+ * mmt_subscriber_token from member-auth). The email is DERIVED from the token;
+ * an email in the body is ignored. Closes the prior trust-the-email IDOR.
+ *
+ *   POST { token, action: 'get' }                                   → { prefs }
+ *   POST { token, agencies, role, naics, notifications }            → { saved }
  *
  * 1. Stores preferences in Supabase table: mmt_preferences
  * 2. Syncs agency tags to Buttondown subscriber profile
@@ -12,6 +17,7 @@
  */
 
 const { createClient } = require('@supabase/supabase-js');
+const { verifySubscriberToken } = require('./lib/subscriber-token');
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -22,9 +28,13 @@ const BUTTONDOWN_API_KEY = process.env.BUTTONDOWN_API_KEY;
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': 'https://missionmeetstech.com',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type',
 };
+
+function json(statusCode, obj) {
+  return { statusCode, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' }, body: JSON.stringify(obj) };
+}
 
 async function syncButtondownTags(email, agencies) {
   if (!BUTTONDOWN_API_KEY || !email) return;
@@ -59,55 +69,56 @@ exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: CORS_HEADERS };
   }
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'method_not_allowed', message: 'Use POST with a token.' });
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch (e) {
+    return json(400, { error: 'bad_request', message: 'Invalid JSON.' });
+  }
+
+  const auth = verifySubscriberToken(body.token);
+  if (!auth.ok) {
+    return json(401, { error: 'unauthorized', message: 'Please sign in again to manage your preferences.' });
+  }
+  const cleanEmail = auth.email;
+  const { action, agencies, role, naics, notifications } = body;
 
   try {
-    if (event.httpMethod === 'GET') {
-      const email = event.queryStringParameters?.email;
-      if (!email) return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'email required' }) };
-
+    if (action === 'get') {
       const { data, error } = await supabase
         .from('mmt_preferences')
         .select('agencies, role, naics, notifications')
-        .eq('email', email.toLowerCase().trim())
+        .eq('email', cleanEmail)
         .single();
 
       if (error && error.code !== 'PGRST116') throw error; // PGRST116 = no rows
-      return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ prefs: data || null }) };
+      return json(200, { prefs: data || null });
     }
 
-    if (event.httpMethod === 'POST') {
-      const body = JSON.parse(event.body);
-      const { email, agencies, role, naics, notifications } = body;
+    // Default = save. Upsert preferences to Supabase (email from the token).
+    const { error } = await supabase
+      .from('mmt_preferences')
+      .upsert({
+        email: cleanEmail,
+        agencies: agencies || [],
+        role: role || '',
+        naics: naics || [],
+        notifications: notifications || {},
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'email' });
 
-      if (!email) {
-        return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'email required' }) };
-      }
+    if (error) throw error;
 
-      const cleanEmail = email.toLowerCase().trim();
+    // Sync tags to Buttondown (non-blocking)
+    syncButtondownTags(cleanEmail, agencies || []).catch(() => {});
 
-      // Upsert preferences to Supabase
-      const { error } = await supabase
-        .from('mmt_preferences')
-        .upsert({
-          email: cleanEmail,
-          agencies: agencies || [],
-          role: role || '',
-          naics: naics || [],
-          notifications: notifications || {},
-          updated_at: new Date().toISOString(),
-        }, { onConflict: 'email' });
-
-      if (error) throw error;
-
-      // Sync tags to Buttondown (non-blocking)
-      syncButtondownTags(cleanEmail, agencies || []).catch(() => {});
-
-      return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ saved: true }) };
-    }
-
-    return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'method not allowed' }) };
+    return json(200, { saved: true });
   } catch (err) {
     console.error('Preferences error:', err);
-    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'internal error' }) };
+    return json(500, { error: 'internal_error', message: 'Something went wrong. Try again.' });
   }
 };

--- a/netlify/functions/member-read-state.js
+++ b/netlify/functions/member-read-state.js
@@ -1,8 +1,12 @@
 /**
  * member-read-state.js — Track which articles/entries a member has read
  *
- * GET  ?email=x         → returns list of read entry_ids
- * POST { email, entry_id }  → marks entry as read
+ * All requests are POST and MUST carry a valid `token` (the HMAC-signed
+ * mmt_subscriber_token from member-auth). The email is DERIVED from the token;
+ * an email in the body is ignored. Closes the prior trust-the-email IDOR.
+ *
+ *   POST { token, action: 'list' }        → { read: [entry_id, ...] }
+ *   POST { token, entry_id }              → { marked: true }
  *
  * Stores in Supabase table: mmt_read_state
  * Schema: id (uuid), email (text), entry_id (text), read_at (timestamptz)
@@ -10,6 +14,7 @@
  */
 
 const { createClient } = require('@supabase/supabase-js');
+const { verifySubscriberToken } = require('./lib/subscriber-token');
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -18,53 +23,59 @@ const supabase = createClient(
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': 'https://missionmeetstech.com',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Content-Type',
 };
+
+function json(statusCode, obj) {
+  return { statusCode, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' }, body: JSON.stringify(obj) };
+}
 
 exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: CORS_HEADERS };
   }
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'method_not_allowed', message: 'Use POST with a token.' });
+  }
+
+  let body;
+  try {
+    body = JSON.parse(event.body || '{}');
+  } catch (e) {
+    return json(400, { error: 'bad_request', message: 'Invalid JSON.' });
+  }
+
+  const auth = verifySubscriberToken(body.token);
+  if (!auth.ok) {
+    return json(401, { error: 'unauthorized', message: 'Please sign in again.' });
+  }
+  const email = auth.email;
+  const { action, entry_id } = body;
 
   try {
-    if (event.httpMethod === 'GET') {
-      const email = event.queryStringParameters?.email;
-      if (!email) return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'email required' }) };
-
+    if (action === 'list') {
       const { data, error } = await supabase
         .from('mmt_read_state')
         .select('entry_id')
-        .eq('email', email.toLowerCase().trim());
-
+        .eq('email', email);
       if (error) throw error;
-      const ids = (data || []).map(r => r.entry_id);
-      return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ read: ids }) };
+      return json(200, { read: (data || []).map(r => r.entry_id) });
     }
 
-    if (event.httpMethod === 'POST') {
-      const body = JSON.parse(event.body);
-      const { email, entry_id } = body;
+    if (!entry_id) return json(400, { error: 'bad_request', message: 'entry_id required' });
+    const { error } = await supabase
+      .from('mmt_read_state')
+      .upsert({
+        email,
+        entry_id,
+        read_at: new Date().toISOString(),
+      }, { onConflict: 'email,entry_id' });
 
-      if (!email || !entry_id) {
-        return { statusCode: 400, headers: CORS_HEADERS, body: JSON.stringify({ error: 'email and entry_id required' }) };
-      }
-
-      const { error } = await supabase
-        .from('mmt_read_state')
-        .upsert({
-          email: email.toLowerCase().trim(),
-          entry_id,
-          read_at: new Date().toISOString(),
-        }, { onConflict: 'email,entry_id' });
-
-      if (error) throw error;
-      return { statusCode: 200, headers: CORS_HEADERS, body: JSON.stringify({ marked: true }) };
-    }
-
-    return { statusCode: 405, headers: CORS_HEADERS, body: JSON.stringify({ error: 'method not allowed' }) };
+    if (error) throw error;
+    return json(200, { marked: true });
   } catch (err) {
     console.error('Read state error:', err);
-    return { statusCode: 500, headers: CORS_HEADERS, body: JSON.stringify({ error: 'internal error' }) };
+    return json(500, { error: 'internal_error', message: 'Something went wrong.' });
   }
 };

--- a/premium/settings.html
+++ b/premium/settings.html
@@ -229,7 +229,20 @@
   </div>
   <script>
     var email=localStorage.getItem('mmt_email');
+    var token=localStorage.getItem('mmt_subscriber_token');
     var __de=document.getElementById('dash-email');if(__de&&email)__de.textContent=email;
+
+    // Preferences are read/written through member-preferences, which now
+    // authenticates on the signed token (not a trusted email). POST both ways
+    // so the token never rides in a URL.
+    function prefsPost(payload) {
+      payload.token = token;
+      return fetch('/.netlify/functions/member-preferences', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+    }
 
     // --- Notification preferences ---
     var solCheck = document.getElementById('notif-solicitations');
@@ -276,10 +289,14 @@
     if (wlInput) wlInput.addEventListener('keydown', function(e) { if (e.key === 'Enter') { e.preventDefault(); addWatchlistItem(); } });
 
     function loadNotifications() {
-      if (!email) { document.getElementById('notif-loading').textContent = 'Sign in to manage notifications.'; return; }
-      fetch('/.netlify/functions/member-preferences?email=' + encodeURIComponent(email))
-        .then(function(r) { return r.json(); })
+      if (!token) { document.getElementById('notif-loading').textContent = 'Sign in to manage notifications.'; return; }
+      prefsPost({ action: 'get' })
+        .then(function(r) {
+          if (r.status === 401) { document.getElementById('notif-loading').textContent = 'Your session has expired. Sign in again to manage notifications.'; return null; }
+          return r.json();
+        })
         .then(function(data) {
+          if (!data) return;
           var n = (data.prefs && data.prefs.notifications) || {};
           if (n.solicitations) { solCheck.checked = true; solFreq.style.display = 'block'; }
           var freq = n.solicitation_frequency || 'weekly';
@@ -301,7 +318,7 @@
     }
 
     function saveNotifications() {
-      if (!email) return;
+      if (!token) return;
       var btn = document.getElementById('notif-save-btn');
       btn.disabled = true; btn.textContent = 'Saving...';
       var freqRadio = document.querySelector('input[name="sol-freq"]:checked');
@@ -314,16 +331,16 @@
         new_articles: document.getElementById('notif-articles').checked,
         watchlist: _watchlist.slice()
       };
-      fetch('/.netlify/functions/member-preferences', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email, notifications: notifications })
+      prefsPost({ notifications: notifications })
+      .then(function(r) {
+        if (r.status === 401) { return { _expired: true }; }
+        return r.json();
       })
-      .then(function(r) { return r.json(); })
       .then(function(data) {
         btn.disabled = false; btn.textContent = 'Save preferences';
         var status = document.getElementById('notif-status');
-        if (data.saved) { status.textContent = 'Saved'; status.style.color = '#16A34A'; }
+        if (data && data._expired) { status.textContent = 'Session expired — sign in again'; status.style.color = '#E63946'; }
+        else if (data.saved) { status.textContent = 'Saved'; status.style.color = '#16A34A'; }
         else { status.textContent = 'Error saving'; status.style.color = '#E63946'; }
         status.style.display = 'inline';
         setTimeout(function() { status.style.display = 'none'; }, 3000);


### PR DESCRIPTION
Completes the member-* endpoint hardening started in #137. These two endpoints shared the same trust-the-email pattern.

## Fix
Both now require the HMAC-signed `mmt_subscriber_token`, verify it server-side (reusing `lib/subscriber-token.js` from #137), and **derive the email from the token** — a body email is ignored.

- **`member-preferences.js`**: POST-only; `action:'get'` to read, default path to save; `GET → 405`; `401` on bad/missing/expired. Upsert behavior unchanged.
- **`member-read-state.js`**: POST-only; `action:'list'` to read; `GET → 405`. (`mmtMarkRead` was orphaned, so zero UI risk.)
- **`settings.html`**: loads/saves via POST with the token (no more `GET ?email=`); shows a "sign in again" state on 401.
- **`mmt-paywall.js`**: `mmtMarkRead` sends the token.

## Verified
- Unit **455/455**.
- Auth-gate harness (both endpoints): no/bad/expired token → **401**, `GET → 405`, **body-email swap ignored**, valid token passes.
- build clean · validate-dist **591** · validate-routes **35** · scan-pii OK.
- Browser e2e: settings load is now POST, no-token → sign-in state, no console errors.

With this, all three browser member-* endpoints (`watchlist`, `preferences`, `read-state`) authenticate on the verified token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)