### PR TITLE
Release the announcement send (default to real send on deploy)

### DIFF
--- a/netlify/functions/announce-new-tools-send.js
+++ b/netlify/functions/announce-new-tools-send.js
@@ -161,7 +161,11 @@ exports.handler = async () => {
     return { statusCode: 500, body: "supabase not configured" };
   }
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
-  const GO = process.env.ANNOUNCE_TOOLS_GO === "true";
+  // 2026-08-05: Mary green-lit the real send. Default is now GO (send for
+  // real) so a deploy releases it without a Netlify env change. Set
+  // ANNOUNCE_TOOLS_GO=false to force preview mode again, or
+  // ANNOUNCE_TOOLS_DISABLED=true (checked above) to halt entirely.
+  const GO = process.env.ANNOUNCE_TOOLS_GO !== "false";
 
   // ---- PREVIEW MODE (default): send both versions to admin only, once ----
   if (!GO) {


### PR DESCRIPTION
## Summary

You're ready to send, so this flips the `ANNOUNCE_TOOLS_GO` gate in `announce-new-tools-send.js` from **preview-only** to **real-send by default**. Merging triggers a Netlify deploy; the next 15-minute cron tick then sends for real — no Netlify env change needed.

On that tick the function sends, once:
- **Version A (informative)** → active premium members via Resend
- **Version B (subscribe CTA)** → your free Buttondown list, paid members excluded

## Guards still in place
- **Idempotent** — per-segment `ops_events` markers; it sends each list exactly once even though the cron keeps ticking.
- **Throttled** 220ms between sends.
- **Fail-safe** — a bad Buttondown fetch skips the free send rather than partial-blasting.
- **Kill switch** — `ANNOUNCE_TOOLS_DISABLED=true` halts everything; `ANNOUNCE_TOOLS_GO=false` reverts to preview.
- You get a **summary email** with the sent/failed counts.

## Changes
- `netlify/functions/announce-new-tools-send.js` — one-line gate default change (`GO !== "false"`), plus comment.

## Risk Assessment
- **Send safety**: this IS the release — after deploy, the blast fires within ~15 min. Abort with `ANNOUNCE_TOOLS_DISABLED=true` before then if needed.
- **Security impact**: none — no secrets; keys from env.
- **Rollback**: `ANNOUNCE_TOOLS_DISABLED=true`, or revert. Retire the function after the send completes.

## Note
I can't verify delivery from this session (no reach to the live site). Your confirmation is the emails landing + the summary email with counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzCi3VFvv63UufgvS96uHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzCi3VFvv63UufgvS96uHg)_