### PR TITLE
fix(health): stop alerting on transient Cloudflare 522 from Anthropic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,6 +409,46 @@ Verified 2026-07-10: `node -c` clean; offline resolution test against the live
 roster maps 6/7 orphans to a valid in-roster canonical, 1 to manual review.
 
 ---
+## Sprint 2026-07-22 — False "Health Check FAILED" alert (Cloudflare 522)
+
+The 6-hourly `health-check` emailed Mary "Anthropic API returned 522." Nothing
+was broken. **522 is a Cloudflare edge code** (`api.anthropic.com` sits behind
+Cloudflare) meaning the edge could not reach the origin in time — a transient
+network blip that says NOTHING about our key or billing. Verified live the same
+morning: 3/3 probes returned 200.
+
+Two defects, both fixed:
+
+1. **`health-check.js` fired one un-retried probe and classified any non-ok
+   status outside 401/403/429/529 as a hard failure.** So a momentary blip
+   produced a red alert phrased like a broken key. Now: the probe runs through
+   `withRetry` (2 retries, exponential backoff) and results are classified —
+   401/403 and malformed-request 4xx stay hard failures; 408/429/5xx/520-524
+   and total network failures become **warnings**, not failures. Warnings alone
+   return `200 DEGRADED` and send no email. Each run writes a
+   `HEALTH_CHECK_UPSTREAM` ops_ledger row carrying `details.degraded`; if the
+   PREVIOUS run was also degraded, the second consecutive one (~12h of real
+   outage) escalates to the alert email. Same 2-consecutive convention as
+   `scheduled-fn-wrapper`.
+2. **`lib/retry.js` did not treat the Cloudflare codes as retryable.**
+   `RETRYABLE_STATUSES` was `{429,500,502,503,529}`, so a single 522 also blew
+   straight through every Claude-calling background job that uses the helper
+   (contract-intel-refresh, gold-team-review, score-deck, tactical-brief,
+   opportunity-radar, sb-vehicle-radar, ebuy-open-radar, fact-check,
+   claude-search). Added `504, 520, 521, 522, 523, 524`.
+
+Hard rule (do not regress): **a transient upstream status is not a health-check
+failure.** This check exists to catch broken keys and missing config — things
+Mary must fix. Alerting on somebody else's edge timeout trains her to ignore the
+alert, which is worse than no alert. Any new upstream probe added here must
+classify (hard vs transient) and retry before it is allowed to email.
+
+Verified 2026-07-22: `node -c` clean on both files; 8 new tests in
+`tests/unit/health-check-anthropic.test.js` (200 / 401 / 403 / persistent 522 /
+522-then-recover / all CF codes / 400 / network failure); full unit suite
+**467/467** pass; `node build.js` exit 0; `validate-dist` OK (591 pages).
+
+---
 ## Sprint 2026-07-03 — Capture Corner premium email never auto-sent (twice-weekly gap)
 
 Mary: "why didn't my Capture Corner email go out to premium this morning?" The

--- a/netlify/functions/health-check.js
+++ b/netlify/functions/health-check.js
@@ -9,47 +9,115 @@
 //     schedule = "0 */6 * * *"
 // ============================================================
 
+const { createClient } = require("@supabase/supabase-js");
 const { sendEmail } = require("./lib/send-email");
 const { withOpsLogging } = require("./lib/scheduled-fn-wrapper");
+const { logOpsEvent } = require("./lib/ops-ledger");
+const { withRetry } = require("./lib/retry");
 
 const ALERT_EMAIL = "mary@missionmeetstech.com";
