### PR TITLE
Premium dashboard: surface Budget Signals + Forecast Pipeline as cards

### DIFF
--- a/premium/cr-exposure.html
+++ b/premium/cr-exposure.html
@@ -122,7 +122,7 @@
 
         <div id="deadlines"></div>
 
-        <div style="margin:28px 0 8px;">
+        <div id="budget-signals" style="margin:28px 0 8px;scroll-margin-top:80px;">
           <h2 style="font-size:18px;font-weight:800;margin:0 0 4px;">FY2027 Budget Signals &mdash; where health-IT money is moving</h2>
           <p style="font-size:13px;color:var(--mmt-text-secondary);line-height:1.6;margin:0 0 14px;">Deadlines tell you <em>when</em> money is at risk. This tells you <em>where it&rsquo;s flowing.</em> FY2026 enacted &rarr; FY2027 request, straight from the congressional budget justifications. A pursuit riding a growing account is a stronger opening than one riding contract size alone. Dollars in millions.</p>
           <div class="bs-filters" id="bsFilters"></div>

--- a/premium/dashboard.html
+++ b/premium/dashboard.html
@@ -166,6 +166,21 @@
     </a>
   </div>
 
+  <!-- New this week — Budget Signals + Forecast Pipeline -->
+  <p style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.1em;color:var(--mmt-text-secondary);margin:24px 0 10px;">New this week</p>
+  <div class="dash-pair-grid">
+    <a href="/premium/cr-exposure.html#budget-signals" class="dash-card" style="text-decoration:none;color:inherit;display:block;border-left:3px solid var(--mmt-teal);">
+      <h3 style="font-size:15px;margin:0 0 6px;">Budget Signals <span style="font-size:10px;font-weight:700;color:var(--mmt-teal);background:rgba(69,123,157,0.1);padding:1px 6px;border-radius:8px;vertical-align:middle;">NEW</span></h3>
+      <p style="margin:0 0 10px;color:var(--mmt-text-secondary);font-size:13px;line-height:1.5;">FY2026 to FY2027 money map for federal health IT, straight from the budget justifications. See which accounts are growing and which are getting cut before the solicitations hit. EHRM up 24.7 percent, DHA IM/IT up 14.5, CMS down 17.</p>
+      <span style="font-size:13px;font-weight:600;color:var(--mmt-teal);">Open Budget Signals &rarr;</span>
+    </a>
+    <a href="/premium/forecast-delta.html#forecast-pipeline" class="dash-card" style="text-decoration:none;color:inherit;display:block;border-left:3px solid var(--mmt-teal);">
+      <h3 style="font-size:15px;margin:0 0 6px;">Forecast Pipeline <span style="font-size:10px;font-weight:700;color:var(--mmt-teal);background:rgba(69,123,157,0.1);padding:1px 6px;border-radius:8px;vertical-align:middle;">NEW</span></h3>
+      <p style="margin:0 0 10px;color:var(--mmt-text-secondary);font-size:13px;line-height:1.5;">78 named opportunities the agencies say are coming, with anticipated solicitation and award dates. From the CMS and DHA official forecasts. Filter by agency, sort by what fires first, spot the recompetes.</p>
+      <span style="font-size:13px;font-weight:600;color:var(--mmt-teal);">Open Forecast Pipeline &rarr;</span>
+    </a>
+  </div>
+
   <div class="dash-pair-grid">
     <div class="dash-card">
       <h3>ProposalPulse</h3>

--- a/premium/forecast-delta.html
+++ b/premium/forecast-delta.html
@@ -116,7 +116,7 @@
           <p><strong>The methodology note for subscribers:</strong> federal procurement forecasts are not a single source of truth. They're per-agency snapshots, updated on their own cadence, in formats that range from a downloadable Excel sheet (VA, GSA) to a search interface (HHS via mySBCX) to plain HTML (DHA-via-DoD). The MMT Forecast Delta Tracker layers editorial commentary on top of the official sources below &mdash; because the diff matters more than the snapshot, and nobody else is publishing it month-over-month.</p>
         </div>
 
-        <div class="dash-card">
+        <div class="dash-card" id="forecast-pipeline" style="scroll-margin-top:80px;">
           <h2 style="font-size:18px;font-weight:700;margin:0 0 4px;">Forecast Pipeline &mdash; what agencies say is coming</h2>
           <p style="font-size:13px;color:var(--mmt-text-secondary);margin:0 0 14px;">Named opportunities pulled straight from the official agency forecasts &mdash; the CMS Forecast of Contracting Opportunities and the DHA Long Range Acquisition Forecast &mdash; each with the anticipated solicitation and award dates the agency published. Recompetes are where an incumbent is defending; sort by solicitation date to see what fires first. This is the agency&rsquo;s own forecast, not a market rumor.</p>
           <div class="fp-controls">


### PR DESCRIPTION
## Summary

The two new features shipped as sections *inside* the CR Exposure and Forecast Delta pages, so they had no presence on the dashboard home — you couldn't find them. This adds a **"New this week"** pair of linked cards on `/premium/dashboard` that deep-link straight to each feature.

## Changes
- **`premium/dashboard.html`** — two cards ("Budget Signals", "Forecast Pipeline", each with a NEW badge) in a pair-grid, styled to match the existing tool cards, teal left border for emphasis.
- **`premium/cr-exposure.html`** — `id="budget-signals"` + `scroll-margin-top` on the section.
- **`premium/forecast-delta.html`** — `id="forecast-pipeline"` + `scroll-margin-top` on the section.

The dashboard cards link to `/premium/cr-exposure.html#budget-signals` and `/premium/forecast-delta.html#forecast-pipeline`, so a click lands right on the content.

## Checklist
- [x] `node build.js` clean; `validate-dist` OK (625 pages)
- [x] Cards render in `dist/premium/dashboard.html`; both anchors present
- [x] Content-only; no shell/route/build wiring changed

## Risk Assessment
- **Security impact**: none.
- **Rollback**: revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzCi3VFvv63UufgvS96uHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzCi3VFvv63UufgvS96uHg)_