### PR TITLE
Premium: FY2027 Budget Signals on the CR/Appropriations page

### DIFF
--- a/data/budget-signals.json
+++ b/data/budget-signals.json
@@ -1,0 +1,354 @@
+{
+  "_schema": {
+    "version": "1.0",
+    "last_verified": "2026-08-05",
+    "note": "FY2027 federal health / health-IT appropriation lines from the congressional budget justifications. Each line's FY26 enacted -> FY27 request change and percentage were verified internally consistent before publish. Dollars in $ millions. This is budget INTENT (where money is planned), distinct from obligated-contract data.",
+    "verification": "30 of the workbook's 104 rows retained: the internally-consistent budget-justification block. The Treasury account-level rows below it use different column semantics (FY25->FY26 account resources) and were excluded to avoid a mixed table.",
+    "sources": [
+      {
+        "label": "VA FY2027 Budget Submission (Budget in Brief)",
+        "url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+      },
+      {
+        "label": "Military Health System FY2027 Budget Estimates, Vol. 1",
+        "url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+      },
+      {
+        "label": "HHS FY2027 Budget in Brief",
+        "url": "https://www.hhs.gov/sites/default/files/fy-2027-budget-in-brief.pdf"
+      }
+    ]
+  },
+  "lines": [
+    {
+      "agency": "VA",
+      "line": "VA total budget authority (discretionary + mandatory, incl. MCCF and RETF)",
+      "fy25_m": 401294.0,
+      "fy26_m": 453343.0,
+      "fy27_m": 488211.0,
+      "change_m": 34868.0,
+      "change_pct": 0.0769,
+      "basis": "FY25: (enacted w/ transfers) | FY26: (enacted w/ transfers)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VA total discretionary (with MCCF and RETF)",
+      "fy25_m": 134134.0,
+      "fy26_m": 138291.0,
+      "fy27_m": 150562.0,
+      "change_m": 12271.0,
+      "change_pct": 0.0887,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VHA Medical Services \u2014 discretionary",
+      "fy25_m": 69129.0,
+      "fy26_m": 57241.0,
+      "fy27_m": 59958.0,
+      "change_m": 2717.0,
+      "change_pct": 0.0475,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VHA Medical Services \u2014 all funding sources (disc + Toxic Exposures Fund)",
+      "fy25_m": 81013.0,
+      "fy26_m": 92611.0,
+      "fy27_m": 95177.0,
+      "change_m": 2566.0,
+      "change_pct": 0.0277,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VHA Medical Community Care \u2014 discretionary",
+      "fy25_m": 22555.0,
+      "fy26_m": 34000.0,
+      "fy27_m": 39727.0,
+      "change_m": 5727.0,
+      "change_pct": 0.1684,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VHA Medical Community Care \u2014 all funding sources",
+      "fy25_m": 38249.0,
+      "fy26_m": 48030.0,
+      "fy27_m": 56174.0,
+      "change_m": 8144.0,
+      "change_pct": 0.1696,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VHA Medical Support and Compliance \u2014 discretionary",
+      "fy25_m": 11719.0,
+      "fy26_m": 11669.0,
+      "fy27_m": 11050.0,
+      "change_m": -619.0,
+      "change_pct": -0.053,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VHA Medical Support and Compliance \u2014 all funding sources",
+      "fy25_m": 11719.0,
+      "fy26_m": 12069.0,
+      "fy27_m": 11455.0,
+      "change_m": -614.0,
+      "change_pct": -0.0509,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VHA Medical Facilities \u2014 discretionary",
+      "fy25_m": 9548.0,
+      "fy26_m": 11876.0,
+      "fy27_m": 12650.0,
+      "change_m": 774.0,
+      "change_pct": 0.0652,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "VHA Medical Facilities \u2014 all funding sources (incl. PACT \u00a7707 leases)",
+      "fy25_m": 9748.0,
+      "fy26_m": 12276.0,
+      "fy27_m": 13100.0,
+      "change_m": 824.0,
+      "change_pct": 0.0671,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "Subtotal, Medical Care Appropriations (all funding sources)",
+      "fy25_m": 140729.0,
+      "fy26_m": 164986.0,
+      "fy27_m": 175906.0,
+      "change_m": 10920.0,
+      "change_pct": 0.0662,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "Information Technology Systems (OIT) \u2014 discretionary",
+      "fy25_m": 6192.0,
+      "fy26_m": 6219.0,
+      "fy27_m": 6308.0,
+      "change_m": 89.0,
+      "change_pct": 0.0143,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "Information Technology Systems \u2014 total (disc + TEF mandatory)",
+      "fy25_m": 7556.0,
+      "fy26_m": 7604.0,
+      "fy27_m": 7364.0,
+      "change_m": -240.0,
+      "change_pct": -0.0316,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "Electronic Health Record Modernization (EHRM)",
+      "fy25_m": 1306.0,
+      "fy26_m": 3400.0,
+      "fy27_m": 4240.0,
+      "change_m": 840.0,
+      "change_pct": 0.2471,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "Medical and Prosthetic Research \u2014 discretionary",
+      "fy25_m": 935.0,
+      "fy26_m": 945.0,
+      "fy27_m": 922.0,
+      "change_m": -23.0,
+      "change_pct": -0.0243,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "VA",
+      "line": "Medical and Prosthetic Research \u2014 all funding sources (incl. TEF 57)",
+      "fy25_m": 994.0,
+      "fy26_m": 1002.0,
+      "fy27_m": 979.0,
+      "change_m": -23.0,
+      "change_pct": -0.023,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://department.va.gov/wp-content/uploads/2026/04/2027-BiB.pdf"
+    },
+    {
+      "agency": "DHA",
+      "line": "Defense Health Program total \u2014 discretionary",
+      "fy25_m": 39847.4,
+      "fy26_m": 41775.2,
+      "fy27_m": 42517.1,
+      "change_m": 741.9,
+      "change_pct": 0.0178,
+      "basis": "FY25: (actual execution) | FY26: (enacted) | FY27: (COMP 20,341.643 + PSCP 22,175.472)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "DHP/COMP mandatory funding",
+      "fy25_m": 2000.0,
+      "fy26_m": 1687.0,
+      "fy27_m": 3138.9,
+      "change_m": 1451.9,
+      "change_pct": 0.8607,
+      "basis": "FY25: (OBBBA, available beginning FY2025) | FY26: (FY2026 \"Mandatory Spend\", O-1 exhibit)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "DHP O&M \u2014 Private Sector Care (purchased care / TRICARE)",
+      "fy25_m": 20201.0,
+      "fy26_m": 20773.9,
+      "fy27_m": 22175.5,
+      "change_m": 1401.6,
+      "change_pct": 0.0675,
+      "basis": "FY26: (enacted) | FY27: (moved to new account 0146D PSCP)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "DHP O&M \u2014 In-House Care",
+      "fy25_m": 10294.5,
+      "fy26_m": 10735.1,
+      "fy27_m": 10863.3,
+      "change_m": 128.2,
+      "change_pct": 0.0119,
+      "basis": "FY26: disc enacted (11,435.135 incl. $700.0 mandatory)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "DHP O&M \u2014 Information Management / IM-IT",
+      "fy25_m": 2452.6,
+      "fy26_m": 2271.8,
+      "fy27_m": 2600.2,
+      "change_m": 328.4,
+      "change_pct": 0.1445,
+      "basis": "FY26: disc enacted (2,371.798 incl. $100.0 mandatory)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "DHP Procurement (BA 03)",
+      "fy25_m": 398.9,
+      "fy26_m": 354.8,
+      "fy27_m": 366.7,
+      "change_m": 11.9,
+      "change_pct": 0.0336,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "DHP RDT&E (BA 02)",
+      "fy25_m": 1695.4,
+      "fy26_m": 2472.7,
+      "fy27_m": 1019.4,
+      "change_m": -1453.3,
+      "change_pct": -0.5878,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "MHS GENESIS / DHMSM (O&M, within IM/IT)",
+      "fy25_m": 606.1,
+      "fy26_m": 487.8,
+      "fy27_m": 491.2,
+      "change_m": 3.4,
+      "change_pct": 0.0069,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "DHMSM (RDT&E PE 0605026DHA)",
+      "fy25_m": 5.9,
+      "fy26_m": 6.0,
+      "fy27_m": 5.1,
+      "change_m": -0.9,
+      "change_pct": -0.1486,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "Joint Operational Medicine Information System (JOMIS)",
+      "fy25_m": 242.5,
+      "fy26_m": 254.2,
+      "fy27_m": 255.3,
+      "change_m": 1.1,
+      "change_pct": 0.0044,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "DHA",
+      "line": "IT Technology Development \u2014 integrated EHR (iEHR)",
+      "fy25_m": 23.4,
+      "fy26_m": 24.2,
+      "fy27_m": 24.3,
+      "change_m": 0.0,
+      "change_pct": 0.0014,
+      "basis": "FY26: (enacted)",
+      "source_url": "https://comptroller.war.gov/Portals/45/Documents/defbudget/FY2027/budget_justification/"
+    },
+    {
+      "agency": "HHS",
+      "line": "HHS total discretionary budget authority",
+      "fy25_m": 128167.0,
+      "fy26_m": 128737.0,
+      "fy27_m": 112238.0,
+      "change_m": -16499.0,
+      "change_pct": -0.1282,
+      "basis": "FY25: (reorg-comparable) / 128,054 (existing structure) | FY26: reorg-comparable / 128,459 existing structure (enacted) | FY27: (\"Total, Discretionary Budget Authority\"); 111,062 after NEF cancellation/rescissions",
+      "source_url": "https://www.hhs.gov/sites/default/files/fy-2027-budget-in-brief.pdf"
+    },
+    {
+      "agency": "CMS",
+      "line": "CMS total program level (discretionary program level)",
+      "fy25_m": 7562.0,
+      "fy26_m": 8282.0,
+      "fy27_m": 6848.0,
+      "change_m": -1434.0,
+      "change_pct": -0.1731,
+      "basis": "FY25: (reorg-comparable) / 7,550 (existing structure) | FY26: / 8,270 (enacted) | FY27: / 6,836",
+      "source_url": "https://www.hhs.gov/sites/default/files/fy-2027-budget-in-brief.pdf"
+    },
+    {
+      "agency": "CMS",
+      "line": "CMS Program Management account \u2014 Total Program Management",
+      "fy25_m": 7562.0,
+      "fy26_m": 8282.0,
+      "fy27_m": 6848.0,
+      "change_m": -1434.0,
+      "change_pct": -0.1731,
+      "basis": "FY25: (BA 4,137) | FY26: (enacted; BA 4,137) | FY27: (BA 3,700)",
+      "source_url": "https://www.hhs.gov/sites/default/files/fy-2027-budget-in-brief.pdf"
+    }
+  ]
+}

--- a/premium/cr-exposure.html
+++ b/premium/cr-exposure.html
@@ -44,7 +44,23 @@
     .status-band p { margin:0 0 6px; font-size:13px; line-height:1.55; color:var(--mmt-navy); }
     .status-band p:last-child { margin-bottom:0; }
     .status-band strong { font-weight:700; }
-    @media (max-width:768px) { .dash-shell { grid-template-columns:1fr; } .dash-nav { display:none; } .dash-main { padding:16px; padding-bottom:80px; } }
+    .bs-filters { display:flex; flex-wrap:wrap; gap:8px; margin-bottom:12px; }
+    .bs-filter { font-size:12px; font-weight:600; padding:5px 12px; border-radius:16px; border:1px solid var(--mmt-border); background:var(--mmt-white); color:var(--mmt-teal); cursor:pointer; transition:all 0.15s; }
+    .bs-filter.active { background:var(--mmt-teal); color:#fff; border-color:var(--mmt-teal); }
+    table.bs-table { border-collapse:collapse; width:100%; font-size:13px; background:var(--mmt-white); border:1px solid var(--mmt-border); border-radius:10px; overflow:hidden; }
+    table.bs-table th { text-align:left; font-size:11px; text-transform:uppercase; letter-spacing:0.04em; color:var(--mmt-text-secondary); padding:10px 12px; background:var(--mmt-surface); border-bottom:1px solid var(--mmt-border); white-space:nowrap; }
+    table.bs-table th.num, table.bs-table td.num { text-align:right; }
+    table.bs-table td { padding:10px 12px; border-bottom:1px solid var(--mmt-border); vertical-align:top; }
+    table.bs-table tr:last-child td { border-bottom:none; }
+    .bs-agency { font-size:11px; font-weight:700; padding:2px 7px; border-radius:10px; background:rgba(69,123,157,0.1); color:var(--mmt-teal); white-space:nowrap; }
+    .bs-delta { font-weight:800; white-space:nowrap; }
+    .bs-delta.up { color:#1B7A4B; }
+    .bs-delta.down { color:#E63946; }
+    .bs-delta.flat { color:var(--mmt-text-secondary); }
+    .bs-note { font-size:12px; color:var(--mmt-text-secondary); margin:10px 0 0; line-height:1.6; }
+    .bs-src { color:var(--mmt-teal); text-decoration:none; font-weight:600; font-size:12px; }
+    .bs-src:hover { text-decoration:underline; }
+    @media (max-width:768px) { .dash-shell { grid-template-columns:1fr; } .dash-nav { display:none; } .dash-main { padding:16px; padding-bottom:80px; } table.bs-table { font-size:12px; } table.bs-table th, table.bs-table td { padding:8px 9px; } }
   </style>
   <script>
     (function() {
@@ -106,6 +122,14 @@
 
         <div id="deadlines"></div>
 
+        <div style="margin:28px 0 8px;">
+          <h2 style="font-size:18px;font-weight:800;margin:0 0 4px;">FY2027 Budget Signals &mdash; where health-IT money is moving</h2>
+          <p style="font-size:13px;color:var(--mmt-text-secondary);line-height:1.6;margin:0 0 14px;">Deadlines tell you <em>when</em> money is at risk. This tells you <em>where it&rsquo;s flowing.</em> FY2026 enacted &rarr; FY2027 request, straight from the congressional budget justifications. A pursuit riding a growing account is a stronger opening than one riding contract size alone. Dollars in millions.</p>
+          <div class="bs-filters" id="bsFilters"></div>
+          <div id="bsTableWrap" style="overflow-x:auto;"></div>
+          <p class="bs-note" id="bsNote"></p>
+        </div>
+
         <div class="dash-card">
           <h2 style="font-size:16px;font-weight:700;margin:0 0 8px;">How to use this page</h2>
           <p style="font-size:13px;color:var(--mmt-navy);line-height:1.65;margin:0 0 8px;">For each upcoming deadline, ask three questions about your pipeline:</p>
@@ -160,6 +184,53 @@
         document.getElementById('deadlines').innerHTML = html;
       }).catch(function(){
         document.getElementById('deadlines').innerHTML = '<div class="dash-card"><p>Could not load deadline data.</p></div>';
+      });
+
+      // FY2027 Budget Signals table (data/budget-signals.json)
+      var fmtM = function(v){ if(v==null) return '—'; return v>=1000 ? '$'+(v/1000).toFixed(2)+'B' : '$'+Math.round(v)+'M'; };
+      var fmtPct = function(p){ if(p==null) return '—'; return (p>=0?'+':'')+(p*100).toFixed(1)+'%'; };
+      var deltaClass = function(p){ if(p==null) return 'flat'; if(p>=0.03) return 'up'; if(p<=-0.03) return 'down'; return 'flat'; };
+      fetch('/data/budget-signals.json').then(function(r){return r.json();}).then(function(d){
+        var lines = (d.lines||[]).slice();
+        var agencies = ['All'].concat(Object.keys(lines.reduce(function(m,l){m[l.agency]=1;return m;},{})));
+        var active = 'All';
+        var srcMap = {}; (d._schema && d._schema.sources || []).forEach(function(s){ srcMap[s.label]=s.url; });
+        function render(){
+          var rows = lines.filter(function(l){ return active==='All' || l.agency===active; });
+          // sort by magnitude of change desc so biggest movers lead
+          rows.sort(function(a,b){ return Math.abs((b.change_pct||0)) - Math.abs((a.change_pct||0)); });
+          var html = '<table class="bs-table"><thead><tr>' +
+            '<th>Agency</th><th>Appropriation line</th><th class="num">FY26</th><th class="num">FY27</th><th class="num">Change</th><th>Source</th>' +
+            '</tr></thead><tbody>' +
+            rows.map(function(l){
+              return '<tr>' +
+                '<td><span class="bs-agency">'+esc(l.agency)+'</span></td>' +
+                '<td>'+esc(l.line)+(l.basis?'<div style="font-size:11px;color:var(--mmt-text-secondary);margin-top:2px;">'+esc(l.basis)+'</div>':'')+'</td>' +
+                '<td class="num">'+fmtM(l.fy26_m)+'</td>' +
+                '<td class="num">'+fmtM(l.fy27_m)+'</td>' +
+                '<td class="num"><span class="bs-delta '+deltaClass(l.change_pct)+'">'+fmtPct(l.change_pct)+'</span></td>' +
+                '<td>'+(l.source_url?'<a class="bs-src" href="'+esc(l.source_url)+'" target="_blank" rel="noopener">Doc &rarr;</a>':'—')+'</td>' +
+              '</tr>';
+            }).join('') +
+            '</tbody></table>';
+          document.getElementById('bsTableWrap').innerHTML = html;
+        }
+        // filter chips
+        document.getElementById('bsFilters').innerHTML = agencies.map(function(a){
+          return '<button class="bs-filter'+(a==='All'?' active':'')+'" data-ag="'+esc(a)+'">'+esc(a)+'</button>';
+        }).join('');
+        Array.prototype.forEach.call(document.querySelectorAll('.bs-filter'), function(btn){
+          btn.addEventListener('click', function(){
+            active = this.getAttribute('data-ag');
+            Array.prototype.forEach.call(document.querySelectorAll('.bs-filter'), function(b){ b.classList.toggle('active', b===btn); });
+            render();
+          });
+        });
+        var verified = (d._schema && d._schema.last_verified) || '';
+        document.getElementById('bsNote').innerHTML = 'Green = growing, red = shrinking (&plusmn;3% threshold). ' + esc(lines.length) + ' health / health-IT appropriation lines, each reconciled FY26&rarr;FY27 and cited to its budget document. Verified ' + esc(verified) + '. Budget <em>intent</em> — planned dollars, not obligated contracts; cross-reference the <a href="/contract-tracker.html" style="color:var(--mmt-teal);">Contract Tracker</a> for where it has landed.';
+        render();
+      }).catch(function(){
+        document.getElementById('bsTableWrap').innerHTML = '<div class="dash-card"><p>Could not load budget signal data.</p></div>';
       });
     })();
   </script>


### PR DESCRIPTION
## Summary

Adds a **FY2027 Budget Signals** table to `/premium/cr-exposure` — "where health-IT money is moving." Your CR page tells subscribers *when* funding is at risk; this tells them *where it's flowing*, straight from the congressional budget justifications (FY2026 enacted → FY2027 request across 30 federal health / health-IT appropriation lines).

This is the "budget intent" layer the site didn't have. It came out of Daniel's Top-100 workbook (Tab 4).

**Signals surfaced:** VA EHRM **+24.7% → $4.24B**, DHA IM/IT **+14.5%**, VHA Community Care **+17%**, CMS program management **−17.3%**, HHS discretionary **−12.8%**, DHP RDT&E **−58.8%**.

## Data quality (the important part)

The workbook's Tab 4 had **two stacked datasets** with different column meanings: budget-justification lines on top, and Treasury account-level rows below (where the same columns mean FY25→FY26 account resources). I kept **only the 30 internally-consistent budget-justification lines** — every row's FY26→FY27 change and percentage were reconciled before publish — and excluded the account-level rows so the table isn't a mix of two things. Each line is cited to its source document (VA Budget in Brief, MHS FY2027 Budget Estimates Vol. 1, HHS Budget in Brief).

## Changes
- **`data/budget-signals.json`** (new) — the verified 30-line dataset with per-row source. Auto-copied to `dist/data/` by the existing `data/*.json` build step (no build.js change).
- **`premium/cr-exposure.html`** — new section + client-side render, using the same fetch/render pattern as the page's existing deadlines table. Sortable by magnitude, agency filter chips, green/red for grow/cut. **Content-only** — no shell, route, or build wiring touched.

## Checklist
- [x] Build succeeds (`node build.js`) — clean
- [x] Dist validation (`node scripts/validate-dist.js`) — OK, 625 pages
- [x] Premium-gated (page's existing `mmt_premium` gate is unchanged)
- [x] Source-cited per row (per the premium-data rule)
- [x] PR is focused (single feature, content-only)

## Risk Assessment
- **Critical surfaces touched**: none (premium content page; no auth/billing/data-write changes).
- **Security impact**: none — static JSON + client render behind the existing gate.
- **Rollback plan**: revert the commit; the data file and section are self-contained.

## Evidence
- 30 lines, each reconciled `(FY27−FY26)/FY26 == change_pct`; the 74 non-reconciling account-level rows excluded.
- Section renders in both `dist/premium/cr-exposure.html` and the `/premium/cr-exposure/` subdir build; `budget-signals.json` present in `dist/data/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzCi3VFvv63UufgvS96uHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzCi3VFvv63UufgvS96uHg)_