+
+// Transient upstream conditions. These say nothing about whether our key or
+// config is valid, so they are NOT hard failures — see UPSTREAM_EVENT below.
+// 520-524 are Cloudflare edge codes (api.anthropic.com is behind Cloudflare);
+// 522 = edge-to-origin connect timeout, which is what fired the false
+// "MMT Health Check FAILED" alert on 2026-07-22.
+const TRANSIENT_STATUSES = new Set([408, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 529]);
+
+// One row per run recording whether the Anthropic probe was degraded, so a
+// single blip stays quiet but a sustained outage still reaches Mary on the
+// second consecutive degraded run (same convention as scheduled-fn-wrapper).
+const UPSTREAM_EVENT = "HEALTH_CHECK_UPSTREAM";
+
+function _supabase() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key);
+}
+
+async function _lastRunWasDegraded(supabase) {
+  if (!supabase) return false;
+  try {
+    const { data, error } = await supabase
+      .from("ops_ledger")
+      .select("details")
+      .eq("event_type", UPSTREAM_EVENT)
+      .order("created_at", { ascending: false })
+      .limit(1);
+    if (error) {
+      console.error("[health-check] degraded-history read failed:", error.message);
+      return false;
+    }
+    return !!(data && data[0] && data[0].details && data[0].details.degraded);
+  } catch (err) {
+    console.error("[health-check] degraded-history read threw:", err.message);
+    return false;
+  }
+}
+
+// Probe Anthropic with retries. Returns { ok } | { hardFailure } | { transient }.
+async function _checkAnthropic(apiKey, retryOptions = { maxRetries: 2, baseDelayMs: 1500 }) {
+  let res;
+  try {
+    res = await withRetry(
+      () =>
+        fetch("https://api.anthropic.com/v1/messages", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-key": apiKey,
+            "anthropic-version": "2023-06-01",
+          },
+          body: JSON.stringify({
+            model: "claude-sonnet-4-6",
+            max_tokens: 5,
+            messages: [{ role: "user", content: "Reply with OK" }],
+          }),
+        }),
+      retryOptions
+    );
+  } catch (err) {
+    // Every attempt threw — network-level, not a config problem.
+    return { transient: `Anthropic API unreachable after retries: ${err.message}` };
+  }
+
+  if (res.status === 401) {
+    return { hardFailure: "ANTHROPIC_API_KEY is invalid (401 Unauthorized)" };
+  }
+  if (res.status === 403) {
+    return { hardFailure: "ANTHROPIC_API_KEY is forbidden (403) — check billing or permissions" };
+  }
+  if (res.ok) return { ok: true };
+
+  const errText = await res.text().catch(() => "");
+  const detail = `Anthropic API returned ${res.status}: ${errText.slice(0, 200)}`;
+  // A 4xx that isn't 401/403/408/429 is our request being wrong (bad model id,
+  // malformed body) — that IS actionable and stays a hard failure.
+  return TRANSIENT_STATUSES.has(res.status) ? { transient: detail } : { hardFailure: detail };
+}
 
 async function _handler() {
   // Scheduled invocation — run full checks
   console.log("Health check started:", new Date().toISOString());
   const failures = [];
+  const warnings = [];
+  let anthropicDegraded = false;
 
   // --- Check Anthropic API Key ---
   const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
   if (!ANTHROPIC_API_KEY) {
     failures.push("ANTHROPIC_API_KEY is not set in environment variables");
   } else {
-    try {
-      const res = await fetch("https://api.anthropic.com/v1/messages", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": ANTHROPIC_API_KEY,
-          "anthropic-version": "2023-06-01",
-        },
-        body: JSON.stringify({
-          model: "claude-sonnet-4-6",
-          max_tokens: 5,
-          messages: [{ role: "user", content: "Reply with OK" }],
-        }),
-      });
-      if (res.status === 401) {
-        failures.push("ANTHROPIC_API_KEY is invalid (401 Unauthorized)");
-      } else if (res.status === 403) {
-        failures.push("ANTHROPIC_API_KEY is forbidden (403) — check billing or permissions");
-      } else if (!res.ok && res.status !== 429 && res.status !== 529) {
-        const errText = await res.text();
-        failures.push(`Anthropic API returned ${res.status}: ${errText.slice(0, 200)}`);
-      } else {
-        console.log("Anthropic API key: OK");
-      }
-    } catch (err) {
-      failures.push(`Anthropic API unreachable: ${err.message}`);
+    const result = await _checkAnthropic(ANTHROPIC_API_KEY);
+    if (result.hardFailure) {
+      failures.push(result.hardFailure);
+    } else if (result.transient) {
+      anthropicDegraded = true;
+      warnings.push(result.transient);
+      console.warn("Anthropic API transient:", result.transient);
+    } else {
+      console.log("Anthropic API key: OK");
     }
   }
 
@@ -88,28 +156,63 @@ async function _handler() {
     failures.push("REPORT_VIEWER_SECRET is not set — MarketPulse report URLs will use fallback HMAC (set this before production traffic)");
   }
 
+  // --- Record upstream state + decide whether a transient warrants alerting ---
+  const supabase = _supabase();
+  const previouslyDegraded = anthropicDegraded ? await _lastRunWasDegraded(supabase) : false;
+  if (supabase) {
+    try {
+      await logOpsEvent(supabase, {
+        event_type: UPSTREAM_EVENT,
+        source_function: "health-check",
+        severity: anthropicDegraded ? "warn" : "info",
+        signature: "anthropic_probe",
+        details: {
+          degraded: anthropicDegraded,
+          consecutive: previouslyDegraded,
+          warnings,
+        },
+      });
+    } catch (err) {
+      console.error("[health-check] upstream ops_ledger write failed:", err.message);
+    }
+  }
+
+  // A single transient blip is noise. Two consecutive degraded runs (12h apart)
+  // means Anthropic is genuinely down for us, and that is worth an email.
+  const alertable = [...failures];
+  if (anthropicDegraded && previouslyDegraded) {
+    alertable.push(
+      `Anthropic API has been unreachable for two consecutive health checks (~12h). Latest: ${warnings[0]}`
+    );
+  }
+
   // --- Report results ---
