### PR TITLE
fix(loops): harden L3 status_snapshot + regression-guard spec bundling

### DIFF
--- a/netlify/functions/lib/loops/publishers/status_snapshot.js
+++ b/netlify/functions/lib/loops/publishers/status_snapshot.js
@@ -5,6 +5,16 @@
 // want the unhealthy state recorded too, so this is a normal step, not a
 // gated publish). The public /status.json endpoint reads the newest row
 // per source from this table.
+//
+// BEST-EFFORT by design (mirrors publishers/intel_coverage_snapshot): the
+// /status.json snapshot is a bonus surface. A transient loop_status write
+// error — or the table not existing yet (the loop_infra migration is gated
+// on Mary's approval) — must NOT throw the whole loop. Throwing here fired a
+// spurious loop_contract_freshness *_RUN_FAILED dead-man alert on every hourly
+// tick AND, because this step runs BEFORE the lag_thresholds eval, blinded the
+// drift detector (the loop's other deliverable) whenever the write hiccuped.
+// Degrade to a recorded skip instead; a persistently unwritable table shows up
+// as a stale /status.json, which is itself observable.
 // ============================================================
 
 async function run(ctx) {
@@ -26,7 +36,7 @@ async function run(ctx) {
     const { error } = await ctx.supabase.from("loop_status").insert(rows);
     if (error) throw error;
   } catch (e) {
-    throw new Error(`loop_status insert failed: ${e.message}`);
+    return { written: 0, skipped: `loop_status_unavailable:${String(e && e.message).slice(0, 80)}` };
   }
   ctx.outputRef = `loop_status:${rows.length}`;
   return { written: rows.length };

--- a/tests/unit/loops.test.js
+++ b/tests/unit/loops.test.js
@@ -3,8 +3,12 @@
 // gates and the quota-safe scorer against regression.
 
 import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import { runLoop, loadSpec } from "../../netlify/functions/lib/loops/runner.js";
-import { resolve } from "../../netlify/functions/lib/loops/registry.js";
+import { resolve, SPECS } from "../../netlify/functions/lib/loops/registry.js";
+import statusSnapshot from "../../netlify/functions/lib/loops/publishers/status_snapshot.js";
 import dedupe from "../../netlify/functions/lib/loops/transforms/dedupe.js";
 import { scoreOne } from "../../netlify/functions/lib/loops/scorers/pursuit_score.js";
 import scoreSanity from "../../netlify/functions/lib/loops/evals/score_sanity.js";
@@ -29,6 +33,61 @@ describe("spec + registry wiring", () => {
 
   it("loadSpec throws on unknown loop", () => {
     expect(() => loadSpec("does_not_exist")).toThrow();
+  });
+
+  // Regression guard for #138. Root cause of the 2026-07-17 loop RUN_FAILED
+  // burst: loadSpec() read specs via fs.readFileSync(__dirname/specs/*.json),
+  // which esbuild does NOT bundle — so every loop threw "loop spec not found:
+  // /var/task/..." on Lambda the moment LOOPS_ENABLED was turned on. It passed
+  // locally (files exist on disk), so no test caught it. The fix was a static
+  // require() SPECS map in registry.js. This asserts EVERY spec .json on disk
+  // is present in that bundled map, so a new spec that ships without a static
+  // require (invisible to esbuild, fatal on Lambda) fails CI here, not in prod.
+  it("every specs/*.json is registered in the bundled SPECS map (esbuild-safe)", () => {
+    const specsDir = join(dirname(fileURLToPath(import.meta.url)), "../../netlify/functions/lib/loops/specs");
+    const files = readdirSync(specsDir).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      const name = file.replace(/\.json$/, "");
+      // Registered in the static map the runner reads (require-based, bundled).
+      expect(SPECS, `specs/${file} missing from registry.SPECS`).toHaveProperty(name);
+      // The bundled copy matches the file on disk, and loadSpec resolves it.
+      const onDisk = JSON.parse(readFileSync(join(specsDir, file), "utf8"));
+      expect(SPECS[name].name).toBe(onDisk.name);
+      expect(loadSpec(name).name).toBe(name);
+    }
+  });
+});
+
+describe("publishers/status_snapshot resilience", () => {
+  // A loop_status write failure (transient, or the gated loop_infra migration
+  // not applied yet) must NOT throw the loop — that would re-fire the exact
+  // hourly loop_contract_freshness *_RUN_FAILED the QA report flagged, and
+  // skip the lag_thresholds eval that runs after this step. Degrade to a skip.
+  const health = { sources: [{ source: "usaspending", http_status: 200, latency_ms: 5, lag_hours: 1, healthy: true }] };
+
+  it("returns a recorded skip (does not throw) when the insert errors", async () => {
+    const supabase = { from: () => ({ insert: async () => ({ error: { message: 'relation "loop_status" does not exist' } }) }) };
+    const out = await statusSnapshot.run({ supabase, data: { health } });
+    expect(out.written).toBe(0);
+    expect(out.skipped).toMatch(/^loop_status_unavailable:/);
+  });
+
+  it("returns a recorded skip (does not throw) when the insert rejects", async () => {
+    const supabase = { from: () => ({ insert: async () => { throw new Error("network down"); } }) };
+    const out = await statusSnapshot.run({ supabase, data: { health } });
+    expect(out.written).toBe(0);
+    expect(out.skipped).toMatch(/^loop_status_unavailable:/);
+  });
+
+  it("writes one row per source on success", async () => {
+    let received = null;
+    const supabase = { from: () => ({ insert: async (rows) => { received = rows; return { error: null }; } }) };
+    const out = await statusSnapshot.run({ supabase, data: { health }, runId: "run-1" });
+    expect(out.written).toBe(1);
+    expect(received).toHaveLength(1);
+    expect(received[0].source).toBe("usaspending");
+    expect(received[0].run_id).toBe("run-1");
   });
 });
 