-  if (failures.length > 0) {
-    console.error("HEALTH CHECK FAILURES:", failures);
+  if (alertable.length > 0) {
+    console.error("HEALTH CHECK FAILURES:", alertable);
 
     // Only send email alert if Resend key exists
     if (RESEND_API_KEY) {
       const html = `
         <h2 style="color:#ef4444;">⚠️ MMT Health Check Failed</h2>
         <p>The following issues were detected at ${new Date().toISOString()}:</p>
-        <ul>${failures.map(f => `<li style="color:#ef4444;margin-bottom:8px;">${f}</li>`).join("")}</ul>
+        <ul>${alertable.map(f => `<li style="color:#ef4444;margin-bottom:8px;">${f}</li>`).join("")}</ul>
         <p style="color:#666;font-size:12px;">This check runs every 6 hours. Fix these before users are affected.</p>
       `;
 
       await sendEmail({
         to: ALERT_EMAIL,
-        subject: `⚠️ MMT Health Check FAILED — ${failures.length} issue${failures.length > 1 ? "s" : ""}`,
+        subject: `⚠️ MMT Health Check FAILED — ${alertable.length} issue${alertable.length > 1 ? "s" : ""}`,
         html,
         from: "Mission Meets Tech <noreply@missionmeetstech.com>",
       });
     }
 
-    return { statusCode: 500, body: JSON.stringify({ status: "FAIL", failures }) };
+    return { statusCode: 500, body: JSON.stringify({ status: "FAIL", failures: alertable, warnings }) };
+  }
+
+  if (warnings.length > 0) {
+    console.warn("Health checks passed with transient upstream warnings:", warnings);
+    return { statusCode: 200, body: JSON.stringify({ status: "DEGRADED", warnings }) };
   }
 
   console.log("All health checks passed");
@@ -117,3 +220,7 @@ async function _handler() {
 }
 
 exports.handler = withOpsLogging("health_check", _handler);
+
+// Exported for unit tests only.
+exports._checkAnthropic = _checkAnthropic;
+exports.TRANSIENT_STATUSES = TRANSIENT_STATUSES;

--- a/netlify/functions/lib/retry.js
+++ b/netlify/functions/lib/retry.js
@@ -1,8 +1,16 @@
 // Retry with exponential backoff for transient API failures.
 // Retries on 429 (rate limit), 529 (overloaded), and 5xx server errors.
 // Does NOT retry on 4xx client errors (except 429).
+//
+// 504 and the Cloudflare edge codes 520-524 are included: api.anthropic.com
+// sits behind Cloudflare, so a momentary edge-to-origin hiccup surfaces as
+// 522 ("Connection timed out") rather than a 5xx from Anthropic itself.
+// Without these, one blip fails a whole background job. (Added 2026-07-22
+// after a 522 tripped the 6-hourly health check.)
 
-const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 529]);
+const RETRYABLE_STATUSES = new Set([
+  429, 500, 502, 503, 504, 520, 521, 522, 523, 524, 529,
+]);
 
 async function withRetry(fn, { maxRetries = 2, baseDelayMs = 2000 } = {}) {
   let lastError;

--- a/tests/unit/health-check-anthropic.test.js
+++ b/tests/unit/health-check-anthropic.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { _checkAnthropic, TRANSIENT_STATUSES } = require("../../netlify/functions/health-check.js");
+
+// No delay between retries so the transient cases don't add seconds per test.
+const FAST = { maxRetries: 2, baseDelayMs: 0 };
+
+function stubFetch(responses) {
+  const queue = [...responses];
+  const fn = vi.fn(async () => {
+    const next = queue.length > 1 ? queue.shift() : queue[0];
+    if (next instanceof Error) throw next;
+    return {
+      status: next.status,
+      ok: next.status >= 200 && next.status < 300,
+      text: async () => next.body || "",
+    };
+  });
+  global.fetch = fn;
+  return fn;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("health-check Anthropic probe classification", () => {
+  it("passes on 200", async () => {
+    stubFetch([{ status: 200 }]);
+    expect(await _checkAnthropic("sk-test", FAST)).toEqual({ ok: true });
+  });
+
+  it("treats 401 as a hard failure (bad key)", async () => {
+    stubFetch([{ status: 401 }]);
+    const result = await _checkAnthropic("sk-test", FAST);
+    expect(result.hardFailure).toMatch(/401/);
+    expect(result.transient).toBeUndefined();
+  });
+
+  it("treats 403 as a hard failure (billing/permissions)", async () => {
+    stubFetch([{ status: 403 }]);
+    expect((await _checkAnthropic("sk-test", FAST)).hardFailure).toMatch(/403/);
+  });
+
+  // The 2026-07-22 false alarm: Cloudflare edge timeout in front of
+  // api.anthropic.com, reported to Mary as if the key were broken.
+  it("treats a persistent 522 as transient, not a failure", async () => {
+    stubFetch([{ status: 522, body: "error code: 522" }]);
+    const result = await _checkAnthropic("sk-test", FAST);
+    expect(result.transient).toMatch(/522/);
+    expect(result.hardFailure).toBeUndefined();
+  });
+
+  it("retries a transient status and passes when it recovers", async () => {
+    const fetchFn = stubFetch([{ status: 522 }, { status: 200 }]);
+    expect(await _checkAnthropic("sk-test", FAST)).toEqual({ ok: true });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies every Cloudflare edge code as transient", () => {
+    for (const status of [520, 521, 522, 523, 524]) {
+      expect(TRANSIENT_STATUSES.has(status)).toBe(true);
+    }
+  });
+
+  it("keeps a malformed-request 400 as a hard failure", async () => {
+    stubFetch([{ status: 400, body: "model: unknown model" }]);
+    const result = await _checkAnthropic("sk-test", FAST);
+    expect(result.hardFailure).toMatch(/400/);
+    expect(result.transient).toBeUndefined();
+  });
+
+  it("treats a total network failure as transient, not a bad key", async () => {
+    stubFetch([new Error("fetch failed")]);
+    const result = await _checkAnthropic("sk-test", FAST);
+    expect(result.transient).toMatch(/unreachable after retries/);
+    expect(result.hardFailure).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What happened

The 6-hourly `health-check` cron emailed **"⚠️ MMT Health Check FAILED — Anthropic API returned 522"** at 12:08 UTC today.

Nothing was broken. **522 is a Cloudflare edge code** — `api.anthropic.com` sits behind Cloudflare, and 522 means the edge could not reach the origin in time. It says nothing about our API key, billing, or permissions. Verified live the same morning: 3/3 probes to the exact endpoint the check uses returned 200.

## Two defects

**1. The check fired one un-retried probe and treated almost any non-ok status as a hard failure.**
The classifier only excused 401/403 (as their own specific messages) and 429/529. Everything else — including a one-second edge timeout — became a red "FAILED" alert phrased like a broken key.

**2. `lib/retry.js` did not consider the Cloudflare codes retryable.**
`RETRYABLE_STATUSES` was `{429, 500, 502, 503, 529}`. A single 522 therefore also blew straight through every Claude-calling background job using the helper: contract-intel-refresh, gold-team-review, score-deck, generate-tactical-brief, opportunity-radar, sb-vehicle-radar, ebuy-open-radar, fact-check, claude-search.

## The fix

- `health-check.js` probes through `withRetry` (2 retries, exponential backoff) and **classifies** the outcome:
  - **hard failure** — 401, 403, and malformed-request 4xx (bad model id, bad body). These are actionable and still alert.
  - **transient** — 408, 429, 5xx, 520–524, and total network failure. These become warnings.
- Warnings alone return `200 DEGRADED` and send **no email**.
- Every run writes a `HEALTH_CHECK_UPSTREAM` row to `ops_ledger` with `details.degraded`. If the previous run was *also* degraded, the second consecutive one (~12h of genuine outage) escalates to the alert email — same 2-consecutive convention as `scheduled-fn-wrapper`.
- `lib/retry.js` gains `504, 520, 521, 522, 523, 524`.

Net effect: a blip is silent, a real Anthropic outage still reaches Mary within 12 hours, and a genuinely bad key still alerts on the first run.

## Why this matters beyond the noise

Alerting on someone else's edge timeout trains the recipient to ignore the alert. That is worse than no alert.

## Verification

- `node -c` clean on both changed files
- 8 new tests in `tests/unit/health-check-anthropic.test.js` — 200 / 401 / 403 / persistent 522 / 522-then-recover / all CF codes / 400 / network failure
- Full unit suite **467/467** pass
- `node build.js` exit 0; `validate-dist` OK (591 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)