### PR DESCRIPTION
## Summary

The 2026-07-18 pre-digest QA reported a burst of `loop_contract_freshness` and `loop_contract_intel_freshness` `*_RUN_FAILED` events, all clustered 2026-07-17 **17:06–19:09 UTC**, then nothing after.

**Root cause (already fixed):** `loadSpec()` read specs via `fs.readFileSync(__dirname/specs/*.json)`, which esbuild never bundles. On Lambda that path doesn't exist, so *every* loop threw `loop spec not found: /var/task/...` before its try-block, on every run, the moment `LOOPS_ENABLED` was turned on — which is why **both** loops failed identically. Commit #138 replaced it with a static `require()`-based `SPECS` map and deployed at 19:40 UTC; the failures ceased exactly then. #138 is already on `main`, so the reported alarm is resolved.

This PR closes the two gaps #138 left so the same class of `RUN_FAILED` can't recur.

## Changes

- **`netlify/functions/lib/loops/publishers/status_snapshot.js`** — L3's snapshot no longer throws the whole loop when the `loop_status` write fails. A transient blip — or the gated `loop_infra` migration not being applied — previously fired a spurious hourly `loop_contract_freshness` `RUN_FAILED` dead-man alert AND, because this step runs *before* the `lag_thresholds` eval, blinded the drift detector. It now degrades to a recorded skip (`loop_status_unavailable:...`), the identical best-effort pattern `intel_coverage_snapshot` already uses. A persistently unwritable table surfaces as a stale `/status.json` instead.
- **`tests/unit/loops.test.js`** — regression test asserting every `specs/*.json` on disk is registered in the bundled `registry.SPECS` map (a spec that ships without a static `require` is invisible to esbuild and fatal on Lambda — this now fails CI, not prod; the old fs loader had no such guard). Plus `status_snapshot` resilience tests: insert error → skip, insert reject → skip, success → one row per source.

## Checklist
- [x] Unit tests passing (`npm test`) — full suite **459/459**, loops **27/27** (+4 new)
- [ ] Smoke tests passing (`npm run test:smoke`) — not run (no change to smoke-covered paths)
- [ ] E2E tests passing (`npm run test:e2e`) — not run (no UI change)
- [ ] Integrity audit passing (`node integrity-audit.js`) — not run (no route/HTML change)
- [x] Build succeeds — no site HTML/CSS/JS or `build.js` inputs touched; change is scoped to a Netlify function lib + its unit tests
- [x] Security lint passing (no privileged secrets exposed)
- [x] No new uploads without access controls
- [x] No new external calls without retry and validation
- [x] No critical-path changes without smoke-test evidence — detection-only loop; no publish/write to live subscriber data
- [x] No breaking contract changes without downstream updates
- [x] PR is focused

## Risk Assessment
- **Critical surfaces touched**: none. `status_snapshot` writes only to the isolated `loop_status` table (feeds `/status.json`); no auth, billing, or subscriber-data writes.
- **Security impact**: none
- **Contract changes**: none / compatible — the step's return shape gains a `skipped` field on failure (already used by the sibling intel snapshot); the runner determines status from evals, not step returns.
- **Rollback plan**: revert this commit. #138 (the actual incident fix) is a separate, already-merged commit and is unaffected.

## Evidence
- Full unit suite: `Test Files 38 passed (38) · Tests 459 passed (459)`.
- Reproduction: with `loop_status` unavailable, `contract_tracker_freshness` previously **threw** `loop_status insert failed`; after this change it completes and its `lag_thresholds` eval runs (status `drift`/`pass` instead of `RUN_FAILED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnqsWwibTFeEjLoJtzPQGp

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnqsWwibTFeEjLoJtzPQGp)_